### PR TITLE
Respecting standard autotools targets in doc/

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,7 +6,7 @@ GregorioRef-$(FILENAME_VERSION).pdf: $(SRCFILES)
 doc: GregorioRef-$(FILENAME_VERSION).pdf
 
 distclean-local:
-	latexmk -quiet -c -jobname=GregorioRef-$(FILENAME_VERSION) GregorioRef.tex
+	latexmk -quiet -c -f -jobname=GregorioRef-$(FILENAME_VERSION) GregorioRef.tex
 	rm -rf _minted*
 
 EXTRA_DIST = $(SRCFILES) GregorioRef-$(FILENAME_VERSION).pdf

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -5,8 +5,9 @@ GregorioRef-$(FILENAME_VERSION).pdf: $(SRCFILES)
 
 doc: GregorioRef-$(FILENAME_VERSION).pdf
 
-clean:
-	latexmk -quiet -C -jobname=GregorioRef-$(FILENAME_VERSION) GregorioRef.tex
+distclean-local:
+	latexmk -quiet -c -jobname=GregorioRef-$(FILENAME_VERSION) GregorioRef.tex
 	rm -rf _minted*
 
 EXTRA_DIST = $(SRCFILES) GregorioRef-$(FILENAME_VERSION).pdf
+MAINTAINERCLEANFILES = GregorioRef-$(FILENAME_VERSION).pdf


### PR DESCRIPTION
 * clean does nothing because you're not supposed to build the doc from
   the tarball
 * distclean cleans everything but the final PDF
 * maintainer-clean cleans everything including the PDF
 * fixes #237 