### PR TITLE
Fixed clean target in doc folder

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,6 +6,7 @@ GregorioRef-$(FILENAME_VERSION).pdf: $(SRCFILES)
 doc: GregorioRef-$(FILENAME_VERSION).pdf
 
 clean:
-	latexmk -quiet -C
+	latexmk -quiet -C -jobname=GregorioRef-$(FILENAME_VERSION) GregorioRef.tex
+	rm -rf _minted*
 
 EXTRA_DIST = $(SRCFILES) GregorioRef-$(FILENAME_VERSION).pdf


### PR DESCRIPTION
Clean target in doc folder wasn't working because of the jobname option.  With that option the `latexmk -C` has to be invoked with the same jobname and target file in order to work.
Also added a remove statement to get rid of the `_minted*` directory that's created as part of building `GregorioRef-###.pdf`