### PR TITLE
Bugfix #84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file.
-This project does not currently adhere to [Semantic Versioning](http://semver.org/), but should one day.
+As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## 3.0.beta - 2015-03-15
@@ -9,6 +9,7 @@ This project does not currently adhere to [Semantic Versioning](http://semver.or
 - Temporary distance registers renamed to follow the pattern `\gre@skip@temp@...` or `\gre@dimen@temp@...` as appropriate.  Issue [#80](https://github.com/gregorio-project/gregorio/issues/80) indicates this wasn't done completely the first time and had to be corrected.
 
 ### Fixed
+- Missed renaming `bitristrospace`.  See [#84](https://github.com/gregorio-project/gregorio/issues/84)
 - Syllables were not being spaced correctly (see [#79](https://github.com/gregorio-project/gregorio/issues/79)).  This appears to result from the space calculations not terminating properly.  There's a need for a `\relax` somewhere.  Since the problem didn't show up in debug mode, I simply added a `\else\relax` to `\gre@debug` to eliminate the problem.  We may need to go back and fix this better later.
 - Some glues were leaking into the document because there were places where a dimension was being set to a skip or incremented by one.  See [#65](https://github.com/gregorio-project/gregorio/issues/65), [#75](https://github.com/gregorio-project/gregorio/issues/75), and [#78](https://github.com/gregorio-project/gregorio/issues/78)
 

--- a/tests/Main.tex
+++ b/tests/Main.tex
@@ -28,4 +28,7 @@ This document is a compilation of all the MWEs for bugs which have been reported
 
 \section{Issue \# 82: Undefined control sequence}
 \includescore{test82}
+
+\section{Issue \#84: Undefined control sequence on bistropha}
+\includescore{test84}
 \end{document}

--- a/tests/test84.gabc
+++ b/tests/test84.gabc
@@ -1,0 +1,6 @@
+% !TEX root = Main.tex
+% !TEX TS-program = LuaLaTeX
+% !TEX encoding = UTF-8
+
+%%
+(c4) test(fss<)

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -1069,7 +1069,7 @@
     \gre@skip@temp@four = \gre@skip@bitrivirspace%
     \grehskip\gre@skip@temp@four %
   \or% case 5
-    \gre@skip@temp@four = \gre@bitristrospace%
+    \gre@skip@temp@four = \gre@skip@bitristrospace%
     \grehskip\gre@skip@temp@four %
   \or% case 6
     \gre@skip@temp@four = \gre@skip@spaceaftersigns%


### PR DESCRIPTION
Must have missed `bitristrospace` when renaming distances.  Fixes #84.