### PR TITLE
Fix #205

### DIFF
--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -727,8 +727,7 @@
 }%
 
 
-% We input the default config, for everything to work fine it has to be done after the gregoriotex package is completely loaded (so that all functions are well defined).  As a result we delay the loading to the beginning of the document.
-\AtBeginDocument{\GreLoadSpaceConf{default}}%
+% For everything to work fine the default configuration has to loaded after the gregoriotex package is completely loaded (so that all functions are well defined).  As a result you'll find that as the last line in gregoriotex.tex
 
 
 %%%%%%%%%%%%%%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -1441,3 +1441,7 @@
 \def\GreUseZeroHyphen{%
   \global\let\grehyph\grezerhyph %
 }%
+
+
+% We load the default space configuration.
+\GreLoadSpaceConf{default}%


### PR DESCRIPTION
Changes when the default space configuration is loaded so that spaces and `\grefactor` can be changed in preamble.  This restores functionality that used to exist before I made all my changes to the way spaces are handled.

Addresses #205 