### PR TITLE
Fix error with manual linebreaking in a score. #65

### DIFF
--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -204,7 +204,7 @@
 % warning: the behaviour of all this is quite difficult to understand: this function is called with simple arguments (between 0 and 20) by the glyph function. In this case we add the align center of the argument to notesaligncenter ; and notesaligncenter can be already set to something by flat and natural.
 \def\grefindnotesaligncenter#1{%
   \grefindsimplenotesaligncenter{#1}{0}%
-  \newskip\gre@tempdim
+  \newdimen\gre@tempdim
   \gre@tempdim=\wd\GreTempwidth %
   \divide\gre@tempdim by 2\relax %
   \global\advance\gre@notesaligncenter by \gre@tempdim %
@@ -215,7 +215,7 @@
 \def\grefindnextnotesaligncenter#1{%
   \ifnum#1<20\relax %
     \grefindsimplenotesaligncenter{#1}{1}%
-    \newskip\gre@tempdim
+    \newdimen\gre@tempdim
     \gre@tempdim=\wd\GreTempwidth %
     \divide\gre@tempdim by 2\relax %
     \global\gre@notesaligncenter=\gre@tempdim %
@@ -225,14 +225,14 @@
     \ifnum#1<40\relax%
       \advance\gretempdimcount by -20\relax %
       \grefindsimplenotesaligncenter{\gretempdimcount}{1}%
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=\wd\GreTempwidth %
       \divide\gre@tempdim by 2\relax %
       \setbox\GreTempwidth=\hbox{\gregoriofont \char 6}%
     \else%\ifnum#1<40
       \advance\gretempdimcount by -40\relax %
       \grefindsimplenotesaligncenter{\gretempdimcount}{1}%
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=\wd\GreTempwidth %
       \divide\gre@tempdim by 2\relax %
       \setbox\GreTempwidth=\hbox{\gregoriofont \char 7}%
@@ -437,20 +437,20 @@
   % there must be at least a certain space between the key and the first note. The first letter can be beneath the key, but not to the left
   \ifnum\grelastoflinecount=2\relax %
     \ifnum\gredisableeolshifts=0\relax%
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=\gre@intersyllablespace %
       \advance\gre@tempdim by \gre@begindifference %
       % a little trick... we don't want to kern more than clefwidth minus minimalspaceatlinebeginning
       \advance\gre@clefwidth by -\gre@minimalspaceatlinebeginning %
       \ifdim\gre@tempdim <-\gre@clefwidth %
-        \newskip\gre@tempdim
+        \newdimen\gre@tempdim
         \gre@tempdim=-\gre@clefwidth %
       \fi %
       \advance\gre@clefwidth by \gre@minimalspaceatlinebeginning %
       \hbox{}%
       \advance\gre@tempdim by -\gre@spaceafterlineclef %
       \ifdim\the\gre@tempdim < \the\gre@begindifference %
-        \newskip\gre@tempdim
+        \newdimen\gre@tempdim
         \gre@tempdim=\the\gre@begindifference %
       \fi %
       % Don't allow kern past the beginning of the first line with no initial
@@ -470,7 +470,7 @@
     % and we do it only if it is not the first syllable of a word
     % but we must not do it when there is a bar before... so when there is a bar enddifference = 0
     \ifnum\grefirstsyllableofword=0 %
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=\gre@intersyllablespace %
       \advance\gre@tempdim by \gre@begindifference %
       \ifdim\gre@enddifference<0pt%
@@ -495,7 +495,7 @@
   \ifcase#4 %
     % we enter here if the end of word is 0, so we must determine if we need to type a dash here
     % we set gretempdim to the actual space between the text of the two syllables. The algorithm is quite complex, but quite similar to the one computing the space between the two syllables several lines above.
-    \newskip\gre@tempdim
+    \newdimen\gre@tempdim
     \gre@tempdim=\gre@intersyllablespace %
     \advance\gre@tempdim by \gre@nextbegindifference %
     \ifdim\gre@enddifference<0pt%
@@ -504,7 +504,7 @@
     % there is a small """feature""" here: if the first glyph is an alteration, the algorithm will be quite pessimistic
     % about the space, so an hyphen may be added when it's not really necessary.
     \ifdim\gre@tempdim<0pt%
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=0pt%
     \fi %
     \ifdim\gre@enddifference >0pt%
@@ -549,7 +549,7 @@
   % For the kern in this case, the base is to kern -\gre@enddifference if it's negative, but we can kern a bit more for the text to get a bit more to the right, but not after the end of the scores minus \gre@minimalspaceatlinebeginning
   \ifnum\grelastoflinecount=1\relax %
     \ifdim\the\gre@enddifference <0pt%
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=-\gre@enddifference %
       % we don't do it if it's the last syllable of a score or if the user disabled it
       \ifnum\gredisableeolshifts=0\relax %
@@ -563,7 +563,7 @@
         \advance\gre@tempdim by \gre@minimalspaceatlinebeginning %
       \fi %
       \ifdim\the\gre@tempdim <-\the\gre@enddifference %
-        \newskip\gre@tempdim
+        \newdimen\gre@tempdim
         \gre@tempdim=-\the\gre@enddifference %
       \fi %
       \xdef\grekernbeforeeol{\the\gre@tempdim\relax}%
@@ -675,10 +675,10 @@
     \advance\gre@skipone by \wd\GreSyllablenotes %
     % now let's get temp
     \ifdim\gre@nextbegindifference < 0 pt%
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=-\gre@nextbegindifference %
     \else %
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=0 pt%
     \fi %
     \ifdim\gre@previousenddifference < 0 pt%
@@ -693,12 +693,12 @@
       \gre@skipone=\gre@tempdim %
     \fi %
     \divide\gre@skipone by 2\relax %
-    \newskip\gre@tempdim
+    \newdimen\gre@tempdim
     \gre@tempdim=\wd\GreSyllablenotes %
     \divide\gre@tempdim by 2\relax %
     \advance\gre@skipone by -\gre@tempdim %
     % now we have our skipone
-    \newskip\gre@tempdim
+    \newdimen\gre@tempdim
     \gre@tempdim=\gre@skipone %
     \ifdim\gre@previousenddifference < 0 pt%
       \advance\gre@tempdim by \gre@previousenddifference %
@@ -728,7 +728,7 @@
       %\gre@tempdim=\wd\GreSyllablenotes %
       %\divide\gre@tempdim by 2\relax %
       %\kern -\gre@tempdim %
-      \newskip\gre@tempdim
+      \newdimen\gre@tempdim
       \gre@tempdim=\gre@skipone %
       \ifdim\gre@nextbegindifference < 0 pt%
         \advance\gre@tempdim by \gre@nextbegindifference %
@@ -745,7 +745,7 @@
     \newskip\gre@skipone
     \gre@skipone=\gre@textbartextspace %
     % same code as in syllable
-    \newskip\gre@tempdim
+    \newdimen\gre@tempdim
     \gre@tempdim=\gre@begindifference %
     \ifdim\gre@tempdim > 0 pt%
       \advance\gre@skipone by \gre@tempdim %


### PR DESCRIPTION
I think TeX could not do the `\ifdim` math with the rubber length of the `newskip`.