### PR TITLE
Fix punctum cavum with some material above it, like:

### DIFF
--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1699,12 +1699,12 @@
 \UseNormalPunctumCavum
 
 \def\grepunctumcavum#1#2#3#4#5{%
-  \grecalculateglyphraisevalue{#1}{0}%
   \setbox\GreTempwidth=\hbox{\gregoriofont\grepunctumcavumchar}%
   \global\grelastglyphwidth=\wd\GreTempwidth %
   \kern\grelastglyphwidth %
   #4\relax %
   \kern-\grelastglyphwidth %
+  \grecalculateglyphraisevalue{#1}{0}%
   \ifnum\grehidepclines=1\relax %
     \grefillhole{\grepunctumcavumholechar}%
   \fi %
@@ -1713,12 +1713,12 @@
 }
 
 \def\grelineapunctumcavum#1#2#3#4#5{%
-  \grecalculateglyphraisevalue{#1}{0}%
   \setbox\GreTempwidth=\hbox{\gregoriofont\grelineapunctumcavumchar}%
   \global\grelastglyphwidth=\wd\GreTempwidth %
   \kern\grelastglyphwidth %
   #4\relax %
   \kern-\grelastglyphwidth %
+  \grecalculateglyphraisevalue{#1}{0}%
   \ifnum\grehidepclines=1\relax %
     \grefillhole{\grelineapunctumcavumholechar}%
   \fi %


### PR DESCRIPTION
(hr[ocba:1;3mm])
Without the patch, without the [ocba:1;3mm] the punctum cavum is not crossed
by the score line, with it it is incorrectly crossed, while with the patch
it is not crossed in either case.
From my understanding, grecalculateglyphraisevalue is not needed for the
hbox and kern, but #4 could do \raise etc.
If I replace
    \color{grebackgroundcolor}%
in \grefillhole macro with \color{red}%, it clearly shows that without the
patch the fill punctum is put above the curly brace above the score.
