### PR TITLE
Changed version test to only fail on mismatched major versions.

### DIFF
--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -94,8 +94,8 @@
 % #1 is the version of GregorioTeX the score is made for.
 
 \def\gregoriotexapiversion#1{%
-  \StrBefore{\gregoriotexversion}{.}[\gre@temp]%
-  \IfBeginWith{#1}{\gre@temp}{\relax}{%else
+  \StrBefore{\gregoriotexversion}{.}[\gre@gregoriomajorversion]%
+  \IfBeginWith{#1}{\gre@gregoriomajorversion}{\relax}{%else
     \greerror{GregorioTeX is in version \gregoriotexversion \space\space while a score you included requires version #1. Please recompile your scores}}%
 }%
 

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -79,6 +79,7 @@
 \xdef\greinternalversion{\directlua{tex.write(gregoriotex.get_gregorioversion())}}%
 
 % first some macros to allow checks for version:
+% Tests that all gregoriotex files are of the same version.
 % #1 is the name of the file
 % #2 is the version
 
@@ -87,11 +88,14 @@
     \greerror{uncoherent file versions: gregoriotex.tex is in version \number\greinternalversion \space\space while #1 is in version \number#2}}%
 }%
 
-% macro called by scores
+% Macro called by scores.
+% Tests the major version of gregorio (X.0.0) against the score. Fails
+% if the major version (X) does not match.
 % #1 is the version of GregorioTeX the score is made for.
 
 \def\gregoriotexapiversion#1{%
-  \IfStrEq*{#1}{\gregoriotexversion}{}{%else
+  \StrBefore{\gregoriotexversion}{.}[\gre@temp]%
+  \IfBeginWith{#1}{\gre@temp}{\relax}{%else
     \greerror{GregorioTeX is in version \gregoriotexversion \space\space while a score you included requires version #1. Please recompile your scores}}%
 }%
 


### PR DESCRIPTION
Fix for #101 

If a score declares that is it for version `x.y.z` the score will only
need to be recompiled if the major version of gregorio changes,
i.e. `x+1.y.z`.

This does not effect the `[autocompile]` options. When `autocompile` is
`true` a new score will be compiled for any version change.