### PR TITLE
Fix missing argument for \greendnlbarea

### DIFF
--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -810,7 +810,7 @@
   \global\grelastoflinecount=0\relax %
   \global\greblockcusto=0\relax %
   \ifnum\grenlbstate=0\else %
-    \greendnlbarea{2}%
+    \greendnlbarea{2}{0}%
   \fi %
   \grelocalleftbox{}%
   \ifnum\keeprightbox=0\relax %


### PR DESCRIPTION
This little bug is a persistent one. It keeps popping back up. Causes an error in a  score that ends with an unclosed `<nlba>`.