### PR TITLE
Expanding places searched for `kpsewhich`

### DIFF
--- a/macosx/Gregorio.pkgproj
+++ b/macosx/Gregorio.pkgproj
@@ -812,7 +812,9 @@
 							<key>LANGUAGE</key>
 							<string>English</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Gregorio requires TeX in order to work.  Please install TeX and then try again.  You can get TeX from https://www.tug.org/texlive/.</string>
+							<string>Gregorio requires TeX in order to work.  If you do not have a TeX distribution installed, you can get one from https://www.tug.org/texlive/.
+
+If you have a TeX distribution installed in a non-standard location, then either place a symlink to kpsewhich in /usr/texbin/ and try again with this installer or build Gregorio from source.</string>
 							<key>VALUE</key>
 							<string>No TeX distribution found on this volume.</string>
 						</dict>

--- a/macosx/douninstall.sh
+++ b/macosx/douninstall.sh
@@ -6,7 +6,10 @@ PREFIX="/usr/local"
 BINDIR="$PREFIX/bin"
 PKGCONFIGDIR="$PREFIX/lib/pkgconfig"
 GREINCLUDEDIR="$PREFIX/include/gregorio"
-TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
+TEXMFLOCAL=`kpsewhich -var-value TEXMFLOCAL`
+if [ -z "$TEXMFLOCAL" ]; then
+    TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
+fi
 GRETEXDIR="$TEXMFLOCAL/tex/luatex/gregoriotex/"
 GREFONTDIR="$TEXMFLOCAL/fonts/truetype/public/gregoriotex/"
 GREFONTSOURCE="$TEXMFLOCAL/source/gregoriotex/"

--- a/macosx/douninstall.sh
+++ b/macosx/douninstall.sh
@@ -6,14 +6,15 @@ PREFIX="/usr/local"
 BINDIR="$PREFIX/bin"
 PKGCONFIGDIR="$PREFIX/lib/pkgconfig"
 GREINCLUDEDIR="$PREFIX/include/gregorio"
-TEXMFLOCAL=`kpsewhich -var-value TEXMFLOCAL`
-if [ -z "$TEXMFLOCAL" ]; then
-    TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
+GRETEXDIR=`kpsewhich gregoriotex.tex`
+if [ -z "$GRETEXDIR" ]; then
+    GRETEXDIR=`/usr/texbin/kpsewhich gregoriotex.tex`
 fi
-GRETEXDIR="$TEXMFLOCAL/tex/luatex/gregoriotex/"
-GREFONTDIR="$TEXMFLOCAL/fonts/truetype/public/gregoriotex/"
-GREFONTSOURCE="$TEXMFLOCAL/source/gregoriotex/"
-GREDOCDIR="$TEXMFLOCAL/doc/luatex/gregoriotex/"
+GRETEXDIR="${GRETEXDIR%/gregoriotex.tex}"
+TEXMFLOCAL="${GRETEXDIR%/tex/luatex/gregoriotex}"
+GREFONTDIR="$TEXMFLOCAL/fonts/truetype/public/gregoriotex"
+GREFONTSOURCE="$TEXMFLOCAL/source/gregoriotex"
+GREDOCDIR="$TEXMFLOCAL/doc/luatex/gregoriotex"
 
 rm $BINDIR/gregorio
 rm $PKGCONFIGDIR/gregorio.pc
@@ -23,5 +24,3 @@ rm -rf $GREFONTDIR
 rm -rf $GREFONTSOURCE
 rm -rf $GREDOCDIR
 pkgutil --forget com.gregorio.pkg.Gregorio
-#pkgutil --forget com.gregorio.pkg.Uninstall-Gregorio
-#exit 0

--- a/macosx/postflight.sh
+++ b/macosx/postflight.sh
@@ -5,9 +5,17 @@
 # aware of the changes.
 
 
-TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
+TEXMFLOCAL=`kpsewhich -var-value TEXMFLOCAL`
+if [ -z "$TEXMFLOCAL" ]; then
+    TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
+fi
+
+TEXHASH=`which texhash`
+if [ -z "$TEXHASH" ]; then
+    TEXHASH="/usr/texbin/texhash"
+fi
 
 cp -r /tmp/gregorio/* $TEXMFLOCAL
 rm -rf /tmp/gregorio
 
-/usr/texbin/texhash
+$TEXHASH

--- a/macosx/postflight.sh
+++ b/macosx/postflight.sh
@@ -5,7 +5,15 @@
 # aware of the changes.
 
 
-TEXMFLOCAL=`kpsewhich -var-value TEXMFLOCAL`
+TEXMFLOCAL=`kpsewhich -expand-path \$TEXMFLOCAL`
+sep=`kpsewhich -expand-path "{.,.}"`
+if [ -z "$TEXMFLOCAL" ]; then
+    TEXMFLOCAL=`kpsewhich -var-value TEXMFLOCAL`
+fi
+if [ -z "$TEXMFLOCAL" ]; then
+    TEXMFLOCAL=`/usr/texbin/kpsewhich -expand-path $TEXMFLOCAL`
+    sep=`/usr/texbin/kpsewhich -expand-path "{.,.}"`
+fi
 if [ -z "$TEXMFLOCAL" ]; then
     TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
 fi
@@ -14,6 +22,10 @@ TEXHASH=`which texhash`
 if [ -z "$TEXHASH" ]; then
     TEXHASH="/usr/texbin/texhash"
 fi
+
+sep="${sep#.}"
+sep="${sep%.}"
+TEXMFLOCAL="${TEXMFLOCAL%${sep}}"
 
 cp -r /tmp/gregorio/* $TEXMFLOCAL
 rm -rf /tmp/gregorio

--- a/macosx/test.sh
+++ b/macosx/test.sh
@@ -2,12 +2,17 @@
 
 # Test to see if we have a valid TeX installation
 
-TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
-
+TEXMFLOCAL=`kpsewhich -var-value TEXMFLOCAL`
 if [ -n "$TEXMFLOCAL" ]; then
     echo "Passed"
     exit 0
 else
-    echo "Failed"
-    exit 1
+    TEXMFLOCAL=`/usr/texbin/kpsewhich -var-value TEXMFLOCAL`
+    if [ -n "$TEXMFLOCAL" ]; then
+        echo "Passed"
+        exit 0
+    else
+        echo "Failed"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
The scripts now look in both the limited path available to the Installer and the default location for a TeXLive installation.
I also added some details to the error message so that the user who gets it has some more information to go on.