### PR TITLE
Fix #207

### DIFF
--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -200,8 +200,6 @@
 \else%
   \def\setstafflinethickness#1{%
     \xdef\gre@stafflinefactor{#1}%
-    \gre@computespaces %
-    %% TODO: make smarter
     \relax %
   }%
 \fi%
@@ -700,7 +698,6 @@
 % TODO: make smarter so that it knows the dependency tree and only recalculates distances affected by the change
 \def\grechangedim#1#2#3{%
   \gresetdim{#1}{#2}{#3}%
-  \gre@computespaces%
 }%
 
 %a macro to use if all you want to do is turn off the scaling for a particular distance
@@ -722,7 +719,6 @@
   \ifnum\the\grefactor=\greconffactor\else %If the space configuration file is designed for a \grefactor other than the current one, then we need to rescale the distances.
     \gre@changedimenfactor{\greconffactor}{\grefactor} %
   \fi%
-  \gre@computespaces %
   \relax %
 }%
 
@@ -1071,7 +1067,6 @@
     \divide\gre@count@temp@two by #1\relax%
     \xdef\gre@stafflinefactor{\the\gre@count@temp@two}%
   \fi%
-  \gre@computespaces%
   \relax %
 }%
 

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -789,6 +789,7 @@
   \ifnum\greusestylefont=1\relax %
     \gresetstylefont %
   \fi %
+  \gre@computespaces
   \grecancelpenalties %
   \gredofinetuning %
   \gregorioattr=0\relax %
@@ -1281,12 +1282,6 @@
   \else%
     \gre@changedimenfactor{\grefactor}{#1}%
     \global\grefactor=#1\relax %
-    \gre@computespaces %
-    \gregeneratelines %
-    \setgregoriofont{\gregoriofontname}%
-    \ifnum\greusestylefont=1\relax %
-      \gresetstylefont %
-    \fi %
   \fi%
   \relax %
 }%


### PR DESCRIPTION
Re: #207 

Changed timing of `\gre@computespaces`.  Now instead of calling it whenever we change a distance, we call it once at the beginning of each score.  GregorioTeX will now respect the document width on a score by score basis as a result.
Also removed some redundant code from `\setgrefactor` that was already being done as part of `\begingregorioscore`.

Please test.  I don't have time for anything more than the basics at the moment.