### PR TITLE
Extend \includescore

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 gregoriotex_api_version = 20150220
-gregorio_version = 2.4.1
+gregorio_version = 2.4.2
 
 *** Do not add any lines above here. ***
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ dnl You should have received a copy of the GNU General Public License
 dnl along with this program; if not, write to the Free Software
 dnl Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-AC_INIT([gregorio],[2.4.1],[gregorio-devel@gna.org])
+AC_INIT([gregorio],[2.4.2],[gregorio-devel@gna.org])
 AC_PREREQ(2.53)
 AC_CONFIG_SRCDIR([src/gregorio-utils.c])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -203,14 +203,14 @@ local function include_score(input_file)
 	if lfs.isfile(gabc_file) then
 	    compile_gabc(gabc_file, gtex_file)
 	else
-	    err("The %s file does not exist.", gabc_file)
+	    err("The file %s does not exist.", gabc_file)
 	    return
 	end
     end
     local gtex_timestamp = lfs.attributes(gtex_file).modification
     local gabc_timestamp = lfs.attributes(gabc_file).modification
     if gtex_timestamp < gabc_timestamp then
-	log("%s has been modified and %s needs to be updates. Recompiling the gabc file.", gabc_file, gtex_file)
+	log("%s has been modified and %s needs to be updated. Recompiling the gabc file.", gabc_file, gtex_file)
 	compile_gabc(gabc_file, gtex_file)
     end
     tex.print(string.format("\\input %s", gtex_file))

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -174,47 +174,33 @@ local function atScoreEnd ()
     end
 end
 
-local function compile_gabc(gabc_file, tex_file)
+local function compile_gabc(gabc_file, gtex_file)
     info("compiling the score %s...", gabc_file)
-    res = os.execute(string.format("gregorio -o %s %s", tex_file, gabc_file))
+    res = os.execute(string.format("gregorio -o %s %s", gtex_file, gabc_file))
     if res == nil then
         err("\nSomething went wrong when executing\n    'gregorio -o %s %s'.\n"
-        .."shell-escape mode may not be activated. Try\n    '%s --shell-escape %s.tex'\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex_file, gabc_file, tex.formatname, tex.jobname)
+        .."shell-escape mode may not be activated. Try\n    '%s --shell-escape %s.tex'\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", gtex_file, gabc_file, tex.formatname, tex.jobname)
     elseif res ~= 0 then
         err("\nAn error occured when compiling the score file\n'%s' with gregorio.\nPlease check your score file.", gabc_file)
     end
 end
 
-local function include_gabc_score(gabc_file)
-    if not lfs.isfile(gabc_file) then
-        err("the file %s does not exist.", gabc_file)
-        return
-    end
-    local gabc_timestamp = lfs.attributes(gabc_file).modification
-    local tex_file = gabc_file:gsub("%.gabc+$","-auto.gtex")
-    if lfs.isfile(tex_file) then
-        local tex_timestamp = lfs.attributes(tex_file).modification
-        if tex_timestamp < gabc_timestamp then
-            log("%s has changed since last compilation. Recompiling.", gabc_file)
-            gregoriotex.compile_gabc(gabc_file, tex_file)
-        end
-	if tonumber(os.date("%Y%m%d", tex_timestamp)) < internalversion then
-	    log("Recompiling %s because %s does not match the current gregoriotex api version.", gabc_file, tex_file)
-	    compile_gabc(gabc_file, tex_file)
-	end
+local function include_score(input_file)
+    local file_root = ""
+    if input_file:gmatch("%.gtex+$") then
+	file_root = input_file:gsub("%.gtex+$", "")
+    elseif input_file:gmatch("%.tex+$") then
+	file_root = input_file:gsub("%.tex+$", "")
+    elseif input_file:gmatch("%.gabc+$") then
+	file_root = input_file:gsub("%.gabc+$", "")
     else
-	log("No %s file exists. Compiling %s", tex_file, gabc_file)
-        compile_gabc(gabc_file, tex_file)
+	file_root = input_file
     end
-    tex.print(string.format("\\input %s", tex_file))
-end
-
-local function include_gtex_score(gtex_file)
-    local file_root = gtex_file:gsub("%.gtex+$","")
-    local gabc_file = gtex_file:gsub("%.gtex+$", ".gabc")
+    local gtex_file = file_root.."-"..internalversion..".gtex"
+    local gabc_file = file_root..".gabc"
     if not lfs.isfile(gtex_file) then
-       log("the file %s does not exist. Searching for a gabc file.", gtex_file)
-        if lfs.isfile(gabc_file) then
+	log("The file %s does not exist. Searching for a gabc file", gtex_file)
+	if lfs.isfile(gabc_file) then
 	    compile_gabc(gabc_file, gtex_file)
 	else
 	    err("The %s file does not exist.", gabc_file)
@@ -224,13 +210,11 @@ local function include_gtex_score(gtex_file)
     local gtex_timestamp = lfs.attributes(gtex_file).modification
     local gabc_timestamp = lfs.attributes(gabc_file).modification
     if gtex_timestamp < gabc_timestamp then
-	gregoriotex.compile_gabc(gabc_file, gtex_file)
-    end
-    if tonumber(os.date("%Y%m%d", gtex_timestamp)) < internalversion then
-	log("Recompiling %s because %s does not match the current gregoriotex api version.", gabc_file, gtex_file)
+	log("%s has been modified and %s needs to be updates. Recompiling the gabc file.", gabc_file, gtex_file)
 	compile_gabc(gabc_file, gtex_file)
     end
     tex.print(string.format("\\input %s", gtex_file))
+    return
 end
 
 local function check_version(greinternalversion)
@@ -243,8 +227,7 @@ local function get_greapiversion()
     return internalversion
 end
 
-gregoriotex.include_gabc_score = include_gabc_score
-gregoriotex.include_gtex_score = include_gtex_score
+gregoriotex.include_score      = include_score
 gregoriotex.compile_gabc       = compile_gabc
 gregoriotex.atScoreEnd         = atScoreEnd
 gregoriotex.atScoreBeggining   = atScoreBeggining

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -1364,44 +1364,51 @@
 %% score including
 %%%%%%%%%%%%%%%%%%
 
-% function that includes a score in TeX format
-\def\gre@includetexscore#1{%
-	\directlua{gregoriotex.include_gtex_score([[#1]])}%
-	\relax %
+% The primary macro that includes a score in gTeX or gabc format.
+\def\gre@includescore#1{%
+  \directlua{gregoriotex.include_score([[#1]])}%
+  \relax%
 }
+
 \ifdefined\includetexscore
-	\greerror{\protect\includetexscore\space is already defined.  Check for package conflicts.}
+	\gre@warning{\protect\includetexscore\space is deprecated. \MessageBreak Use \protect\includescore\space instead.}
 \else
 	\def\includetexscore#1{%
-		\gre@includetexscore{#1}
+		\gre@includescore{#1}
 	}
 \fi
 \def\greincludetexscore#1{%
 	\gre@warning{\protect\greincludedtexscore\space is deprecated.\MessageBreak Use \protect\includescore\space instead.}
-	\gre@includetexscore{#1}
+	\gre@includescore{#1}
 }
 
-% function that includes scores in gabc format
-\def\gre@includegabcscore#1{%
-	\directlua{gregoriotex.include_gabc_score([[#1]])}%
-	\relax %
-}
 \ifdefined\includegabcscore
-	\greerror{\protect\includegabcscore\space is already defined.  Check for package conflicts.}
+	\gre@warning{\protect\includegabcscore\space is deprecated.\MessageBreak Use \protect\includescore\space instead.}
 \else
 	\def\includegabcscore#1{%
-		\gre@includegabcscore{#1}
+		\gre@includescore{#1}
 	}
 \fi
 \def\greincludegabcscore#1{%
 	\gre@warning{\protect\greincludedgabcscore\space is deprecated.\MessageBreak Use \protect\includescore\space instead.}
-	\gre@includegabcscore{#1}
+	\gre@includescore{#1}
 }
 
-% Wrapper function that can handle both file types.  This is done by checking the filename (using the string tests from the xstring package) to see if it ends with .gabc.  If it does, we assume the file is in gabc format and pass it to \ger@includegabcscore.  All other files are assumed to be in gtex format and are processed using \gre@includetexscore.
-\def\includescore#1{%
-	\IfEndWith{#1}{.gabc}{\gre@includegabcscore{#1}}{\gre@includetexscore{#1}}
+% A macro that passes the score directly to TeX without performing the API version check or if the gabc was modified since the creation of the gtex file.
+\def\gre@includescorewithoption[#1]#2{%
+  \input #2%
+  \relax%
 }
+
+% The main macro used by the user to input scores into the document.
+
+\def\includescore{\@ifnextchar[{\gre@includescorewithoption}%
+    {\gre@includescore}%
+}
+
+% If called without the optional argument '\includescore{Antiphon}' the filename will be passed to the lua function 'include_score' which will check: whether the gtex file exists, if the API version of the gtex file, or if the gabc file is newer than the gtex file. If one of these tests fails, the gabc file will be (re)compiled.
+
+% If called with the optional argument '\includescore[f]{Antiphon.gtex}' the gtex file will be forced into the document and will not be checked by the lua function 'include_score'. This does not bypass the API version test done by '\gregoriotexapiversion'.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %% some hyphen definitions

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -1364,7 +1364,12 @@
 %% score including
 %%%%%%%%%%%%%%%%%%
 
-% The primary macro that includes a score in gTeX or gabc format.
+% The primary macro that includes a score. The lua function check that:
+%  -- The gtex file exists.
+%  -- The gtex file is of the correct gregoriotexapi_version.
+%  -- The gtex file is 'newer' than it's corresponding gabc file.
+% If either test fails, the gabc file is (re)compiled.
+
 \def\gre@includescore#1{%
   \directlua{gregoriotex.include_score([[#1]])}%
   \relax%
@@ -1406,9 +1411,20 @@
     {\gre@includescore}%
 }
 
-% If called without the optional argument '\includescore{Antiphon}' the filename will be passed to the lua function 'include_score' which will check: whether the gtex file exists, if the API version of the gtex file, or if the gabc file is newer than the gtex file. If one of these tests fails, the gabc file will be (re)compiled.
+% If called without the optional argument: '\includescore{Antiphon}'
+% the filename will be passed to the lua function 'include_score'
+% which will check: whether the gtex file exists, if the API version
+% of the gtex file, or if the gabc file is newer than the gtex
+% file. If one of these tests fails, the gabc file will be
+% (re)compiled.
+% The argument may or may not include a file extension. These are all valid:
+% '\includescore{Antiphon}' or '\includescore{Antiphon.gabc}' or
+% '\includescore{Antiphon.gtex}'
 
-% If called with the optional argument '\includescore[f]{Antiphon.gtex}' the gtex file will be forced into the document and will not be checked by the lua function 'include_score'. This does not bypass the API version test done by '\gregoriotexapiversion'.
+% If called with the optional argument: '\includescore[f]{Antiphon.gtex}'
+% the gtex file will be forced into the document and will not be
+% checked by the lua function 'include_score'. This does not bypass
+% the API version test done by '\gregoriotexapiversion'.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %% some hyphen definitions

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -1366,7 +1366,7 @@
 
 % function that includes a score in TeX format
 \def\gre@includetexscore#1{%
-	\input #1%
+	\directlua{gregoriotex.include_gtex_score([[#1]])}%
 	\relax %
 }
 \ifdefined\includetexscore

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=gregorio
-AppVersion=2.4.1
+AppVersion=2.4.2
 DefaultDirName={pf}\gregorio
 DefaultGroupName=gregorio
 SetupIconFile=gregorio.ico


### PR DESCRIPTION
Continuation of #53 
Behavior Change: \includescore#1 now performs the following checks:

  -- If #1 is a `gabc` file and there already is an `-auto.gtex` file
     then gregoriotex will check the api version of the gtex file for
     compatibility and recompile the `gabc` file if necessary.

  -- If #1 is a `gtex` file then gregoriotex will:

  * check for a `gtex` file and if none exists then compile one from
       a `gabc` file if that exists.

  * check the api version of the `gtex` file for compatibility and
       recompile the `gabc` file if necessary.

  * compare the timestamp of the `gtex` file against the `gabc` file
       and recompile if the `gtex` is older.

Note: #1 should either end with .gabc or .gtex

If someone could test, I'm not 100% sure of this. I don't think I tested all the possible use cases of `\includescore`.