### PR TITLE
includescore upgrade

### DIFF
--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -191,7 +191,7 @@ local function include_gabc_score(gabc_file)
         return
     end
     local gabc_timestamp = lfs.attributes(gabc_file).modification
-    local tex_file = gabc_file:gsub("%.gabc+$","-auto.tex")
+    local tex_file = gabc_file:gsub("%.gabc+$","-auto.gtex")
     if lfs.isfile(tex_file) then
         local tex_timestamp = lfs.attributes(tex_file).modification
         if tex_timestamp < gabc_timestamp then

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -25,13 +25,17 @@
   \input luatexbase.sty
   \input luaotfload.sty
   \input graphicx.sty % for \resizebox
-  \def\greerror#1{GregorioTeX: \errmessage{#1}}
+  \input xstring.sty
+  \def\greerror#1{\errmessage{GregorioTeX error: #1}}
+  \def\gre@warning#1{\message{GregorioTeX warning: #1}}
 \else
   \RequirePackage{ifluatex}
   \RequirePackage{graphicx}% for \resizebox
   \RequirePackage{luatexbase}
   \RequirePackage{luaotfload}
+  \RequirePackage{xstring}
   \def\greerror#1{\PackageError{GregorioTeX}{#1}{}}
+  \def\gre@warning#1{\PackageWarning{GregorioTeX}{#1}}
 \fi
 
 \ifluatex\else
@@ -1357,22 +1361,43 @@
 %%%%%%%%%%%%%%%%%%
 
 % function that includes a score in TeX format
+\def\gre@includetexscore#1{%
+	\input #1%
+	\relax %
+}
+\ifdefined\includetexscore
+	\greerror{\protect\includetexscore\space is already defined.  Check for package conflicts.}
+\else
+	\def\includetexscore#1{%
+		\gre@includetexscore{#1}
+	}
+\fi
 \def\greincludetexscore#1{%
-  \input #1%
-  \relax %
+	\gre@warning{\protect\greincludedtexscore\space is deprecated.\MessageBreak Use \protect\includescore\space instead.}
+	\gre@includetexscore{#1}
 }
 
-% function provided for backward compatibility
-\let\includetexscore\greincludetexscore
-\let\includescore\includetexscore
-
-% TODO: comment
+% function that includes scores in gabc format
+\def\gre@includegabcscore#1{%
+	\directlua{gregoriotex.include_gabc_score([[#1]])}%
+	\relax %
+}
+\ifdefined\includegabcscore
+	\greerror{\protect\includegabcscore\space is already defined.  Check for package conflicts.}
+\else
+	\def\includegabcscore#1{%
+		\gre@includegabcscore{#1}
+	}
+\fi
 \def\greincludegabcscore#1{%
-  \directlua{gregoriotex.include_gabc_score([[#1]])}%
-  \relax %
+	\gre@warning{\protect\greincludedgabcscore\space is deprecated.\MessageBreak Use \protect\includescore\space instead.}
+	\gre@includegabcscore{#1}
 }
 
-\let\includegabcscore\greincludegabcscore
+% Wrapper function that can handle both file types.  This is done by checking the filename (using the string tests from the xstring package) to see if it ends with .gabc.  If it does, we assume the file is in gabc format and pass it to \ger@includegabcscore.  All other files are assumed to be in gtex format and are processed using \gre@includetexscore.
+\def\includescore#1{%
+	\IfEndWith{#1}{.gabc}{\gre@includegabcscore{#1}}{\gre@includetexscore{#1}}
+}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %% some hyphen definitions


### PR DESCRIPTION
These modifications allow `\includescore` to handle both gtex and gabc file.
	Still to do: there should be a check of the date of gtex files against their original gabc file to see if they need to be recompiled by date (a function currently handled by the greg-book engine), the lua script which handles gabc files does this already so that might be leveraged for this.  Also need to add api version checker to both sides
I've also changed the extension of the auto generated file.  This will prevent conflicts with LilyPond-Book (which doesn't like included files to have the extension tex).