### PR TITLE
Upgraded requirements to TeX Live 2014 and LuaTex 0.79.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ## [Unreleased][unreleased]
 ### Changed
-- The glyphs in the fonts have been moved to the Universal Character Set Private Use Area to future-proof the fonts.  This means dropping support for TeX Live older than 2013 and LuaTeX older than 0.76.  Please upgrade to at least TeX Live 2013 to use Gregorio.
+- The glyphs in the fonts have been moved to the Universal Character Set Private Use Area to future-proof the fonts.  This means dropping support for TeX Live older than 2014 and LuaTeX older than 0.79.1.  Please upgrade to at least TeX Live 2014 to use Gregorio.  After installation, try `luaotfload-tool --cache=clear` to clear your font cache if you encounter font issues before reporting a problem.  Each user should not need to do this more than once after installing a new version of Gregorio.
 - Clarified post installation options for Windows installer.  What was the "Install Fonts" option is now labeled to indicate that this also adds GregorioTeX files to the texmf tree.
 
 ### Fixed

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -39,8 +39,8 @@
 \fi%
 
 \ifluatex%
-  \ifnum\luatexversion<76%
-    \greerror{Error: this document must be compiled with LuaTeX (lualatex) 0.76 or later}%
+  \ifnum\luatexversion<79%
+    \greerror{Error: this document must be compiled with LuaTeX (lualatex) 0.79 or later}%
   \fi%
 \else%
   \greerror{Error: this document must be compiled with LuaTeX (lualatex)}%


### PR DESCRIPTION
If we don't roll back the font changes, it looks like we may need to at least require this version. See #266