### PR TITLE
Corrected to use "torculus liquescens" only if the last note is actually liquescent. Fixes #284.

### DIFF
--- a/plugins/gabc/gabc-glyphs-determination.c
+++ b/plugins/gabc/gabc-glyphs-determination.c
@@ -743,10 +743,15 @@ gregorio_add_note_to_a_glyph (char current_glyph_type, char current_pitch,
             {
               next_glyph_type = G_TORCULUS_RESUPINUS;
             }
-          else
+          else if (liquescentia == L_DEMINUTUS)
             {
               *end_of_glyph = DET_END_OF_CURRENT;
               next_glyph_type = G_TORCULUS_LIQUESCENS;
+            }
+          else
+            {
+              *end_of_glyph = DET_END_OF_PREVIOUS;
+              next_glyph_type = G_PUNCTUM;
             }
           break;
         case G_TORCULUS_RESUPINUS:


### PR DESCRIPTION
This is the pull request for `release-3.0`.