### PR TITLE
Fixes for automake / make dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ src/gregorio
 #emacs auto gen files
 auto/
 
+#tarball
+*.tar.gz
+
 !UserManual.pdf
 
 #gregorio specific

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,1 +1,1 @@
-EXTRA_DIST = gprocess gabc.lang gabc.xml gabc.vim 900_gregorio.xml gregorio-scribus.lua gregorio.png gregorio.scpt gabc-syntax.plist gregorio.engine README gregorio-mode.el
+EXTRA_DIST = gprocess gabc.lang gabc.xml gabc.vim 900_gregorio.xml gregorio-scribus.lua gregorio.png gabc-syntax.plist README gregorio-mode.el

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,7 @@
 SRCFILES= Command_Index_gregorio.tex  Command_Index_internal.tex  Command_Index_User.tex UserManual.tex
 
 UserManual.pdf: $(SRCFILES)
-	latexmk -lualatex -e '$$pdflatex=q/lualatex %O --shell-escape %S/' UserManual.tex
+	latexmk -pdf -pdflatex='lualatex --shell-escape %O %S' UserManual.tex
 
 doc: UserManual.pdf
 


### PR DESCRIPTION
I ran into a few issues while trying to test the build of UserManual.pdf.

1. contrib/Makefile.am was requiring files that haven't existed since November 2009.  They have been removed from the list of extra dist files.
2. The -lualatex option of latexmk is not in TeX Live 2012, which happens to be what I'm using, so I modified the script to hopefully work in more versions of TeX Live.  Please review!
3. The distribution tarball was not being ignored.  Added to .gitignore.