### PR TITLE
Added comment in spaces et al.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Changed
 - The glyphs in the fonts have been moved to the Universal Character Set Private Use Area to future-proof the fonts.  This means dropping support for TeX Live older than 2013 and LuaTeX older than 0.76.  Please upgrade to at least TeX Live 2013 to use Gregorio.
 - Clarified post installation options for Windows installer.  What was the "Install Fonts" option is now labeled to indicate that this also adds GregorioTeX files to the texmf tree.
+- `\grechangedim` now checks to make sure it only operates on existing distances and doesn't create a new one.
 
 ### Fixed
 - Windows post install script wasn't adding files to texmf tree.  Bug introduced by 3.0.0-rc1.

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -671,6 +671,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% This macro sets one dim (#1) to the value #2 and sets whether it should scale when the \grefactor changes (#3, 1 if yes, 0 if no).  While it does check that #1 can accept the kind of distance given in #2, it does not propagate the changes through the calculated distances.
+%% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
 \newif\ifchecklength%
 \def\gresetdim#1#2#3{%
   \checklengthfalse%
@@ -694,10 +695,23 @@
   \relax %
 }%
 
-% a macro for changing a dimension and making sure that the change cascades through.
-% TODO: make smarter so that it knows the dependency tree and only recalculates distances affected by the change
+% a macro for changing a dimension.  Unlike \gresetdim, this function won’t create a new distance, just change an existing one.
 \def\grechangedim#1#2#3{%
-  \gresetdim{#1}{#2}{#3}%
+  \gre@rubberpermit{#1}%
+  % figure out our prefix
+  \ifrubber%
+    \gre@debug{Changing a skip.}
+    \def\gre@prefix{skip}%
+  \else%
+    \gre@debug{Changing a dimen.}
+    \def\gre@prefix{dimen}%
+  \fi
+  \ifcsname gre@\gre@prefix @#1\endcsname%
+    \gre@debug{It does exist.}
+    \gresetdim{#1}{#2}{#3}%
+  \else
+    \greerror{#1 is not a recognized distance.}
+  \fi
 }%
 
 %a macro to use if all you want to do is turn off the scaling for a particular distance


### PR DESCRIPTION
Added a comment in the source code indicating that `\gresetdim` stores distances as strings and indicating why.
Added functionality to `\grechangedim` so that it checks to make sure the distance exists before changing it.  Previously it would have happily created a new distance if passed an unexpected name.  This should make it easier to catch typos when manipulating distances.

Addresses suggestion made by @henryso in #258.