### PR TITLE
Stop gregoriotex from overriding user defined \setfirstannotation

### DIFF
--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -562,23 +562,27 @@
 }
 
 \def\gregorianmode#1{%
-  \ifcase#1%
-  \or%
-    \writemode{I}%
-  \or%
-    \writemode{II}%
-  \or%
-    \writemode{III}%
-  \or%
-    \writemode{IV}%
-  \or%
-    \writemode{V}%
-  \or%
-    \writemode{VI}%
-  \or%
-    \writemode{VII}%
-  \or%
-    \writemode{VIII}%
+  \ifhbox \GreAboveinitialfirstbox%
+    \relax%
+  \else%
+    \ifcase#1%
+    \or%
+      \writemode{I}%
+    \or%
+      \writemode{II}%
+    \or%
+      \writemode{III}%
+    \or%
+      \writemode{IV}%
+    \or%
+      \writemode{V}%
+    \or%
+      \writemode{VI}%
+    \or%
+      \writemode{VII}%
+    \or%
+      \writemode{VIII}%
+    \fi%
   \fi%
   \relax%
 }


### PR DESCRIPTION
Bug fix for #55 : Setting the mode header in the gabc file would override the
user defined \setfirstannotation in the main tex file. Now \writemode
checks to see if \GreAboveinitialfirstbox has been set.