### PR TITLE
Added an option to force autoreconf and/or fonts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@
 #      --build=    : build system for mingw32 cross-compilation
 #      --arch=     : crosscompile for ARCH on OS X
 #      --jobs=     : the number of jobs to run simultaneously in the make step
-#      --force=    : force autoreconf or font bulding
+#      --force=    : force autoreconf or font building
 #      {other)     : anything else is passed to configure verbatim
       
 # try to find bash, in case the standard shell is not capable of

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@
 #      --build=    : build system for mingw32 cross-compilation
 #      --arch=     : crosscompile for ARCH on OS X
 #      --jobs=     : the number of jobs to run simultaneously in the make step
+#      --force=    : force autoreconf or font bulding
 #      {other)     : anything else is passed to configure verbatim
       
 # try to find bash, in case the standard shell is not capable of
@@ -29,6 +30,8 @@ CONFBUILD=
 MACCROSS=FALSE
 MAKEOPTS=
 OTHERARGS=
+FORCE_AUTORECONF=
+FORCE_FONTS=
 
 CFLAGS="$CFLAGS -Wdeclaration-after-statement"
 
@@ -41,6 +44,8 @@ until [ -z "$1" ]; do
     --build=*   ) CONFBUILD="$1" ;;
     --arch=*    ) MACCROSS=TRUE; ARCH=`echo $1 | sed 's/--arch=\(.*\)/\1/' ` ;;
     -j*|--jobs=*) MAKEOPTS="$MAKEOPTS $1" ;;
+    --force=autoreconf) FORCE_AUTORECONF=TRUE ;;
+    --force=fonts) FORCE_FONTS=TRUE ;;
     *           ) OTHERARGS="$OTHERARGS $1" ;;
   esac
   shift
@@ -113,7 +118,7 @@ function die {
 	exit 1
 }
 
-if [ ! -e Makefile.in ]
+if [ "$FORCE_AUTORECONF" = "TRUE" -o ! -e Makefile.in ]
 then
   echo "Creating build files using Autotools"
   autoreconf -f -i || die "create build files"
@@ -129,7 +134,7 @@ echo "Building Gregorio; options:$MAKEOPTS"
 make ${MAKEOPTS} || die "build Gregorio"
 echo
 
-if [ ! -e fonts/greciliae.ttf ]
+if [ "$FORCE_FONTS" = "TRUE" -o ! -e fonts/greciliae.ttf ]
 then
   echo "Building fonts; options:$MAKEOPTS"
   cd fonts


### PR DESCRIPTION
Add --force=autoreconf and/or --force=fonts to force running of these steps.

At @rpspringuel's request in #262.  I've tested this and will merge it now.  I will merge this into develop as well.