### PR TITLE
Backwards behavior.

### DIFF
--- a/plugins/gregoriotex/gregoriotex-write.c
+++ b/plugins/gregoriotex/gregoriotex-write.c
@@ -34,7 +34,7 @@
 
 #include "gregoriotex.h"
 
-typedef enum { NEXT_SYL, THIS_SYL } syllable;
+enum syllable { NEXT_SYL, THIS_SYL };
 
 #if ALL_STATIC == 0
 DECLARE_PLUGIN (gregoriotex)
@@ -1236,7 +1236,7 @@ gtex_print_char (FILE *f, grewchar to_print)
 }
 
 void
-gregoriotex_write_text (FILE *f, gregorio_character *text, char *first_syllable, syllable next_syl)
+gregoriotex_write_text (FILE *f, gregorio_character *text, char *first_syllable, int next_syl)
 {
   char first_syllable_val = 0;
   if (text == NULL)

--- a/plugins/gregoriotex/gregoriotex-write.c
+++ b/plugins/gregoriotex/gregoriotex-write.c
@@ -34,7 +34,7 @@
 
 #include "gregoriotex.h"
 
-enum syllable { NEXT_SYL, THIS_SYL };
+enum syllable { THIS_SYL, NEXT_SYL };
 
 #if ALL_STATIC == 0
 DECLARE_PLUGIN (gregoriotex)

--- a/plugins/gregoriotex/gregoriotex-write.c
+++ b/plugins/gregoriotex/gregoriotex-write.c
@@ -34,6 +34,8 @@
 
 #include "gregoriotex.h"
 
+typedef enum { NEXT_SYL, THIS_SYL } syllable;
+
 #if ALL_STATIC == 0
 DECLARE_PLUGIN (gregoriotex)
 {
@@ -520,7 +522,7 @@ gregoriotex_write_syllable (FILE *f,
     {
       fprintf (f, "\\gresyllable");
     }
-  gregoriotex_write_text (f, syllable->text, first_syllable);
+  gregoriotex_write_text (f, syllable->text, first_syllable, THIS_SYL);
   if (syllable->position == WORD_END
       || syllable->position == WORD_ONE_SYLLABLE || !syllable->text
       || !syllable->next_syllable
@@ -536,7 +538,7 @@ gregoriotex_write_syllable (FILE *f,
   if (syllable->next_syllable)
     {
       fprintf(f, "{\\gresetnextsyllable");
-      gregoriotex_write_text (f, syllable->next_syllable->text, NULL);
+      gregoriotex_write_text (f, syllable->next_syllable->text, NULL, NEXT_SYL);
       fprintf (f, "}{}{%d}{",
                gregoriotex_syllable_first_type (syllable->next_syllable));
     }
@@ -1234,7 +1236,7 @@ gtex_print_char (FILE *f, grewchar to_print)
 }
 
 void
-gregoriotex_write_text (FILE *f, gregorio_character *text, char *first_syllable)
+gregoriotex_write_text (FILE *f, gregorio_character *text, char *first_syllable, syllable next_syl)
 {
   char first_syllable_val = 0;
   if (text == NULL)
@@ -1249,9 +1251,18 @@ gregoriotex_write_text (FILE *f, gregorio_character *text, char *first_syllable)
   gregoriotex_ignore_style = gregoriotex_fix_style (text);
   if (gregoriotex_ignore_style != 0)
     {
-      fprintf (f, "\\gresetfixednexttextformat{%d}",
-               gregoriotex_internal_style_to_gregoriotex
-               (gregoriotex_ignore_style));
+      if (next_syl)
+        {
+          fprintf (f, "\\gresetfixednexttextformat{%d}",
+                   gregoriotex_internal_style_to_gregoriotex
+                   (gregoriotex_ignore_style));
+        }
+      else
+        {
+          fprintf (f, "\\gresetfixedtextformat{%d}",
+                   gregoriotex_internal_style_to_gregoriotex
+                   (gregoriotex_ignore_style));
+        }
     }
   gregorio_write_text (first_syllable_val, text, f,
                        (&gtex_write_verb),

--- a/plugins/gregoriotex/gregoriotex-write.c
+++ b/plugins/gregoriotex/gregoriotex-write.c
@@ -1249,7 +1249,7 @@ gregoriotex_write_text (FILE *f, gregorio_character *text, char *first_syllable)
   gregoriotex_ignore_style = gregoriotex_fix_style (text);
   if (gregoriotex_ignore_style != 0)
     {
-      fprintf (f, "\\gresetfixedtextformat{%d}",
+      fprintf (f, "\\gresetfixednexttextformat{%d}",
                gregoriotex_internal_style_to_gregoriotex
                (gregoriotex_ignore_style));
     }

--- a/plugins/gregoriotex/gregoriotex.h
+++ b/plugins/gregoriotex/gregoriotex.h
@@ -173,7 +173,7 @@ void gregoriotex_write_syllable (FILE *f, gregorio_syllable *syllable,
                                  unsigned char *line_number,
                                  unsigned char first_of_disc);
 void gregoriotex_write_text (FILE *f, gregorio_character *first_character,
-                             char *first_syllable);
+			     char *first_syllable, int);
 unsigned char gregoriotex_fix_style (gregorio_character *first_character);
 void gregoriotex_write_translation (FILE *f, gregorio_character *translation);
 void gregoriotex_write_element (FILE *f, gregorio_syllable *syllable,


### PR DESCRIPTION
My testing had `\gresetfixedtextformat` and `\gresetfixednexttextformat` reversed.  This change fixed that.