### PR TITLE
fix autoconf warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CONFIG_SRCDIR([src/gregorio-utils.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE([subdir-objects foreign dist-bzip2 no-dist-gzip])
+AM_INIT_AUTOMAKE([-Wall subdir-objects foreign dist-bzip2 no-dist-gzip])
 
 AC_PROG_CC
 AC_PROG_CC_STDC

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,8 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([-Wall subdir-objects foreign dist-bzip2 no-dist-gzip])
 
 AC_PROG_CC
+dnl AM_PROG_CC_C_O is deprecated since Automake 1.14, to be removed in the future
+AM_PROG_CC_C_O
 AC_PROG_CC_STDC
 AC_PROG_CPP
 AM_PROG_LEX

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -5,8 +5,10 @@ GregorioRef-$(FILENAME_VERSION).pdf: $(SRCFILES)
 
 doc: GregorioRef-$(FILENAME_VERSION).pdf
 
-clean:
+pdf-local: doc
+
+clean-local:
 	latexmk -quiet -C -jobname=GregorioRef-$(FILENAME_VERSION) GregorioRef.tex
-	rm -rf _minted*
+	$(RM) -rf _minted*
 
 EXTRA_DIST = $(SRCFILES) GregorioRef-$(FILENAME_VERSION).pdf

--- a/fonts/Makefile.am
+++ b/fonts/Makefile.am
@@ -39,10 +39,10 @@ gresym: gresym.ttf
 
 greextra: greextra.ttf
 
-clean:
-	@$(TOP_LEVEL_MAKE) $(RM) -f $(TTFFILES)
+clean-local:
+	$(RM) -f $(TTFFILES)
 
-install:
+install-data-local:
 	@$(TOP_LEVEL_MAKE) echo 'The Makefile in the fonts directory is no longer used for installing'
 	@$(TOP_LEVEL_MAKE) echo 'GregorioTeX.  Please use install-gtex.sh from the parent directory'
 	@$(TOP_LEVEL_MAKE) echo 'to install GregorioTeX.'


### PR DESCRIPTION
 * use `clean-local` instead of `clean`
 * use `install-data-local` instead of `install`
 * use `pdf-local` target, now `make pdf` acts as expected (in the root directory)