### PR TITLE
Simplify the fonts makefile.

### DIFF
--- a/contrib/gregorio-scribus.lua
+++ b/contrib/gregorio-scribus.lua
@@ -79,7 +79,7 @@ end
 
 local format = string.format
 
-texfile:write(format("\n\\includescore{%s-score.tex}\n\\end{document}\n", pathbase))
+texfile:write(format("\n\\includescore[f]{%s-score.tex}\n\\end{document}\n", pathbase))
 texfile:close()
 gabcfile:close()
 

--- a/fonts/Makefile
+++ b/fonts/Makefile
@@ -13,21 +13,15 @@ TDS_ZIP = $(NAME).tds.zip
 # Installation locations
 FORMAT = luatex
 NAME = gregoriotex
+TEXHASH = texhash
 TEXDIR = $(TEXMFROOT)/tex/$(FORMAT)/$(NAME)
 DOCDIR = $(TEXMFROOT)/doc/$(FORMAT)/$(NAME)
 TTFDIR = $(TEXMFROOT)/fonts/truetype/public/$(NAME)
 SRCDIR = $(TEXMFROOT)/source/$(FORMAT)/$(NAME)
 FNTSRCDIR = $(TEXMFROOT)/fonts/source/$(NAME)
-HOMETEXDIR = $(TEXMFHOMEROOT)/tex/$(FORMAT)/$(NAME)
-HOMEDOCDIR = $(TEXMFHOMEROOT)/doc/$(FORMAT)/$(NAME)
-HOMETTFDIR = $(TEXMFHOMEROOT)/fonts/truetype/public/$(NAME)
-HOMESRCDIR = $(TEXMFHOMEROOT)/source/$(FORMAT)/$(NAME)
-HOMEFNTSRCDIR = $(TEXMFHOMEROOT)/fonts/source/$(NAME)
-
 
 # a default value
 TEXMFROOT = `kpsewhich -var-value TEXMFLOCAL`
-TEXMFHOMEROOT = `kpsewhich -var-value TEXMFHOME`
 
 # installation rules
 INSTALL_TEXFILES = @mkdir -p $(TEXDIR) && cp $(TEXFILES) $(TEXDIR)
@@ -35,27 +29,8 @@ INSTALL_DOCFILES = @mkdir -p $(DOCDIR) && cp $(DOCFILES) $(DOCDIR)
 INSTALL_SRCFILES = @mkdir -p $(SRCDIR) && cp $(SRCFILES) $(SRCDIR)
 INSTALL_TTFFILES = @mkdir -p $(TTFDIR) && cp $(TTFFILES) $(TTFDIR)
 INSTALL_FNTSRCFILES = @mkdir -p $(FNTSRCDIR) && cp $(FNTSRCFILES) $(FNTSRCDIR)
-# local $HOME installation rules
-LOCAL_INSTALL_TEXFILES = @mkdir -p $(HOMETEXDIR) && cp $(TEXFILES) $(HOMETEXDIR)
-LOCAL_INSTALL_DOCFILES = @mkdir -p $(HOMEDOCDIR) && cp $(DOCFILES) $(HOMEDOCDIR)
-LOCAL_INSTALL_SRCFILES = @mkdir -p $(HOMESRCDIR) && cp $(SRCFILES) $(HOMESRCDIR)
-LOCAL_INSTALL_TTFFILES = @mkdir -p $(HOMETTFDIR) && cp $(TTFFILES) $(HOMETTFDIR)
-LOCAL_INSTALL_FNTSRCFILES = @mkdir -p $(HOMEFNTSRCDIR) && cp $(FNTSRCFILES) $(HOMEFNTSRCDIR)
 
-
-$(TDS_ZIP): TEXMFROOT=./tmp-texmf
-$(TDS_ZIP): $(ALLFILES)
-	@echo "Making TDS-ready archive $@."
-	@$(RM) -- $@
-	$(INSTALL_TEXFILES)
-	$(INSTALL_DOCFILES)
-	$(INSTALL_SRCFILES)
-	$(INSTALL_TTFFILES)
-	$(INSTALL_FNTSRCFILES)
-	@cd $(TEXMFROOT) && zip -9 ../$@ -r . >/dev/null
-	@$(RM) -r -- $(TEXMFROOT)
-	
-install: $(ALLFILES)
+installfiles: $(ALLFILES)
 	@echo "Installing in '$(TEXMFROOT)'."
 	@mkdir -p $(TEXMFROOT)
 	$(INSTALL_TEXFILES)
@@ -63,17 +38,19 @@ install: $(ALLFILES)
 	$(INSTALL_SRCFILES)
 	$(INSTALL_TTFFILES)
 	$(INSTALL_FNTSRCFILES)
-	texhash
 
-localinstall: $(ALLFILES)
-	@echo "Installing in '$(TEXMFHOMEROOT)'."
-	@mkdir -p $(TEXMFHOMEROOT)
-	$(LOCAL_INSTALL_TEXFILES)
-	$(LOCAL_INSTALL_DOCFILES)
-	$(LOCAL_INSTALL_SRCFILES)
-	$(LOCAL_INSTALL_TTFFILES)
-	$(LOCAL_INSTALL_FNTSRCFILES)
-	texhash
+$(TDS_ZIP): TEXMFROOT=./tmp-texmf
+$(TDS_ZIP): installfiles
+	@echo "Making TDS-ready archive $@."
+	@$(RM) -- $@
+	@cd $(TEXMFROOT) && zip -9 ../$@ -r . >/dev/null
+	@$(RM) -r -- $(TEXMFROOT)
+	
+install: installfiles
+	$(TEXHASH)
+
+localinstall: TEXMFROOT = `kpsewhich -var-value TEXMFHOME`
+localinstall: install
 
 gregorio.ttf: squarize.py gregorio-base.sfd
 	python2 squarize.py gregorio

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -213,7 +213,7 @@ local function compile_gabc(gabc_file, gtex_file)
     end
 end
 
-local function include_score(input_file)
+local function include_score(input_file, force_gabccompile)
     local file_root
     if string.match(input_file:sub(-5), '%.gtex') then
 	file_root = input_file:sub(1,-6)
@@ -231,6 +231,8 @@ local function include_score(input_file)
 	log("The file %s does not exist. Searching for a gabc file", gtex_file)
 	if lfs.isfile(gabc_file) then
 	    compile_gabc(gabc_file, gtex_file)
+	    tex.print(string.format("\\input %s", gtex_file))
+	    return
 	else
 	    err("The file %s does not exist.", gabc_file)
 	    return
@@ -240,6 +242,8 @@ local function include_score(input_file)
     local gabc_timestamp = lfs.attributes(gabc_file).modification
     if gtex_timestamp < gabc_timestamp then
 	log("%s has been modified and %s needs to be updated. Recompiling the gabc file.", gabc_file, gtex_file)
+	compile_gabc(gabc_file, gtex_file)
+    elseif force_gabccompile then
 	compile_gabc(gabc_file, gtex_file)
     end
     tex.print(string.format("\\input %s", gtex_file))

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -1248,14 +1248,36 @@
 %% score including
 %%%%%%%%%%%%%%%%%%%
 
+% BOOL to track whether to force the recompiling of gabc files or not.
+\newif\if@gabcforcecompile%
+
+% User macro to force gregriotex to recompile gabc files. Useful for when there
+% are changes to gregoriotex but the GREGORIOTEX API VERSION is not changed.
+\def\forcegabccompile{%
+  \@gabcforcecompiletrue%
+}%
+
+% User macro to let gregoriotex auto recompile gabc files as necessary.
+% Intended to be used in the main tex file to revert the previous macro.
+\def\normalgabccompile{%
+  \@gabcforcecompilefalse%
+}%
+
 % The primary macro that includes a score. The lua function check that:
 %  -- The gtex file exists.
 %  -- The gtex file is of the correct gregoriotexapi_version.
 %  -- The gtex file is 'newer' than it's corresponding gabc file.
 % If either test fails, the gabc file is (re)compiled.
+%
+% If the \recompilegabc macro is in effect, pass true to the lua function.
+% This forces gregoriotex to recompile the gabc file.
 
 \def\gre@includescore#1{%
-  \directlua{gregoriotex.include_score([[#1]])}%
+  \if@gabcforcecompile%
+    \directlua{gregoriotex.include_score([[#1]], true)}%
+  \else%
+    \directlua{gregoriotex.include_score([[#1]], nil)}%
+  \fi%
   \relax%
 }%
 


### PR DESCRIPTION
From Henry So Jr.

This patch does two things:

Firstly, it consolidates tds, localinstall, and install.  I think this
will make it easier to keep things in sync since there's less
duplication of code.

Secondly, it makes texhash a variable so I can override it in a build.