### PR TITLE
Improving the handling of the first syllable.

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -701,7 +701,8 @@ int gregorio_go_to_end_initial(gregorio_character **param_character)
 void
 gregorio_rebuild_characters(gregorio_character **param_character,
                             char center_is_determined,
-                            gregorio_lyric_centering centering_scheme)
+                            gregorio_lyric_centering centering_scheme,
+                            bool skip_initial)
 {
     // a det_style, to walk through the list
     det_style *current_style = NULL;
@@ -727,8 +728,12 @@ gregorio_rebuild_characters(gregorio_character **param_character,
             (*param_character) = current_character;
             return;
         }
-        // move to the character after the initial
-        current_character = current_character->next_character;
+        if (skip_initial) {
+            // move to the character after the initial
+            current_character = current_character->next_character;
+        } else {
+            gregorio_go_to_first_character(&current_character);
+        }
     }
     // first we see if there is already a center determined
     if (center_is_determined == 0) {

--- a/src/characters.c
+++ b/src/characters.c
@@ -939,8 +939,10 @@ gregorio_rebuild_characters(gregorio_character **param_character,
     // begin the center before the first character (you can notice that there
     // is no problem of style).
     if (!center_is_determined) {
-        if (gregorio_go_to_end_initial(&current_character)) {
+        if (skip_initial && gregorio_go_to_end_initial(&current_character)) {
             current_character = current_character->next_character;
+        } else {
+            gregorio_go_to_first_character(&current_character);
         }
         gregorio_insert_style_before(ST_T_BEGIN, ST_CENTER, current_character);
     }

--- a/src/characters.h
+++ b/src/characters.h
@@ -20,6 +20,7 @@
 #ifndef CHARACTERS_H
 #define CHARACTERS_H
 
+#include <stdbool.h>
 #include "struct.h"
 
 /*
@@ -89,7 +90,8 @@ void gregorio_insert_char_after(grewchar c,
 
 void gregorio_rebuild_characters(gregorio_character **param_character,
                                  char center_is_determined,
-                                 gregorio_lyric_centering centering_scheme);
+                                 gregorio_lyric_centering centering_scheme,
+                                 bool skip_initial);
 
 void gregorio_rebuild_first_syllable(gregorio_character **param_character);
 

--- a/src/characters.h
+++ b/src/characters.h
@@ -93,6 +93,7 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
                                  gregorio_lyric_centering centering_scheme,
                                  bool skip_initial);
 
-void gregorio_rebuild_first_syllable(gregorio_character **param_character);
+void gregorio_rebuild_first_syllable(gregorio_character **param_character,
+                                     bool separate_initial);
 
 #endif

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -27,6 +27,7 @@
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"
@@ -482,18 +483,18 @@ void rebuild_characters(gregorio_character **param_character,
                         char center_is_determined,
                         gregorio_lyric_centering centering_scheme)
 {
+    bool has_initial = score->initial_style != NO_INITIAL;
     // we rebuild the first syllable text if it is the first syllable, or if
     // it is the second when the first has no text.
     // it is a patch for cases like (c4) Al(ab)le(ab)
-    if ((!score->first_syllable && score->initial_style != NO_INITIAL
-         && current_character)
+    if ((!score->first_syllable && has_initial && current_character)
         || (current_syllable && !current_syllable->previous_syllable
             && !current_syllable->text && current_character)) {
         gregorio_rebuild_first_syllable(&current_character);
     }
 
     gregorio_rebuild_characters(param_character, center_is_determined,
-                                centering_scheme);
+                                centering_scheme, has_initial);
 }
 
 /*

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -490,7 +490,7 @@ void rebuild_characters(gregorio_character **param_character,
     if ((!score->first_syllable && has_initial && current_character)
         || (current_syllable && !current_syllable->previous_syllable
             && !current_syllable->text && current_character)) {
-        gregorio_rebuild_first_syllable(&current_character);
+        gregorio_rebuild_first_syllable(&current_character, has_initial);
     }
 
     gregorio_rebuild_characters(param_character, center_is_determined,


### PR DESCRIPTION
This adds a warning when the initial is styled, addressing #247.

In attempting to add the warning, I found some issues with centering of the first syllable.  These are also fixed in this pull request.

These changes pass all the current tests, which obviously don't yet include tests that evoke the centering problem.  I will add these within the next few days.