### PR TITLE
Fixing mingw32 compilation

### DIFF
--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -151,6 +151,12 @@ available formats are:\n\
 \n"));
 }
 
+
+// realpath is not in mingw32
+#ifdef __MINGW32__
+  #define realpath(path,resolved_path) _fullpath(resolved_path, path, 260)
+#endif
+
 void
 check_input_clobber (char *input_file_name, char *output_file_name)
 {

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -154,7 +154,7 @@ available formats are:\n\
 
 // realpath is not in mingw32
 #ifdef __MINGW32__
-  #define realpath(path,resolved_path) _fullpath(resolved_path, path, 260)
+  #define realpath(path,resolved_path) _fullpath(resolved_path, path, _MAX_PATH)
 #endif
 
 void


### PR DESCRIPTION
https://github.com/gregorio-project/gregorio/commit/455f15ffdc707a3e2f937e34c9a19d4de2b08601
broke windows cross-compilation, because mingw32 doesn't have a realpath
function. I used _fullpath instead, but I had to hardcode MAX_PATH to 260.
I don't really know how to improve that...