### PR TITLE
Inconsistent baseline for alt text

### DIFF
--- a/tests/Main.tex
+++ b/tests/Main.tex
@@ -1,7 +1,7 @@
 % !TEX TS-program = LuaLaTeX
 \documentclass[11pt]{article}
 
-\usepackage[autocompile]{gregoriotex}
+\usepackage[debug,autocompile]{gregoriotex}
 \usepackage[T1]{fontenc}
 
 \begin{document}
@@ -31,4 +31,7 @@ This document is a compilation of all the MWEs for bugs which have been reported
 
 \section{Issue \#84: Undefined control sequence on bistropha}
 \includescore{test84}
+
+\section{Issue \#98: Inconsistent baseline for alternate text}
+\includescore{test98}
 \end{document}

--- a/tests/test98.gabc
+++ b/tests/test98.gabc
@@ -1,0 +1,12 @@
+% !TEX root = Main.tex
+% !TEX TS-program = LuaLaTeX
+% !TEX encoding = UTF-8
+
+initial-style: 0;
+%%
+(c4) Test(cd) test (cd)
+<alt>Alt</alt> (:) Test(cd) test (cd)
+<alt>Alt</alt>(:) Test(cd) test (cd)
+(:) <alt>Alt</alt>Test(cd) test (cd) (::)
+<alt>Alt</alt>(:) Test(cd) test (cd)
+<alt>Alt</alt> (:) Test(cd) test (cd)

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -516,15 +516,20 @@
 
 % typesets the text above the line
 \def\gretypesettextabovelines#1{%
-  \greabovelinestextstyle{\gre@dimen@temp@five=\gre@dimen@abovelinestextraise} %
-  \advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight %
-  \advance\gre@dimen@temp@five by 4\gre@dimen@interstafflinespace %
-  \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext %
-  \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
-  \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext %
-  \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace %
-  \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\greabovelinestextstyle{#1}\hss}%
-  \relax %
+	\greabovelinestextstyle{%
+		\gre@debug{Raise alt text: \gre@dimen@abovelinestextraise}%
+		\global\gre@dimen@temp@five=\gre@dimen@abovelinestextraise\relax%
+	} %
+	\gre@debug{Raise alt text: \the\gre@dimen@temp@five}%
+	\advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight %
+	\advance\gre@dimen@temp@five by 4\gre@dimen@interstafflinespace %
+	\advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext %
+	\advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
+	\advance\gre@dimen@temp@five by \gre@dimen@spacelinestext %
+	\advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace %
+	\gre@debug{Raise alt text: \the\gre@dimen@temp@five}%
+	\leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\greabovelinestextstyle{#1}\hss}%
+	\relax %
 }%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Forgot a `\global` when initializing the temp dimension used to calculate the position of the baseline for the alt text. This resulted in it carrying in a value used elsewhere to start instead of resetting it to the user dimension `abovelinestextraise`. The `\global` is necessary because the initialization happens inside the `\greabovelinestextstyle` so that em and ex units are respected.