### PR TITLE
fix #69

### DIFF
--- a/VersionUpdate.py
+++ b/VersionUpdate.py
@@ -13,6 +13,7 @@ import re
 version_file = 'VERSION'
 
 gregorio_files = ["configure.ac",
+                  "windows/gregorio-resources.rc",
                   "windows/gregorio.iss"]
 
 gregoriotex_files = ["tex/gregoriotex.lua",
@@ -48,6 +49,10 @@ def replace_gregorio_version(infile, newver):
             result.append(re.sub
                           (r'[\d.]+-?\w*(\],)', newver + r'\1', line))
         elif re.search(r'AppVersion', line):
+            result.append(re.sub(r'[\d.]+-?\w*', newver, line))
+        elif re.search(r'FileVersion', line):
+            result.append(re.sub(r'[\d.]+-?\w*', newver, line))
+        elif re.search(r'ProductVersion', line):
             result.append(re.sub(r'[\d.]+-?\w*', newver, line))
         else:
             result.append(line)

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AM_PROG_LEX
 AC_PROG_YACC
 AC_PROG_LIBTOOL
 AC_CHECK_TOOL([RC], [windres], [no])
+AM_CONDITIONAL([HAVE_RC], [test x$RC != xno])
 
 ## a dirty patch for cygwin, who needs the -lintl explicit option, that doesn't work under linux
 AC_CHECK_PROGS(UNAME, uname, :)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,15 @@
 AM_CPPFLAGS=-I$(top_srcdir)/include -I$(top_srcdir)/lib -I$(top_srcdir)/plugins -DLOCALEDIR=\"$(localedir)\" -DPLUGINDIR=\"$(libdir)/gregorio\"
 AM_CFLAGS=
 
+.rc.o:
+	$(RC) $(RCFLAGS) $< -o $@
+
 bin_PROGRAMS=gregorio
+if HAVE_RC
+gregorio_SOURCES=gregorio-utils.c  ../windows/gregorio-resources.rc
+else
 gregorio_SOURCES=gregorio-utils.c
+endif
 gregorio_LDADD=$(LIBINTL) $(LIBTOOL_LIB) ../lib/libgregorio.la
 if ALL_STATIC
 gregorio_LDADD+= ../plugins/dump/dump.la ../plugins/opustex/opustex.la ../plugins/gregoriotex/gregoriotex.la ../plugins/gabc/gabc.la ../plugins/xml/xml.la

--- a/windows/gregorio-resources.rc
+++ b/windows/gregorio-resources.rc
@@ -1,0 +1,25 @@
+IDI_ICON1 ICON DISCARDABLE "gregorio.ico"
+1 VERSIONINFO
+FILEVERSION     1,0,0,0
+PRODUCTVERSION  1,0,0,0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904E4"
+    BEGIN
+      VALUE "CompanyName", "Gregorio project"
+      VALUE "FileDescription", "Gregorio"
+      VALUE "FileVersion", "3.0.0-beta"
+      VALUE "InternalName", "gregorio"
+      VALUE "LegalCopyright", "See COPYING in the installation directory."
+      VALUE "OriginalFilename", "gregorio.exe"
+      VALUE "ProductName", "Gregorio"
+      VALUE "ProductVersion", "3.0.0-beta"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x409, 1252
+  END
+END


### PR DESCRIPTION
resources (including icon) are in windows/gregorio-resources.rc, compiled by
windres (if cross-compiling only) into gregorio-resources.o, linked with
the main executable (in src/).