### PR TITLE
Finished the fix for #41

### DIFF
--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -132,12 +132,6 @@
 %% macros for the typesetting of spaces
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% All the following values correspond to a grefactor of 1,
-%% so in most cases it will be much smaller that what you will finally
-%% get with an average factor (17 is the default value for the factor).
-%% We multiply all the columns by the factor when the factor changes,
-%% and it changes at the beginning of the first score by default.
-
 %%%%%%%%%%%%%%%%%%%%
 %% horizontal spaces
 %%%%%%%%%%%%%%%%%%%%
@@ -274,10 +268,21 @@
 
 % this space is the one between the bottom of the first anotation line and the top
 % of the second anotation line (above the initial)
-
 \newdimen\greaboveinitialseparation
 
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%  Some Macros for changing the spacing around the initial
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%Seeing as these are the distances that people will want to change the most often,
+%we give them their own set of macros to make that easier.
+
+
 \def\GreSetAboveInitialSeparation#1{
+  \ifnum\grefactor=0\relax%
+    \setgrefactor{17}%
+  \fi%
   \grechangedim{\greaboveinitialseparation}{#1}%
   \relax %
 }
@@ -285,29 +290,45 @@
 \let\setaboveinitialseparation\GreSetAboveInitialSeparation
 
 \def\GreSetSpaceAfterInitial#1{%
-  \grechangesim{\greafterinitialshift}{#1} %
+  \ifnum\grefactor=0\relax%
+    \setgrefactor{17}%
+  \fi%
+  \ifnum\grebiginitial=0\relax%
+    \greinitialformat{\global\grechangedim{\greafterinitialshift}{#1}}%
+  \else%
+    \grebiginitialformat{\global\grechangedim{\greafterinitialshift}{#1}}%
+  \fi%
   \relax %
 }
 
 \let\setspaceafterinitial\GreSetSpaceAfterInitial
 
 \def\GreSetSpaceBeforeInitial#1{%
-  \grechangedim{\grebeforeinitialshift}{#1} %
+  \ifnum\grefactor=0\relax%
+    \setgrefactor{17}%
+  \fi%
+  \ifnum\grebiginitial=0\relax%
+    \greinitialformat{\global\grechangedim{\grebeforeinitialshift}{#1}}%
+  \else%
+    \grebiginitialformat{\global\grechangedim{\grebeforeinitialshift}{#1}}%
+  \fi%
   \relax %
 }
 
 \let\setspacebeforeinitial\GreSetSpaceBeforeInitial
 
 \def\setinitialspacing#1#2#3{
-  \grechangedim{\grebeforeinitialshift}{#1}
-%  \ifnum\grebiginitial=0\relax %
-%    \greinitialformat{\global\grechangedim{\gremanualinitialwidth}{#2}}
-%  \else
-%    \grebiginitialformat{\global\grechangedim{\gremanualinitialwidth}{#2}}
-%  \fi
-  \grechangedim{\gremanualinitialwidth}{#2}
+  \ifnum\grefactor=0\relax%
+    \setgrefactor{17}%
+  \fi%
+  \grechangedim{\grebeforeinitialshift}{#1}%
+  \ifnum\grebiginitial=0\relax %
+    \greinitialformat{\global\grechangedim{\gremanualinitialwidth}{#2}}%
+  \else%
+    \grebiginitialformat{\global\grechangedim{\gremanualinitialwidth}{#2}}%
+  \fi%
   \grechangedim{\greafterinitialshift}{#3}%
-  \relax
+  \relax%
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -316,15 +337,12 @@
 
 % \grestafflineheight is the height of a staff line
 \newdimen\grestafflineheight
-\grestafflineheight=1500 sp
 
 % \greinterstafflinespace is the space between two lines of staff
 \newdimen\greinterstafflinespace
-\greinterstafflinespace=30000 sp
 
 % the value is (1500*stafflinefactor - 1500)/2
 \newdimen\grestafflinediff
-\grestafflinediff=0 sp
 
 % the default factor
 \xdef\grestafflinefactor{1}%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -420,10 +420,16 @@
   % if it is a big initial we print it on the second line 
   \ifnum\grebiginitial=0\relax %
     \setbox\GreInitial=\hbox{\greinitialformat{#1}}%
-    \ifnum\number\gremanualinitialwidth=0\relax%
-      \global\greinitialwidth=\the\wd\GreInitial %
+    \ifdim\gremanualinitialwidth=0 pt\relax%
+      \global\greinitialwidth=\wd\GreInitial %
     \else%
-      \global\greinitialwidth=\the\gremanualinitialwidth%
+      \global\greinitialwidth=\gremanualinitialwidth%
+    \fi
+    \ifdim\wd\GreAboveinitialfirstbox>\greinitialwidth\relax%
+      \global\greinitialwidth=\wd\GreAboveinitialfirstbox
+    \fi
+    \ifdim\wd\GreAboveinitialsecondbox>\greinitialwidth\relax%
+      \global\greinitialwidth=\wd\GreAboveinitialsecondbox
     \fi
     \setbox\GreInitial=\hbox to \greinitialwidth {\hss\raise -\gretempdim\hbox{\greinitialformat{#1}}\hss}%
   \else %
@@ -434,10 +440,16 @@
     \advance\gretempdim by 4\grestafflineheight %
     \advance\gretempdim by \grecurrenttranslationheight %
     \setbox\GreInitial=\hbox{\grebiginitialformat{#1}}%
-    \ifnum\number\gremanualinitialwidth=0\relax%
-      \global\greinitialwidth=\the\wd\GreInitial %
+    \ifdim\gremanualinitialwidth=0 pt\relax%
+      \global\greinitialwidth=\wd\GreInitial %
     \else%
-      \global\greinitialwidth=\the\gremanualinitialwidth%
+      \global\greinitialwidth=\gremanualinitialwidth%
+    \fi
+    \ifdim\wd\GreAboveinitialfirstbox>\greinitialwidth\relax%
+      \global\greinitialwidth=\wd\GreAboveinitialfirstbox
+    \fi
+    \ifdim\wd\GreAboveinitialsecondbox>\greinitialwidth\relax%
+      \global\greinitialwidth=\wd\GreAboveinitialsecondbox
     \fi
     \setbox\GreInitial=\hbox{\vbox to 0pt{\hbox to \greinitialwidth {\hss\raise -\gretempdim\hbox{\grebiginitialformat{#1}}\hss}\vss}}%
   \fi %

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -59,6 +59,13 @@
 
 %% And finally, all the spacings:
 
+%% All the following values correspond to a grefactor of 1,
+%% so in most cases it will be much smaller that what you will finally
+%% get with an average factor (17 is the default value for the factor).
+%% We multiply all the columns by the factor when the factor changes,
+%% and it changes at the beginning of the first score by default.
+
+
 % the additional width of the additional lines (compared to the width of the glyph they're associated with)
 \greadditionallineswidth = 16000sp
 % null space
@@ -169,12 +176,23 @@
 %the space between the lines and the bottom of the text
 \grespacelinestext = 66500 sp plus 0 sp minus 0 sp
 %the space beneath the text
-\global\grespacebeneathtext = 0 sp plus 0 sp minus 0 sp
+\grespacebeneathtext = 0 sp plus 0 sp minus 0 sp
 % height of the text above the note line
-\global\greabovelinestextraise=-1mm%
+\greabovelinestextraise=-1mm%
 % height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration)
-\global\greabovelinestextheight=3mm%
+\greabovelinestextheight=3mm%
 % an additional shift you can give to the brace above the bars if you don't like it
-\global\grebraceshift = 0pt
+\grebraceshift = 0pt
 % a shift you can give to the accentus above the curly brace
-\global\grecurlybraceaccentusshift = -0.5mm
+\grecurlybraceaccentusshift = -0.5mm
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% staff line height changing
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% \grestafflineheight is the height of a staff line
+\grestafflineheight=1500 sp
+% \greinterstafflinespace is the space between two lines of staff
+\greinterstafflinespace=30000 sp
+% the value is (1500*stafflinefactor - 1500)/2
+\grestafflinediff=0 sp


### PR DESCRIPTION
em and ex units now used in the font of the initial when used to set the initial spacing (finishes #41)
Moved a few distances related to staff line spacing which were being defined in gregoriotex-spaces to gps-default with all the rest
Changed out some \ifnum\number\dimen constructions for \ifdim\dimen to make the code clearer.
Added check of initial width against the width of the annotation boxes.  Long annotations will no longer bleed behind staff (fixes #11)