### PR TITLE
using lzma instead of gzip for dist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CONFIG_SRCDIR([src/gregorio-utils.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE([subdir-objects foreign])
+AM_INIT_AUTOMAKE([subdir-objects foreign dist-xz no-dist-gzip])
 
 AC_PROG_CC
 AC_PROG_CC_STDC

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CONFIG_SRCDIR([src/gregorio-utils.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE([subdir-objects foreign dist-xz no-dist-gzip])
+AM_INIT_AUTOMAKE([subdir-objects foreign dist-bzip2 no-dist-gzip])
 
 AC_PROG_CC
 AC_PROG_CC_STDC


### PR DESCRIPTION
creating `gregorio-xxx.tar.xz` (extractable with `tar xJf` instead of `tar xzf`): this makes the tarball 645ko instead of 910ko (-30%). Seems like the most fashionable way to compress sources now (at least under Linux).

@rpspringuel @henryso @eschwab can you confirm it works for you?