### PR TITLE
Getting the new documentation name into Windows installer

### DIFF
--- a/VersionManager.py
+++ b/VersionManager.py
@@ -131,6 +131,7 @@ def replace_version(version_obj):
     print('Updating source files to version {0}\n'.format(newver))
     for myfile in GREGORIO_FILES:
         result = []
+        following_file = False
         with open(myfile, 'r') as infile:
             for line in infile:
                 if 'AC_INIT([' in line:
@@ -153,6 +154,12 @@ def replace_version(version_obj):
                 elif 'PARSE_VERSION_DATE' in line:
                     newline = re.sub(r'(\d+\.\d+\.\d+(?:[-+~]\w+)*)', newver, line, 1)
                     result.append(re.sub(r'(\d+\/\d+/\d+)', today.strftime("%d/%m/%y"), newline, 1))
+                elif 'ISS_DOC_FILENAME' in line:
+                    result.append(line)
+                    following_file = True
+                elif following_file:
+                    result.append(re.sub(r'(\d+\_\d+\_\d+(?:[-+~]\w+)*)', newver_filename, line, 1))
+                    following_file = False
                 else:
                     result.append(line)
         with open(myfile, 'w') as outfile:

--- a/VersionManager.py
+++ b/VersionManager.py
@@ -131,7 +131,7 @@ def replace_version(version_obj):
     print('Updating source files to version {0}\n'.format(newver))
     for myfile in GREGORIO_FILES:
         result = []
-        following_file = False
+        following_line_filename = False
         with open(myfile, 'r') as infile:
             for line in infile:
                 if 'AC_INIT([' in line:
@@ -154,12 +154,12 @@ def replace_version(version_obj):
                 elif 'PARSE_VERSION_DATE' in line:
                     newline = re.sub(r'(\d+\.\d+\.\d+(?:[-+~]\w+)*)', newver, line, 1)
                     result.append(re.sub(r'(\d+\/\d+/\d+)', today.strftime("%d/%m/%y"), newline, 1))
-                elif 'ISS_DOC_FILENAME' in line:
+                elif 'PARSE_VERSION_FILE_NEXTLINE' in line:
                     result.append(line)
-                    following_file = True
-                elif following_file:
+                    following_line_filename = True
+                elif following_line_filename:
                     result.append(re.sub(r'(\d+\_\d+\_\d+(?:[-+~]\w+)*)', newver_filename, line, 1))
-                    following_file = False
+                    following_line_filename = False
                 else:
                     result.append(line)
         with open(myfile, 'w') as outfile:

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -1,4 +1,4 @@
-% !TEX program = LuaLaTeX
+% !TEX program = LuaLaTeX+se
 \documentclass[12pt]{article}
 \usepackage{fontspec}
 \defaultfontfeatures{Ligatures=TeX}

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -38,7 +38,7 @@ Source: "../CHANGELOG.md"; DestDir: "{app}";
 Source: "../README.md"; DestDir: "{app}";
 Source: "../CONTRIBUTORS.md"; DestDir: "{app}";
 Source: "../UPGRADE.md"; DestDir: "{app}";
-; ISS_DOC_FILENAME
+; PARSE_VERSION_FILE_NEXTLINE
 Source: "../doc/GregorioRef-3_0_0-rc1.pdf"; DestDir: "{app}";
 Source: "../COPYING.md"; DestDir: "{app}";
 Source: "../contrib/900_gregorio.xml"; DestDir: "{app}\contrib";

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -38,7 +38,8 @@ Source: "../CHANGELOG.md"; DestDir: "{app}";
 Source: "../README.md"; DestDir: "{app}";
 Source: "../CONTRIBUTORS.md"; DestDir: "{app}";
 Source: "../UPGRADE.md"; DestDir: "{app}";
-Source: "../doc/UserManual.pdf"; DestDir: "{app}";
+; ISS_DOC_FILENAME
+Source: "../doc/GregorioRef-3_0_0-rc1.pdf"; DestDir: "{app}";
 Source: "../COPYING.md"; DestDir: "{app}";
 Source: "../contrib/900_gregorio.xml"; DestDir: "{app}\contrib";
 Source: "../contrib/gregorio-scribus.lua"; DestDir: "{app}\contrib";


### PR DESCRIPTION
Since the name of the documentation pdf changed, the ISS file had to be made aware of the new file name.
This also required a new rule set in `VersionManager.py` that marks the filename for updating (since it contains the version number).  Unfortunately, ISS doesn't allow inline comments, so this has to be handled by putting the comment on the line before and then modifying the next line.