### PR TITLE
Fix pattern matching for clean_old_gtex in lua.

### DIFF
--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -188,14 +188,14 @@ local function clean_old_gtex_files(file_withdir)
     dirpath = string.match(file_withdir, "(.*)"..sep)
   end
   if dirpath then -- dirpath is nil if current directory
-    filename = "^"..file_withdir:match(".*/".."(.*)").."%-%d+_%d+_%d+_?%a*%.gtex$"
+    filename = "^"..file_withdir:match(".*/".."(.*)").."%-%d+_%d+_%d+[-%a%d]*%.gtex$"
     for a in lfs.dir(dirpath) do
       if a:match(filename) then
 	os.remove(dirpath..sep..a)
       end
     end
   else
-    filename = "^"..file_withdir.."%-%d+_%d+_%d+_?%a*%.gtex$"
+    filename = "^"..file_withdir.."%-%d+_%d+_%d+[-%a%d]*%.gtex$"
     for a in lfs.dir(lfs.currentdir()) do
       if a:match(filename) then os.remove(a) end
     end


### PR DESCRIPTION
It was not removing the old `3_0_0-beta.gtex` files. This should be a better pattern for matching the more unusual version numbers also.