### PR TITLE
Bars with something under them were appearing too close to previous element

### DIFF
--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1530,6 +1530,7 @@
       \grehskip\gre@skip@temp@four %
     \fi %
   \fi %
+  \gre@debug{Width of bar just printed: \the\wd\GreTempwidth}%
   \global\gre@dimen@lastglyphwidth=\wd\GreTempwidth %
   \relax%
 }%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -245,6 +245,7 @@
 \newbox\GreSyllablenotes%
 \def\gresyllablenotes#1{%
   \setbox\GreSyllablenotes=\hbox{#1}%
+  \gre@debug{Width of notes: \the\wd\GreSyllablenotes}%
   \relax%
 }%
 
@@ -648,42 +649,50 @@
 %a macro to typeset a syllable with only a bar inside
 \def\grebarsyllable#1#2#3#4#5#6#7#8#9{%
   % the algorithm of this function is *extremely* complex, and has been much painful to write... good luck to understand.
-  % the main goal is, when there is no text under the bar, to put the bar in the middle of the space between the last note of the prefious syllable and the first note of the next syllable. But there are limits : a bar cant go very far above text. For example if there is nuncncncncn with a punctum on the u, the bar can't go above the fourth n, the most far position is the position where the end of the bar is above the end of the word. The same limitation applies for the syllable after the bar.
+  % the main goal is, when there is no text under the bar, to put the bar in the middle of the space between the last note of the previous syllable and the first note of the next syllable. But there are limits : a bar can't go very far above text. For example if there is "nuncncncncn" with a punctum on the u, the bar can't go above the fourth n, the most far position is the position where the end of the bar is above the end of the word. The same limitation applies for the syllable after the bar.
   % there are two different cases that have almost nothing in common : the case where there is something written under the bar, and the case where there is nothing.
   % first of all we need to calculate previousenddifference, begindifference, enddifference and nextbegindifference.
-  \gre@calculate@textaligncenter{#1}{#2}{0}%
-  \setbox\GreSyllabletext=\hbox{\grefixedtextformat{#1#2#3}}%
+  \ifnum\gre@englishcentering=1\relax %
+    \gdef\gre@firstsyllablepart{}%
+    \gdef\gre@middlesyllablepart{#1#2#3}%
+    \gdef\gre@endsyllablepart{}%
+  \else %
+    \gdef\gre@firstsyllablepart{#1}%
+    \gdef\gre@middlesyllablepart{#2}%
+    \gdef\gre@endsyllablepart{#3}%
+  \fi %
+  \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}%
+  \setbox\GreSyllabletext=\hbox{\grefixedtextformat{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart}}%
+  \gre@debug{Width of bar text: \the\wd\GreSyllabletext}%
   % we need to save lastoflinecount, because otherwise when a \newline appears inside a syllable, it is counted two times (once here and once later when #9 will be really output), so \grelastoflinecount has a wrong value. Thus
   \xdef\gresavedlastoflinecount{\number\grelastoflinecount\relax}%
   % a counter to know we are not really typesetting things (useful for end of lines)
   \xdef\greboxing{1}%
-  \gresyllablenotes{#9}%
+  \gresyllablenotes{#9}% For some reason, the width of this box is not the width of the bar lines.  However, we keep the command because it effects a call to \grewritebar which stores the width of the bar lines in lastglyphwidth as part of its function.  We'll use that in the remainder of this macro.
+  \gre@debug{Width of bar line: \the\gre@dimen@lastglyphwidth}%
   \xdef\greboxing{0}%
   \grefirstglyph=1\relax %
   \global\grelastoflinecount=\gresavedlastoflinecount\relax %
-  \gre@dimen@notesaligncenter=\wd\GreSyllablenotes%
+  \gre@dimen@notesaligncenter=\gre@dimen@lastglyphwidth%
   \divide\gre@dimen@notesaligncenter by 2\relax %
   \gre@dimen@begindifference=\gre@dimen@notesaligncenter %
   \advance\gre@dimen@begindifference by -\gre@dimen@textaligncenter %
-  \gre@calculate@enddifference{\wd\GreSyllablenotes}{\wd\GreSyllabletext}{\gre@dimen@textaligncenter}{\gre@dimen@notesaligncenter}{1}%
+  \gre@calculate@enddifference{\gre@dimen@lastglyphwidth}{\wd\GreSyllabletext}{\gre@dimen@textaligncenter}{\gre@dimen@notesaligncenter}{1}%
   #5%
   \gre@calculate@nextbegindifference{\gre@nextfirstsyllablepart}{\gre@nextmiddlesyllablepart}{\gre@nextendsyllablepart}{#7}%
   \greunsetfixednexttextformat %
-  % for LuaTeX syllable counting in optimize_gabc, we put an empty syllable box with gregorioattr set to 2. With this we can count every syllable.
-  \gregorioattr=2\relax %
-  \hbox to 0pt{}%
   \gregorioattr=0\relax %
   % then we check if there is something to write
   \gre@debug{ifdim wd(GreSyllabletext) = 0pt}%
   \ifdim\wd\GreSyllabletext = 0 pt\relax %
     % the most difficult case : when there is nothing to write
     % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces : 
-    %% 1/ the minimal space between a note and the bar + the width of the bar + the minimal space between the bar and the note (that's the global idea, in fact there are nuances) : we assign skipone to it
-    %% 2/ enddifference + begindifference + space between notes and word : we assign temp to it
+    %% 1/ the minimal space between a note and the bar + the width of the bar + the minimal space between the bar and the note (that's the global idea, in fact there are nuances) : we assign skip@temp@three to it
+    %% 2/ enddifference + begindifference + space between notes and word : we assign skip@temp@two to it
     \gre@skip@temp@three=\gre@skip@notebarspace %
     \advance\gre@skip@temp@three by \gre@skip@notebarspace %
-    \advance\gre@skip@temp@three by \wd\GreSyllablenotes %
-    % now let's get temp
+    \advance\gre@skip@temp@three by \gre@dimen@lastglyphwidth %
+    % now let's get skip@temp@two
     \gre@debug{ifdim nextbegindifference < 0pt}%
     \ifdim\gre@skip@nextbegindifference < 0 pt%
       \gre@skip@temp@two=-\gre@skip@nextbegindifference %
@@ -703,7 +712,7 @@
       \gre@skip@temp@three=\gre@skip@temp@two %
     \fi %
     \divide\gre@skip@temp@three by 2\relax %
-    \gre@dimen@temp@five=\wd\GreSyllablenotes %
+    \gre@dimen@temp@five=\gre@dimen@lastglyphwidth %
     \divide\gre@dimen@temp@five by 2\relax %
     \advance\gre@skip@temp@three by -\gre@dimen@temp@five %
     % now we have our skipone
@@ -713,11 +722,11 @@
       \advance\gre@skip@temp@two by \gre@dimen@previousenddifference %
     \fi %
     \grenobreak %
-    \gre@debug{ifdim temp@skip@two > -wd(GreSyllablenotes)}%
-    \ifdim\gre@skip@temp@two > -\wd\GreSyllablenotes %
+    \gre@debug{ifdim temp@skip@two > -dimen@lastglyphwidth}%
+    \ifdim\gre@skip@temp@two > -\gre@dimen@lastglyphwidth %
       \kern\gre@skip@temp@two %
     \else %
-      \gre@skip@temp@one = -\wd\GreSyllablenotes %
+      \gre@skip@temp@one = -\gre@dimen@lastglyphwidth %
       \kern\gre@skip@temp@one%
     \fi %
     \grenobreak %
@@ -729,8 +738,8 @@
     \fi %
     #9\relax %
     \grepenalty{\greendafterbaraltpenalty }% TODO: isn't it a bit buggy?
-    \gre@debug{ifdim temp@skip@two < -wd(GreSyllablenotes)}
-    \ifdim\gre@skip@temp@two < -\wd\GreSyllablenotes %
+    \gre@debug{ifdim temp@skip@two < -dimen@lastglyphwidth}
+    \ifdim\gre@skip@temp@two < -\gre@dimen@lastglyphwidth %
       \gre@debug{ifdim nextbegindifference > 0pt}
       \ifdim\gre@skip@nextbegindifference > 0 pt%
         \gre@skip@temp@one = \gre@skip@interwordspacetextnotes%
@@ -740,8 +749,8 @@
         \hskip\gre@skip@temp@one %
       \fi %
     \else 
-      %\ifdim\gre@skip@temp@two < -\wd\GreSyllablenotes
-        %\gre@skip@temp@two=\wd\GreSyllablenotes 
+      %\ifdim\gre@skip@temp@two < -\gre@dimen@lastglyphwidth
+        %\gre@skip@temp@two=\gre@dimen@lastglyphwidth
         %\divide\gre@skip@temp@two by 2\relax 
         %\kern -\gre@skip@temp@two 
       \gre@skip@temp@two=\gre@skip@temp@three %
@@ -749,11 +758,11 @@
       \ifdim\gre@skip@nextbegindifference < 0 pt%
         \advance\gre@skip@temp@two by \gre@skip@nextbegindifference %
       \fi %
-      \gre@debug{ifdim temp@skip@two > -wd(GreSyllablenotes)}%
-      \ifdim\gre@skip@temp@two > -\wd\GreSyllablenotes %
+      \gre@debug{ifdim temp@skip@two > -dimen@lastglyphwidth}%
+      \ifdim\gre@skip@temp@two > -\gre@dimen@lastglyphwidth%
         \kern\gre@skip@temp@two %
-      \else % \ifdim\gre@dimen@temp@five > -\wd\GreSyllablenotes 
-        \gre@skip@temp@one = -\wd\GreSyllablenotes %
+      \else % \ifdim\gre@dimen@temp@five > -\gre@dimen@lastglyphwidth
+        \gre@skip@temp@one = -\gre@dimen@lastglyphwidth%
         \grehskip\gre@skip@temp@one%
       \fi %
     \fi %
@@ -767,7 +776,7 @@
     \ifdim\gre@dimen@temp@five > 0 pt%
       \advance\gre@skip@temp@three by \gre@dimen@temp@five %
     \fi%
-    %\kern\gre@skip@temp@three 
+    \kern\gre@skip@temp@three %
     #8\relax %
     \raise\gre@dimen@textlower \copy\GreSyllabletext %
     \ifnum\gremustdotranslationcenterend=1\relax %
@@ -779,7 +788,8 @@
     \kern\gre@skip@temp@one%
     \gre@skip@temp@one = -\gre@dimen@begindifference%
     \kern\gre@skip@temp@one %
-    #9% we do that instead of \unhbox\Syllablnotes, because it would not set the \localrightbox
+    \fboxsep=0pt%
+    #9%
     \gre@debug{ifdim enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference <0pt%
       %% important, else we are not really at the end of the syllable

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -788,7 +788,6 @@
     \kern\gre@skip@temp@one%
     \gre@skip@temp@one = -\gre@dimen@begindifference%
     \kern\gre@skip@temp@one %
-    \fboxsep=0pt%
     #9%
     \gre@debug{ifdim enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference <0pt%


### PR DESCRIPTION
I found a commented out kern statement which when uncommented increases the spacing in the reported MWE.  However, checking the log, this line has been commented out since its introduction back in 7e2bfa4 (which was in 2008).  As a result, I'm not sure why this bug would not have appeared in earlier versions.  My only guess is that there were some missing `%` at the end of lines which resulted in the addition of uncontrolled whitespace and so while the line was added because theoretically it was needed, it was commented out because visually it resulted in too much whitespace.  As part of my spacing changes, I did a whole bunch of work to make sure that most, if not all, of the lines in the package terminated with a `%`, so that might have caused the problem to show up.  Unfortunately, my progressive testing seems to indicate that this bug shows up about the same time as the glue leaks, making it difficult to tell exactly what was going on at that time because I can't get a clean output.
For no discernable reason, `\GreSyllablenotes` has the wrong width for bar lines.  To get around this I take advantage of the fact that `\grewritebar` sets `lastglyphwidth` as the last step of its process and sets it correctly.  I thus make use of `lastglyphwidth` instead of `\wd\GreSyllablenotes` in `\grebarsyllable`.
Added the new english centering code in `\grebarsyllable`.

### Not ready to merge.

Addresses #238.  The solution for the bad width is somewhat hackish, so I'd like comments and suggestions for making it less so if possible before merging.