### PR TITLE
Requested fix for #41

### DIFF
--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -300,6 +300,11 @@
 
 \def\setinitialspacing#1#2#3{
   \grechangedim{\grebeforeinitialshift}{#1}
+%  \ifnum\grebiginitial=0\relax %
+%    \greinitialformat{\global\grechangedim{\gremanualinitialwidth}{#2}}
+%  \else
+%    \grebiginitialformat{\global\grechangedim{\gremanualinitialwidth}{#2}}
+%  \fi
   \grechangedim{\gremanualinitialwidth}{#2}
   \grechangedim{\greafterinitialshift}{#3}%
   \relax

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -266,6 +266,9 @@
 % space before the initial and the beginning of the score
 \newskip\grebeforeinitialshift
 
+% forced size of the box for the initial.  Initial is centered in box.  Ignored if 0.
+\newskip\gremanualinitialwidth
+
 % space before the initial and the beginning of the score
 \newdimen\greminimalspaceatlinebeginning
 
@@ -294,6 +297,13 @@
 }
 
 \let\setspacebeforeinitial\GreSetSpaceBeforeInitial
+
+\def\setinitialspacing#1#2#3{
+  \grechangedim{\grebeforeinitialshift}{#1}
+  \grechangedim{\gremanualinitialwidth}{#2}
+  \grechangedim{\greafterinitialshift}{#3}%
+  \relax
+}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % staff line height changing
@@ -554,5 +564,8 @@
   \grechangeonedimenfactor{\grehighchoralsignshift}{#1}{#2}%
   \grechangeonedimenfactor{\grelowchoralsignshift}{#1}{#2}%
   \grechangeonedimenfactor{\grebeforechoralsignspace}{#1}{#2}%
+  \grechangeonedimenfactor{\gremanualinitialwidth}{#1}{#2}%
+  \grechangeonedimenfactor{\grebeforeinitialshift}{#1}{#2}%
+  \grechangeonedimenfactor{\greafterinitialshift}{#1}{#2}%
   \relax %
 }

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -278,21 +278,21 @@
 \newdimen\greaboveinitialseparation
 
 \def\GreSetAboveInitialSeparation#1{
-  \greaboveinitialseparation=#1%
+  \grechangedim{\greaboveinitialseparation}{#1}%
   \relax %
 }
 
 \let\setaboveinitialseparation\GreSetAboveInitialSeparation
 
 \def\GreSetSpaceAfterInitial#1{%
-  \greafterinitialshift=#1 %
+  \grechangesim{\greafterinitialshift}{#1} %
   \relax %
 }
 
 \let\setspaceafterinitial\GreSetSpaceAfterInitial
 
 \def\GreSetSpaceBeforeInitial#1{%
-  \grebeforeinitialshift=#1 %
+  \grechangedim{\grebeforeinitialshift}{#1} %
   \relax %
 }
 
@@ -567,5 +567,6 @@
   \grechangeonedimenfactor{\gremanualinitialwidth}{#1}{#2}%
   \grechangeonedimenfactor{\grebeforeinitialshift}{#1}{#2}%
   \grechangeonedimenfactor{\greafterinitialshift}{#1}{#2}%
+  \grechangeonedimenfactor{\greaboveinitialseparation}{#1}{#2}%
   \relax %
 }

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -420,8 +420,12 @@
   % if it is a big initial we print it on the second line 
   \ifnum\grebiginitial=0\relax %
     \setbox\GreInitial=\hbox{\greinitialformat{#1}}%
-    \global\greinitialwidth=\the\wd\GreInitial %
-    \setbox\GreInitial=\hbox{\raise -\gretempdim\hbox{\greinitialformat{#1}}}%
+    \ifnum\number\gremanualinitialwidth=0\relax%
+      \global\greinitialwidth=\the\wd\GreInitial %
+    \else%
+      \global\greinitialwidth=\the\gremanualinitialwidth%
+    \fi
+    \setbox\GreInitial=\hbox to \greinitialwidth {\hss\raise -\gretempdim\hbox{\greinitialformat{#1}}\hss}%
   \else %
     \advance\gretempdim by \greadditionalbottomspace %
     \advance\gretempdim by \grespacebeneathtext %
@@ -430,8 +434,12 @@
     \advance\gretempdim by 4\grestafflineheight %
     \advance\gretempdim by \grecurrenttranslationheight %
     \setbox\GreInitial=\hbox{\grebiginitialformat{#1}}%
-    \global\greinitialwidth=\the\wd\GreInitial %
-    \setbox\GreInitial=\hbox{\vbox to 0pt{\hbox{\raise -\gretempdim\hbox{\grebiginitialformat{#1}}}\vss}}%
+    \ifnum\number\gremanualinitialwidth=0\relax%
+      \global\greinitialwidth=\the\wd\GreInitial %
+    \else%
+      \global\greinitialwidth=\the\gremanualinitialwidth%
+    \fi
+    \setbox\GreInitial=\hbox{\vbox to 0pt{\hbox to \greinitialwidth {\hss\raise -\gretempdim\hbox{\grebiginitialformat{#1}}\hss}\vss}}%
   \fi %
   \hskip\grebeforeinitialshift %
   \copy\GreInitial%

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -140,9 +140,11 @@
 % multiplied by 2.
 \greadditionallineswidth = 10000 sp
 % space between the initial and the beginning of the score
-\greafterinitialshift=0.6 em plus 0em minus 0em
+\greafterinitialshift=0.035 em plus 0em minus 0em
 % space before the initial and the beginning of the score
 \greminimalspaceatlinebeginning=1mm
+% space to force the initial width to.  Ignored when 0.
+\gremanualinitialwidth=0pt
 % this space is the one between the bottom of the first anotation line and the top
 % of the second anotation line (above the initial)
 \greaboveinitialseparation = 0.5mm


### PR DESCRIPTION
I've figured out that the problem with using em and ex is related to the scope, but haven't quite worked out how to fix it yet.  Probably need a `\global` somewhere, but my first few tries haven't worked.

Since this is useful as is, I'm putting it in place now, though I'll continue to work on the scope problem.