### PR TITLE
Fix to Windows installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Changed
 - The glyphs in the fonts have been moved to the Universal Character Set Private Use Area to future-proof the fonts.  This means dropping support for TeX Live older than 2013 and LuaTeX older than 0.76.  Please upgrade to at least TeX Live 2013 to use Gregorio.
+- Clarified post installation options for Windows installer.  What was the "Install Fonts" option is now labeled to indicate that this also adds GregorioTeX files to the texmf tree.
+
+### Fixed
+- Windows post install script wasn't adding files to texmf tree.  Bug introduced by 3.0.0-rc1.
 
 ## [3.0.0-rc1] - 2015-04-06
 ### Changed

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -49,7 +49,7 @@ Source: "../examples/main-lualatex.tex"; DestDir: "{app}\examples";
 Source: "../gregoriotex.tds.zip"; DestDir: "{app}";
 
 [Run]
-Filename: "texlua.exe"; Parameters: """{app}\install.lua"" > ""{app}\install.log"""; StatusMsg: "Installing Fonts..."; Description: "Font installation"; Flags: postinstall ; WorkingDir: "{app}";
+Filename: "texlua.exe"; Parameters: """{app}\install.lua"" > ""{app}\install.log"""; StatusMsg: "Configuring texmf..."; Description: "Add files to texmf tree"; Flags: postinstall ; WorkingDir: "{app}";
 
 [Code]
 procedure URLLabelOnClickOne(Sender: TObject);
@@ -63,7 +63,7 @@ procedure URLLabelOnClickTwo(Sender: TObject);
 var
   ErrorCode: Integer;
 begin
-  ShellExec('open', 'http://home.gna.org/gregorio/installation-windows', '', '', SW_SHOWNORMAL, ewNoWait, ErrorCode);
+  ShellExec('open', 'http://gregorio-project.github.io/installation-windows.html', '', '', SW_SHOWNORMAL, ewNoWait, ErrorCode);
 end;
 
 procedure CreateTheWizardPages;
@@ -121,7 +121,7 @@ begin
   
   StaticText := TNewStaticText.Create(Page);
   StaticText.Top := ScaleY(165);;
-  StaticText.Caption := 'http://home.gna.org/gregorio/installation-windows';
+  StaticText.Caption := 'http://gregorio-project.github.io/installation-windows.html';
   StaticText.Cursor := crHand;
   StaticText.OnClick := @URLLabelOnClickTwo;
   StaticText.Parent := Page.Surface;

--- a/windows/install.lua
+++ b/windows/install.lua
@@ -51,6 +51,7 @@ if os.type == "windows" or os.type == "msdos" then
   end
 end
 
+local texmflocal = fixpath(kpse.expand_var("$TEXMFLOCAL"))..pathsep
 local suffix = "gregoriotex"..pathsep
 
 function io.loaddata(filename,textmode)
@@ -84,24 +85,17 @@ function copy_files()
   if not lfs.isdir(texmflocal) then
     lfs.mkdir(texmflocal)
   end
-  print("copying files...\n")
+  print("Copying files...\n")
   local texmfbin = kpse.expand_var("$TEXMFDIST")
   texmfbin = fixpath(texmfbin.."/../bin/win32/")
+  print("gregorio.exe...")
   copy_one_file("gregorio.exe", texmfbin)
   print("unzipping TDS zip file...\n")
   os.spawn("unzip.exe -o gregoriotex.tds.zip -d "..texmflocal:gsub("\\", "/")) -- TeXLive provides unzip!
-  copy_one_file(fixpath('examples/main-lualatex.tex'), dirs.templatemain)
-  copy_one_file(fixpath('examples/PopulusSion.gabc'), dirs.templatescore)
-end
-
-function create_dirs()
-  for _, d in pairs(dirs) do
-    lfs.mkdir(d)
-  end
 end
 
 function run_texcommands()
-  print("running mktexlsr\n")
+  print("Running mktexlsr\n")
   local p = os.spawn("mktexlsr "..texmflocal)
 end
 
@@ -153,11 +147,13 @@ end
 -- gregorio used to be installed in other directories which have precedence
 -- over the new ones
 function remove_possible_old_install()
-  print("Removing possible old GregorioTeX files...\n")
+  print("Looking for old GregorioTeX files...\n")
   local old_install_was_present = false
   for _, d in pairs(old_base_dirs) do
+    print("Looking for "..d.."...")
     if lfs.isdir(d) then
       old_install_was_present = true
+      print("Found "..d..", removing...")
       rmdirrecursive(d)
     end
   end
@@ -168,9 +164,11 @@ end
 
 function main_install()
   remove_possible_old_install()
-  create_dirs()
   copy_files()
   run_texcommands()
+  print("Post-install script complete.")
+  print("Press return to continue...")
+  answer=io.read()
 end
 
 function scribus_config()


### PR DESCRIPTION
Windows installer post installation script was failing.  The changes to remove the TeXworks configuration removed a few lines that were still needed and left a few that were no longer needed.  The result was the script attempting to use variables that weren't declared.
Also added some additional dialog to the post install script to make it easier to tell what is going on.
Clarified the post install option to indicate that it doesn't just install the fonts, it puts all the necessary files into the texmf tree.
Note: The entries I added to the change log are for the purposes of rc2 only.  Since they fix bugs introduced by rc1, they shouldn't appear in the change log for the final release.