### PR TITLE
Upgrading functionality of debug

### DIFF
--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1480,7 +1480,7 @@
       \grehskip\gre@skip@temp@four %
     \fi %
   \fi %
-  \gre@debug{Width of bar just printed: \the\wd\GreTempwidth}%
+  \gre@debugmsg{Width of bar just printed: \the\wd\GreTempwidth}%
   \global\gre@dimen@lastglyphwidth=\wd\GreTempwidth %
   \relax%
 }%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1480,7 +1480,7 @@
       \grehskip\gre@skip@temp@four %
     \fi %
   \fi %
-  \gre@debugmsg{Width of bar just printed: \the\wd\GreTempwidth}%
+  \gre@debugmsg{spacing}{Width of bar just printed: \the\wd\GreTempwidth}%
   \global\gre@dimen@lastglyphwidth=\wd\GreTempwidth %
   \relax%
 }%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -702,14 +702,14 @@
   \gre@rubberpermit{#1}%
   % figure out our prefix
   \ifrubber%
-    \gre@debugmsg{Changing a skip.}
+    \gre@debugmsg{spacing}{Changing a skip.}
     \def\gre@prefix{skip}%
   \else%
-    \gre@debugmsg{Changing a dimen.}
+    \gre@debugmsg{spacing}{Changing a dimen.}
     \def\gre@prefix{dimen}%
   \fi
   \ifcsname gre@\gre@prefix @#1\endcsname%
-    \gre@debugmsg{It does exist.}
+    \gre@debugmsg{spacing}{It does exist.}
     \gresetdim{#1}{#2}{#3}%
   \else
     \greerror{#1 is not a recognized distance.}
@@ -811,8 +811,8 @@
 \newcount\gre@unitfactor%
 \newcount\gre@basefactor%
 \def\gre@convertto#1#2{%
-  \gre@debugmsg{convertto (#1) (#2)}
-  \gre@debugmsg[ifdim]{ #2 = 0pt}
+  \gre@debugmsg{general}{convertto (#1) (#2)}
+  \gre@debugmsg{ifdim}{ #2 = 0pt}
   \ifdim#2=0pt\relax%
     \edef\gre@converted{0 #1}%
   \else%
@@ -825,13 +825,13 @@
     \ifnum\gre@unitfactor < 0\relax%
       \gre@unitfactor = -\gre@unitfactor%
     \fi%
-    \gre@debugmsg{unit: \the\gre@unit ; factor: \the\gre@unitfactor}
+    \gre@debugmsg{spacing}{unit: \the\gre@unit ; factor: \the\gre@unitfactor}
     \gre@basefactor = \number\gre@maxlen%
     \divide\gre@basefactor by \number\gre@base\relax%
     \ifnum\gre@basefactor < 0\relax%
       \gre@basefactor = -\gre@basefactor%
     \fi%
-    \gre@debugmsg{base: \the\gre@base ; factor: \the\gre@basefactor}
+    \gre@debugmsg{spacing}{base: \the\gre@base ; factor: \the\gre@basefactor}
     \ifnum\gre@basefactor<\gre@unitfactor%
       \multiply\gre@unit by \gre@basefactor%
       \multiply\gre@base by \gre@basefactor%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -702,14 +702,14 @@
   \gre@rubberpermit{#1}%
   % figure out our prefix
   \ifrubber%
-    \gre@debug{Changing a skip.}
+    \gre@debugmsg{Changing a skip.}
     \def\gre@prefix{skip}%
   \else%
-    \gre@debug{Changing a dimen.}
+    \gre@debugmsg{Changing a dimen.}
     \def\gre@prefix{dimen}%
   \fi
   \ifcsname gre@\gre@prefix @#1\endcsname%
-    \gre@debug{It does exist.}
+    \gre@debugmsg{It does exist.}
     \gresetdim{#1}{#2}{#3}%
   \else
     \greerror{#1 is not a recognized distance.}
@@ -811,8 +811,8 @@
 \newcount\gre@unitfactor%
 \newcount\gre@basefactor%
 \def\gre@convertto#1#2{%
-  \gre@debug{convertto (#1) (#2)}
-  \gre@debug{ifdim #2 = 0pt}
+  \gre@debugmsg{convertto (#1) (#2)}
+  \gre@debugmsg[ifdim]{ #2 = 0pt}
   \ifdim#2=0pt\relax%
     \edef\gre@converted{0 #1}%
   \else%
@@ -825,13 +825,13 @@
     \ifnum\gre@unitfactor < 0\relax%
       \gre@unitfactor = -\gre@unitfactor%
     \fi%
-    \gre@debug{unit: \the\gre@unit ; factor: \the\gre@unitfactor}
+    \gre@debugmsg{unit: \the\gre@unit ; factor: \the\gre@unitfactor}
     \gre@basefactor = \number\gre@maxlen%
     \divide\gre@basefactor by \number\gre@base\relax%
     \ifnum\gre@basefactor < 0\relax%
       \gre@basefactor = -\gre@basefactor%
     \fi%
-    \gre@debug{base: \the\gre@base ; factor: \the\gre@basefactor}
+    \gre@debugmsg{base: \the\gre@base ; factor: \the\gre@basefactor}
     \ifnum\gre@basefactor<\gre@unitfactor%
       \multiply\gre@unit by \gre@basefactor%
       \multiply\gre@base by \gre@basefactor%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -181,20 +181,20 @@
     \fi%
     \grewidthof{#1}%
     \divide\gre@dimen@temp@three by 2\relax %
-    \gre@debugmsg[ifdim]{ tempwidth > textaligncenter}%
+    \gre@debugmsg{ifdim}{ tempwidth > textaligncenter}%
     \ifdim\gre@dimen@temp@three >\gre@dimen@textaligncenter %
       \global\setbox\GreTempwidth=\hbox{#2}%
     \else%
       \ifcase\gre@englishcentering%
         \grewidthof{\mygre@endsyllablepart}%
-        \gre@debugmsg[ifdim]{ tempwidth > clivisalignmentmin}%
+        \gre@debugmsg{ifdim}{ tempwidth > clivisalignmentmin}%
         \ifdim\gre@dimen@temp@three >\gre@dimen@clivisalignmentmin %
           \global\setbox\GreTempwidth=\hbox{#2}%
         \else%
           \global\setbox\GreTempwidth=\hbox{#1}%
         \fi%
       \or%
-        \gre@debugmsg[ifdim]{ textaligncenter > clivisalignmentmin}%
+        \gre@debugmsg{ifdim}{ textaligncenter > clivisalignmentmin}%
         \ifdim\gre@dimen@textaligncenter >\gre@dimen@clivisalignmentmin %
           \global\setbox\GreTempwidth=\hbox{#2}%
         \else%
@@ -263,7 +263,7 @@
   \xdef\greboxing{1}%
   \xdef\gresavedlastoflinecount{\number\grelastoflinecount\relax }%
   \setbox\GreSyllablenotes=\hbox{#1}%
-  \gre@debugmsg{Width of notes: \the\wd\GreSyllablenotes}%
+  \gre@debugmsg{spacing}{Width of notes: \the\wd\GreSyllablenotes}%
   \xdef\grelastispunctum{\grelastispunctumsauv}%
   \xdef\greboxing{0}%
   \global\grelastoflinecount=\gresavedlastoflinecount\relax %
@@ -432,7 +432,7 @@
 %% with a special option for #7 : if it is a bar, we don't put a space at the end
 %% at the end we wall \greendofword or \greendofsyllable with #7, to reduce the space in case of a flat or natural
 \def\gresyllable#1#2#3#4#5#6#7#8#9{%
-  \gre@debugmsg{New syllable}%
+  \gre@debugmsg{general}{New syllable}%
   \ifnum\gre@englishcentering=1\relax %
     \gdef\gre@firstsyllablepart{}%
     \gdef\gre@middlesyllablepart{#1#2#3}%
@@ -456,25 +456,25 @@
       \advance\gre@skip@temp@one by \gre@dimen@begindifference %
       % a little trick... we don't want to kern more than clefwidth minus minimalspaceatlinebeginning
       \advance\gre@dimen@clefwidth by -\gre@dimen@minimalspaceatlinebeginning %
-      \gre@debugmsg[ifdim]{ temp@skip@one < -clefwidth}%
+      \gre@debugmsg{ifdim}{ temp@skip@one < -clefwidth}%
       \ifdim\gre@skip@temp@one <-\gre@dimen@clefwidth %
         \gre@skip@temp@one=-\gre@dimen@clefwidth %
       \fi %
       \advance\gre@dimen@clefwidth by \gre@dimen@minimalspaceatlinebeginning %
       \hbox{}%
       \advance\gre@skip@temp@one by -\gre@skip@spaceafterlineclef %
-      \gre@debugmsg[ifdim]{ gre@skip@temp@one < gre@begindifference}%
+      \gre@debugmsg{ifdim}{ gre@skip@temp@one < gre@begindifference}%
       \ifdim\gre@skip@temp@one < \gre@dimen@begindifference %
         \gre@skip@temp@one=\the\gre@dimen@begindifference %
       \fi %
       % Don't allow kern past the beginning of the first line with no initial
-      \gre@debugmsg[ifdim]{ initialwidth < 0pt}%
+      \gre@debugmsg{ifdim}{ initialwidth < 0pt}%
       \ifdim\gre@dimen@initialwidth = 0pt %
         \ifnum\greknownline=1 %
           \advance\gre@skip@temp@one by \gre@dimen@clefwidth %
         \fi %
       \fi %
-      \gre@debugmsg[ifdim]{ temp@skip@one < 0pt}%
+      \gre@debugmsg{ifdim}{ temp@skip@one < 0pt}%
       \ifdim\gre@skip@temp@one < 0pt%
         \kern\gre@skip@temp@one %
       \fi %
@@ -488,7 +488,7 @@
     \ifnum\grefirstsyllableofword=0 %
       \gre@skip@temp@one=\gre@skip@intersyllablespace %
       \advance\gre@skip@temp@one by \gre@dimen@begindifference %
-      \gre@debugmsg[ifdim]{ enddifference < 0pt}%
+      \gre@debugmsg{ifdim}{ enddifference < 0pt}%
       \ifdim\gre@dimen@enddifference<0pt%
         \advance\gre@skip@temp@one by \gre@dimen@enddifference %
       \fi % \ifdim\gre@dimen@enddifference>0pt
@@ -496,7 +496,7 @@
         \advance\gre@skip@temp@one by \gre@skip@beforealterationspace %
         \global\grefirstisalteration=0\relax %
       \fi % \ifnum\grefirstisalteration=1
-      \gre@debugmsg[ifdim]{ temp@skip@one > 0pt}%
+      \gre@debugmsg{ifdim}{ temp@skip@one > 0pt}%
       \ifdim\gre@skip@temp@one>0pt %
         \hskip\gre@skip@temp@one %
       \fi %
@@ -514,28 +514,28 @@
     % we set gretempdim to the actual space between the text of the two syllables. The algorithm is quite complex, but quite similar to the one computing the space between the two syllables several lines above.
     \gre@skip@temp@one=\gre@skip@intersyllablespace %
     \advance\gre@skip@temp@one by \gre@skip@nextbegindifference %
-    \gre@debugmsg[ifdim]{ enddifference < 0pt}%
+    \gre@debugmsg{ifdim}{ enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference<0pt%
       \advance\gre@skip@temp@one by \gre@dimen@enddifference %
     \fi % \ifdim\gre@dimen@enddifference>0pt
     % there is a small """feature""" here: if the first glyph is an alteration, the algorithm will be quite pessimistic
     % about the space, so an hyphen may be added when it's not really necessary.
-    \gre@debugmsg[ifdim]{ temp@skip@one < 0pt}%
+    \gre@debugmsg{ifdim}{ temp@skip@one < 0pt}%
     \ifdim\gre@skip@temp@one<0pt%
       \gre@skip@temp@one=0pt%
     \fi %
-    \gre@debugmsg[ifdim]{ enddifference > 0pt}%
+    \gre@debugmsg{ifdim}{ enddifference > 0pt}%
     \ifdim\gre@dimen@enddifference >0pt%
       \advance\gre@skip@temp@one by \gre@dimen@enddifference %
     \fi %
-    \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
+    \gre@debugmsg{ifdim}{ nextbegindifference > 0pt}%
     \ifdim\gre@skip@nextbegindifference >0pt%
       \advance\gre@skip@temp@one by \gre@skip@nextbegindifference %
     \fi %
     %
     % then we compare it with \gre@dimen@maximumspacewithoutdash, if it is larger, we add a dash
     %
-    \gre@debugmsg[ifdim]{ temp@skip@one > maximumspacewithoutdash}%
+    \gre@debugmsg{ifdim}{ temp@skip@one > maximumspacewithoutdash}%
     \ifdim\gre@skip@temp@one>\gre@dimen@maximumspacewithoutdash %
       % if it's the last syllable of line, the hyphen will be \grehyph
       \ifnum\grelastoflinecount=1\relax %
@@ -551,7 +551,7 @@
     \fi%
   \fi% ficase#4
   % then we reuse temp, we assign to it the \gre@dimen@begindifference, but only if it is positive, else it is 0
-  \gre@debugmsg[ifdim]{ begindifference > 0pt}%
+  \gre@debugmsg{ifdim}{ begindifference > 0pt}%
   \ifdim\gre@dimen@begindifference > 0 pt%
     \gre@skip@temp@one = \gre@dimen@begindifference%
     \kern\gre@skip@temp@one %
@@ -572,7 +572,7 @@
   % trick: we want to kern -enddifference if necessary before any change of line, which we can achieve only with this trick if the end of line is the last thing of the notes (it's the case of \grelastoflinecount is 1).
   % For the kern in this case, the base is to kern -\gre@dimen@enddifference if it's negative, but we can kern a bit more for the text to get a bit more to the right, but not after the end of the scores minus \gre@dimen@minimalspaceatlinebeginning
   \ifnum\grelastoflinecount=1\relax %
-    \gre@debugmsg[ifdim]{ enddifference < 0pt}%
+    \gre@debugmsg{ifdim}{ enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference <0pt%
       \gre@skip@temp@one=-\gre@dimen@enddifference %
       % we don't do it if it's the last syllable of a score or if the user disabled it
@@ -585,7 +585,7 @@
         \fi %
         \advance\gre@skip@temp@one by \gre@dimen@minimalspaceatlinebeginning %
       \fi %
-      \gre@debugmsg[ifdim]{ temp@skip@one < -enddifference}%
+      \gre@debugmsg{ifdim}{ temp@skip@one < -enddifference}%
       \ifdim\gre@skip@temp@one <-\gre@dimen@enddifference %
         \gre@skip@temp@one=-\the\gre@dimen@enddifference %
       \fi %
@@ -594,7 +594,7 @@
   \fi%
   \grenobreak % no line breaks between text and notes
   #9% we do that instead of \unhbox\Syllablnotes, because it would not set the \localrightbox
-  \gre@debugmsg[ifdim]{ enddifference < 0pt}%
+  \gre@debugmsg{ifdim}{ enddifference < 0pt}%
   \ifdim\gre@dimen@enddifference <0pt%
     %% important, else we are not really at the end of the syllable
     \grenobreak %
@@ -618,7 +618,7 @@
         % otherwise we call it with 1 only if there is no letters after (we can see it with nextbegindifference)
         \setbox\GreTempwidth=\hbox{\gre@nextfirstsyllablepart\gre@nextmiddlesyllablepart\gre@nextendsyllablepart }%
         % /!\ warning: can be buggy...
-        \gre@debugmsg[ifdim]{ wd(GreTempwidth) = 0pt}%
+        \gre@debugmsg{ifdim}{ wd(GreTempwidth) = 0pt}%
         \ifdim\wd\GreTempwidth=0pt%
           \greendbeforebar{0}%
         \else %
@@ -664,7 +664,7 @@
 
 %a macro to typeset a syllable with only a bar inside
 \def\grebarsyllable#1#2#3#4#5#6#7#8#9{%
-  \gre@debugmsg{New bar syllable}%
+  \gre@debugmsg{general}{New bar syllable}%
   % the algorithm of this function is *extremely* complex, and has been much painful to write... good luck to understand.
   % the main goal is, when there is no text under the bar, to put the bar in the middle of the space between the last note of the previous syllable and the first note of the next syllable. But there are limits : a bar can't go very far above text. For example if there is "nuncncncncn" with a punctum on the u, the bar can't go above the fourth n, the most far position is the position where the end of the bar is above the end of the word. The same limitation applies for the syllable after the bar.
   % there are two different cases that have almost nothing in common : the case where there is something written under the bar, and the case where there is nothing.
@@ -680,9 +680,9 @@
   \fi %
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}%
   \setbox\GreSyllabletext=\hbox{\grefixedtextformat{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart}}%
-  \gre@debugmsg{Width of bar text: \the\wd\GreSyllabletext}%
+  \gre@debugmsg{spacing}{Width of bar text: \the\wd\GreSyllabletext}%
   \gresyllablenotes{#9}%
-  \gre@debugmsg{Width of bar line: \the\wd\GreSyllablenotes}%
+  \gre@debugmsg{spacing}{Width of bar line: \the\wd\GreSyllablenotes}%
   \gre@dimen@notesaligncenter=\wd\GreSyllablenotes%
   \divide\gre@dimen@notesaligncenter by 2\relax %
   \gre@dimen@begindifference=\gre@dimen@notesaligncenter %
@@ -692,7 +692,7 @@
   \gre@calculate@nextbegindifference{\gre@nextfirstsyllablepart}{\gre@nextmiddlesyllablepart}{\gre@nextendsyllablepart}{#7}%
   \greunsetfixednexttextformat %
   % then we check if there is something to write
-  \gre@debugmsg[ifdim]{ wd(GreSyllabletext) = 0pt}%
+  \gre@debugmsg{ifdim}{ wd(GreSyllabletext) = 0pt}%
   \ifdim\wd\GreSyllabletext = 0 pt\relax %
     % the most difficult case : when there is nothing to write
     % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces : 
@@ -702,13 +702,13 @@
     \advance\gre@skip@temp@three by \gre@skip@notebarspace %
     \advance\gre@skip@temp@three by \wd\GreSyllablenotes %
     % now let's get skip@temp@two
-    \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
+    \gre@debugmsg{ifdim}{ nextbegindifference < 0pt}%
     \ifdim\gre@skip@nextbegindifference < 0 pt%
       \gre@skip@temp@two=-\gre@skip@nextbegindifference %
     \else %
       \gre@skip@temp@two=0 pt%
     \fi %
-    \gre@debugmsg[ifdim]{ previousenddifference < 0pt}%
+    \gre@debugmsg{ifdim}{ previousenddifference < 0pt}%
     \ifdim\gre@dimen@previousenddifference < 0 pt%
       \advance\gre@skip@temp@two by -\gre@dimen@previousenddifference %
       \advance\gre@skip@temp@two by \gre@skip@interwordspacetext % in fact it is the max between interwordspacetext and interwordspacetextnotes
@@ -716,7 +716,7 @@
       \advance\gre@skip@temp@two by \gre@skip@interwordspacenotestext % in fact it is the max between interwordspacenotestext and interwordspacenotes
     \fi%
     % we take the max of it, then we divide it by two and we substract half of the width of the bar
-    \gre@debugmsg[ifdim]{ temp@skip@three < temp@skip@two}%
+    \gre@debugmsg{ifdim}{ temp@skip@three < temp@skip@two}%
     \ifdim\gre@skip@temp@three <\gre@skip@temp@two %
       \gre@skip@temp@three=\gre@skip@temp@two %
     \fi %
@@ -726,12 +726,12 @@
     \advance\gre@skip@temp@three by -\gre@dimen@temp@five %
     % now we have our skipone
     \gre@skip@temp@two=\gre@skip@temp@three %
-    \gre@debugmsg[ifdim]{ previousenddifference < 0pt}%
+    \gre@debugmsg{ifdim}{ previousenddifference < 0pt}%
     \ifdim\gre@dimen@previousenddifference < 0 pt%
       \advance\gre@skip@temp@two by \gre@dimen@previousenddifference %
     \fi %
     \grenobreak %
-    \gre@debugmsg[ifdim]{ temp@skip@two > -wd(GreSyllablenotes)}%
+    \gre@debugmsg{ifdim}{ temp@skip@two > -wd(GreSyllablenotes)}%
     \ifdim\gre@skip@temp@two > -\wd\GreSyllablenotes %
       \kern\gre@skip@temp@two %
     \else %
@@ -747,9 +747,9 @@
     \fi %
     #9\relax %
     \grepenalty{\greendafterbaraltpenalty }% TODO: isn't it a bit buggy?
-    \gre@debugmsg[ifdim]{ temp@skip@two < -wd(GreSyllablenotes)}
+    \gre@debugmsg{ifdim}{ temp@skip@two < -wd(GreSyllablenotes)}
     \ifdim\gre@skip@temp@two < -\wd\GreSyllablenotes %
-      \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}
+      \gre@debugmsg{ifdim}{ nextbegindifference > 0pt}
       \ifdim\gre@skip@nextbegindifference > 0 pt%
         \gre@skip@temp@one = \gre@skip@interwordspacetextnotes%
         \hskip\gre@skip@temp@one %
@@ -763,11 +763,11 @@
         %\divide\gre@skip@temp@two by 2\relax 
         %\kern -\gre@skip@temp@two 
       \gre@skip@temp@two=\gre@skip@temp@three %
-      \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
+      \gre@debugmsg{ifdim}{ nextbegindifference < 0pt}%
       \ifdim\gre@skip@nextbegindifference < 0 pt%
         \advance\gre@skip@temp@two by \gre@skip@nextbegindifference %
       \fi %
-      \gre@debugmsg[ifdim]{ temp@skip@two > -wd(GreSyllablenotes)}%
+      \gre@debugmsg{ifdim}{ temp@skip@two > -wd(GreSyllablenotes)}%
       \ifdim\gre@skip@temp@two > -\wd\GreSyllablenotes %
         \kern\gre@skip@temp@two %
       \else % \ifdim\gre@dimen@temp@five > -\wd\GreSyllablenotes 
@@ -789,7 +789,7 @@
     \gre@skip@temp@one = -\gre@dimen@begindifference%
     \kern\gre@skip@temp@one %
     #9%
-    \gre@debugmsg[ifdim]{ enddifference < 0pt}%
+    \gre@debugmsg{ifdim}{ enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference <0pt%
       %% important, else we are not really at the end of the syllable
       \gre@skip@temp@one = -\gre@dimen@enddifference%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -181,20 +181,20 @@
     \fi%
     \grewidthof{#1}%
     \divide\gre@dimen@temp@three by 2\relax %
-    \gre@debug{ifdim tempwidth > textaligncenter}%
+    \gre@debugmsg[ifdim]{ tempwidth > textaligncenter}%
     \ifdim\gre@dimen@temp@three >\gre@dimen@textaligncenter %
       \global\setbox\GreTempwidth=\hbox{#2}%
     \else%
       \ifcase\gre@englishcentering%
         \grewidthof{\mygre@endsyllablepart}%
-        \gre@debug{ifdim tempwidth > clivisalignmentmin}%
+        \gre@debugmsg[ifdim]{ tempwidth > clivisalignmentmin}%
         \ifdim\gre@dimen@temp@three >\gre@dimen@clivisalignmentmin %
           \global\setbox\GreTempwidth=\hbox{#2}%
         \else%
           \global\setbox\GreTempwidth=\hbox{#1}%
         \fi%
       \or%
-        \gre@debug{ifdim textaligncenter > clivisalignmentmin}%
+        \gre@debugmsg[ifdim]{ textaligncenter > clivisalignmentmin}%
         \ifdim\gre@dimen@textaligncenter >\gre@dimen@clivisalignmentmin %
           \global\setbox\GreTempwidth=\hbox{#2}%
         \else%
@@ -263,7 +263,7 @@
   \xdef\greboxing{1}%
   \xdef\gresavedlastoflinecount{\number\grelastoflinecount\relax }%
   \setbox\GreSyllablenotes=\hbox{#1}%
-  \gre@debug{Width of notes: \the\wd\GreSyllablenotes}%
+  \gre@debugmsg{Width of notes: \the\wd\GreSyllablenotes}%
   \xdef\grelastispunctum{\grelastispunctumsauv}%
   \xdef\greboxing{0}%
   \global\grelastoflinecount=\gresavedlastoflinecount\relax %
@@ -432,7 +432,7 @@
 %% with a special option for #7 : if it is a bar, we don't put a space at the end
 %% at the end we wall \greendofword or \greendofsyllable with #7, to reduce the space in case of a flat or natural
 \def\gresyllable#1#2#3#4#5#6#7#8#9{%
-  \gre@debug{New syllable}%
+  \gre@debugmsg{New syllable}%
   \ifnum\gre@englishcentering=1\relax %
     \gdef\gre@firstsyllablepart{}%
     \gdef\gre@middlesyllablepart{#1#2#3}%
@@ -456,25 +456,25 @@
       \advance\gre@skip@temp@one by \gre@dimen@begindifference %
       % a little trick... we don't want to kern more than clefwidth minus minimalspaceatlinebeginning
       \advance\gre@dimen@clefwidth by -\gre@dimen@minimalspaceatlinebeginning %
-      \gre@debug{ifdim temp@skip@one < -clefwidth}%
+      \gre@debugmsg[ifdim]{ temp@skip@one < -clefwidth}%
       \ifdim\gre@skip@temp@one <-\gre@dimen@clefwidth %
         \gre@skip@temp@one=-\gre@dimen@clefwidth %
       \fi %
       \advance\gre@dimen@clefwidth by \gre@dimen@minimalspaceatlinebeginning %
       \hbox{}%
       \advance\gre@skip@temp@one by -\gre@skip@spaceafterlineclef %
-      \gre@debug{ifdim gre@skip@temp@one < gre@begindifference}%
+      \gre@debugmsg[ifdim]{ gre@skip@temp@one < gre@begindifference}%
       \ifdim\gre@skip@temp@one < \gre@dimen@begindifference %
         \gre@skip@temp@one=\the\gre@dimen@begindifference %
       \fi %
       % Don't allow kern past the beginning of the first line with no initial
-      \gre@debug{ifdim initialwidth < 0pt}%
+      \gre@debugmsg[ifdim]{ initialwidth < 0pt}%
       \ifdim\gre@dimen@initialwidth = 0pt %
         \ifnum\greknownline=1 %
           \advance\gre@skip@temp@one by \gre@dimen@clefwidth %
         \fi %
       \fi %
-      \gre@debug{ifdim temp@skip@one < 0pt}%
+      \gre@debugmsg[ifdim]{ temp@skip@one < 0pt}%
       \ifdim\gre@skip@temp@one < 0pt%
         \kern\gre@skip@temp@one %
       \fi %
@@ -488,7 +488,7 @@
     \ifnum\grefirstsyllableofword=0 %
       \gre@skip@temp@one=\gre@skip@intersyllablespace %
       \advance\gre@skip@temp@one by \gre@dimen@begindifference %
-      \gre@debug{ifdim enddifference < 0pt}%
+      \gre@debugmsg[ifdim]{ enddifference < 0pt}%
       \ifdim\gre@dimen@enddifference<0pt%
         \advance\gre@skip@temp@one by \gre@dimen@enddifference %
       \fi % \ifdim\gre@dimen@enddifference>0pt
@@ -496,7 +496,7 @@
         \advance\gre@skip@temp@one by \gre@skip@beforealterationspace %
         \global\grefirstisalteration=0\relax %
       \fi % \ifnum\grefirstisalteration=1
-      \gre@debug{ifdim temp@skip@one > 0pt}%
+      \gre@debugmsg[ifdim]{ temp@skip@one > 0pt}%
       \ifdim\gre@skip@temp@one>0pt %
         \hskip\gre@skip@temp@one %
       \fi %
@@ -514,28 +514,28 @@
     % we set gretempdim to the actual space between the text of the two syllables. The algorithm is quite complex, but quite similar to the one computing the space between the two syllables several lines above.
     \gre@skip@temp@one=\gre@skip@intersyllablespace %
     \advance\gre@skip@temp@one by \gre@skip@nextbegindifference %
-    \gre@debug{ifdim enddifference < 0pt}%
+    \gre@debugmsg[ifdim]{ enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference<0pt%
       \advance\gre@skip@temp@one by \gre@dimen@enddifference %
     \fi % \ifdim\gre@dimen@enddifference>0pt
     % there is a small """feature""" here: if the first glyph is an alteration, the algorithm will be quite pessimistic
     % about the space, so an hyphen may be added when it's not really necessary.
-    \gre@debug{ifdim temp@skip@one < 0pt}%
+    \gre@debugmsg[ifdim]{ temp@skip@one < 0pt}%
     \ifdim\gre@skip@temp@one<0pt%
       \gre@skip@temp@one=0pt%
     \fi %
-    \gre@debug{ifdim enddifference > 0pt}%
+    \gre@debugmsg[ifdim]{ enddifference > 0pt}%
     \ifdim\gre@dimen@enddifference >0pt%
       \advance\gre@skip@temp@one by \gre@dimen@enddifference %
     \fi %
-    \gre@debug{ifdim nextbegindifference > 0pt}%
+    \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
     \ifdim\gre@skip@nextbegindifference >0pt%
       \advance\gre@skip@temp@one by \gre@skip@nextbegindifference %
     \fi %
     %
     % then we compare it with \gre@dimen@maximumspacewithoutdash, if it is larger, we add a dash
     %
-    \gre@debug{ifdim temp@skip@one > maximumspacewithoutdash}%
+    \gre@debugmsg[ifdim]{ temp@skip@one > maximumspacewithoutdash}%
     \ifdim\gre@skip@temp@one>\gre@dimen@maximumspacewithoutdash %
       % if it's the last syllable of line, the hyphen will be \grehyph
       \ifnum\grelastoflinecount=1\relax %
@@ -551,7 +551,7 @@
     \fi%
   \fi% ficase#4
   % then we reuse temp, we assign to it the \gre@dimen@begindifference, but only if it is positive, else it is 0
-  \gre@debug{ifdim begindifference > 0pt}%
+  \gre@debugmsg[ifdim]{ begindifference > 0pt}%
   \ifdim\gre@dimen@begindifference > 0 pt%
     \gre@skip@temp@one = \gre@dimen@begindifference%
     \kern\gre@skip@temp@one %
@@ -572,7 +572,7 @@
   % trick: we want to kern -enddifference if necessary before any change of line, which we can achieve only with this trick if the end of line is the last thing of the notes (it's the case of \grelastoflinecount is 1).
   % For the kern in this case, the base is to kern -\gre@dimen@enddifference if it's negative, but we can kern a bit more for the text to get a bit more to the right, but not after the end of the scores minus \gre@dimen@minimalspaceatlinebeginning
   \ifnum\grelastoflinecount=1\relax %
-    \gre@debug{ifdim enddifference < 0pt}%
+    \gre@debugmsg[ifdim]{ enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference <0pt%
       \gre@skip@temp@one=-\gre@dimen@enddifference %
       % we don't do it if it's the last syllable of a score or if the user disabled it
@@ -585,7 +585,7 @@
         \fi %
         \advance\gre@skip@temp@one by \gre@dimen@minimalspaceatlinebeginning %
       \fi %
-      \gre@debug{ifdim temp@skip@one < -enddifference}%
+      \gre@debugmsg[ifdim]{ temp@skip@one < -enddifference}%
       \ifdim\gre@skip@temp@one <-\gre@dimen@enddifference %
         \gre@skip@temp@one=-\the\gre@dimen@enddifference %
       \fi %
@@ -594,7 +594,7 @@
   \fi%
   \grenobreak % no line breaks between text and notes
   #9% we do that instead of \unhbox\Syllablnotes, because it would not set the \localrightbox
-  \gre@debug{ifdim enddifference < 0pt}%
+  \gre@debugmsg[ifdim]{ enddifference < 0pt}%
   \ifdim\gre@dimen@enddifference <0pt%
     %% important, else we are not really at the end of the syllable
     \grenobreak %
@@ -618,7 +618,7 @@
         % otherwise we call it with 1 only if there is no letters after (we can see it with nextbegindifference)
         \setbox\GreTempwidth=\hbox{\gre@nextfirstsyllablepart\gre@nextmiddlesyllablepart\gre@nextendsyllablepart }%
         % /!\ warning: can be buggy...
-        \gre@debug{ifdim wd(GreTempwidth) = 0pt}%
+        \gre@debugmsg[ifdim]{ wd(GreTempwidth) = 0pt}%
         \ifdim\wd\GreTempwidth=0pt%
           \greendbeforebar{0}%
         \else %
@@ -664,7 +664,7 @@
 
 %a macro to typeset a syllable with only a bar inside
 \def\grebarsyllable#1#2#3#4#5#6#7#8#9{%
-  \gre@debug{New bar syllable}%
+  \gre@debugmsg{New bar syllable}%
   % the algorithm of this function is *extremely* complex, and has been much painful to write... good luck to understand.
   % the main goal is, when there is no text under the bar, to put the bar in the middle of the space between the last note of the previous syllable and the first note of the next syllable. But there are limits : a bar can't go very far above text. For example if there is "nuncncncncn" with a punctum on the u, the bar can't go above the fourth n, the most far position is the position where the end of the bar is above the end of the word. The same limitation applies for the syllable after the bar.
   % there are two different cases that have almost nothing in common : the case where there is something written under the bar, and the case where there is nothing.
@@ -680,9 +680,9 @@
   \fi %
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}%
   \setbox\GreSyllabletext=\hbox{\grefixedtextformat{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart}}%
-  \gre@debug{Width of bar text: \the\wd\GreSyllabletext}%
+  \gre@debugmsg{Width of bar text: \the\wd\GreSyllabletext}%
   \gresyllablenotes{#9}%
-  \gre@debug{Width of bar line: \the\wd\GreSyllablenotes}%
+  \gre@debugmsg{Width of bar line: \the\wd\GreSyllablenotes}%
   \gre@dimen@notesaligncenter=\wd\GreSyllablenotes%
   \divide\gre@dimen@notesaligncenter by 2\relax %
   \gre@dimen@begindifference=\gre@dimen@notesaligncenter %
@@ -692,7 +692,7 @@
   \gre@calculate@nextbegindifference{\gre@nextfirstsyllablepart}{\gre@nextmiddlesyllablepart}{\gre@nextendsyllablepart}{#7}%
   \greunsetfixednexttextformat %
   % then we check if there is something to write
-  \gre@debug{ifdim wd(GreSyllabletext) = 0pt}%
+  \gre@debugmsg[ifdim]{ wd(GreSyllabletext) = 0pt}%
   \ifdim\wd\GreSyllabletext = 0 pt\relax %
     % the most difficult case : when there is nothing to write
     % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces : 
@@ -702,13 +702,13 @@
     \advance\gre@skip@temp@three by \gre@skip@notebarspace %
     \advance\gre@skip@temp@three by \wd\GreSyllablenotes %
     % now let's get skip@temp@two
-    \gre@debug{ifdim nextbegindifference < 0pt}%
+    \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
     \ifdim\gre@skip@nextbegindifference < 0 pt%
       \gre@skip@temp@two=-\gre@skip@nextbegindifference %
     \else %
       \gre@skip@temp@two=0 pt%
     \fi %
-    \gre@debug{ifdim previousenddifference < 0pt}%
+    \gre@debugmsg[ifdim]{ previousenddifference < 0pt}%
     \ifdim\gre@dimen@previousenddifference < 0 pt%
       \advance\gre@skip@temp@two by -\gre@dimen@previousenddifference %
       \advance\gre@skip@temp@two by \gre@skip@interwordspacetext % in fact it is the max between interwordspacetext and interwordspacetextnotes
@@ -716,7 +716,7 @@
       \advance\gre@skip@temp@two by \gre@skip@interwordspacenotestext % in fact it is the max between interwordspacenotestext and interwordspacenotes
     \fi%
     % we take the max of it, then we divide it by two and we substract half of the width of the bar
-    \gre@debug{ifdim temp@skip@three < temp@skip@two}%
+    \gre@debugmsg[ifdim]{ temp@skip@three < temp@skip@two}%
     \ifdim\gre@skip@temp@three <\gre@skip@temp@two %
       \gre@skip@temp@three=\gre@skip@temp@two %
     \fi %
@@ -726,12 +726,12 @@
     \advance\gre@skip@temp@three by -\gre@dimen@temp@five %
     % now we have our skipone
     \gre@skip@temp@two=\gre@skip@temp@three %
-    \gre@debug{ifdim previousenddifference < 0pt}%
+    \gre@debugmsg[ifdim]{ previousenddifference < 0pt}%
     \ifdim\gre@dimen@previousenddifference < 0 pt%
       \advance\gre@skip@temp@two by \gre@dimen@previousenddifference %
     \fi %
     \grenobreak %
-    \gre@debug{ifdim temp@skip@two > -wd(GreSyllablenotes)}%
+    \gre@debugmsg[ifdim]{ temp@skip@two > -wd(GreSyllablenotes)}%
     \ifdim\gre@skip@temp@two > -\wd\GreSyllablenotes %
       \kern\gre@skip@temp@two %
     \else %
@@ -747,9 +747,9 @@
     \fi %
     #9\relax %
     \grepenalty{\greendafterbaraltpenalty }% TODO: isn't it a bit buggy?
-    \gre@debug{ifdim temp@skip@two < -wd(GreSyllablenotes)}
+    \gre@debugmsg[ifdim]{ temp@skip@two < -wd(GreSyllablenotes)}
     \ifdim\gre@skip@temp@two < -\wd\GreSyllablenotes %
-      \gre@debug{ifdim nextbegindifference > 0pt}
+      \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}
       \ifdim\gre@skip@nextbegindifference > 0 pt%
         \gre@skip@temp@one = \gre@skip@interwordspacetextnotes%
         \hskip\gre@skip@temp@one %
@@ -763,11 +763,11 @@
         %\divide\gre@skip@temp@two by 2\relax 
         %\kern -\gre@skip@temp@two 
       \gre@skip@temp@two=\gre@skip@temp@three %
-      \gre@debug{ifdim nextbegindifference < 0pt}%
+      \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
       \ifdim\gre@skip@nextbegindifference < 0 pt%
         \advance\gre@skip@temp@two by \gre@skip@nextbegindifference %
       \fi %
-      \gre@debug{ifdim temp@skip@two > -wd(GreSyllablenotes)}%
+      \gre@debugmsg[ifdim]{ temp@skip@two > -wd(GreSyllablenotes)}%
       \ifdim\gre@skip@temp@two > -\wd\GreSyllablenotes %
         \kern\gre@skip@temp@two %
       \else % \ifdim\gre@dimen@temp@five > -\wd\GreSyllablenotes 
@@ -789,7 +789,7 @@
     \gre@skip@temp@one = -\gre@dimen@begindifference%
     \kern\gre@skip@temp@one %
     #9%
-    \gre@debug{ifdim enddifference < 0pt}%
+    \gre@debugmsg[ifdim]{ enddifference < 0pt}%
     \ifdim\gre@dimen@enddifference <0pt%
       %% important, else we are not really at the end of the syllable
       \gre@skip@temp@one = -\gre@dimen@enddifference%

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -21,20 +21,22 @@
 \ProvidesPackage{gregoriotex}%
     [2015/04/13 v3.0.0-rc2 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
 \RequirePackage{xcolor}
+\RequirePackage{kvoptions}
+
+\SetupKeyvalOptions{prefix=gre@}
+\DeclareStringOption{debug}[all]
 
 \input gregoriotex.tex
 
-%% We declare and process the options after loading the package (instead of at the beginning) because the options manipulate flags which are declared in the package.
-
-\DeclareOption{debug}{\gredebugtrue}
+%% We declare and process some additional options after loading the package (instead of at the beginning) because the options manipulate flags which are declared in the package.
 
 % These options control the global behavior of \includescore.  The default, forceinclude, is the old behavior (no attempt to compile the score with gregorio is made, it is simply included as is).  forcecompile is at the opposite end of the spectrum: all scores are compiled through gregorio at time of inclusion.  autocompile strikes a balance by checking to see if the score needs to be recompiled and only doing so if it needs it (see the definition of \includescore in gregoriotex.tex for more details).
-\DeclareOption{nevercompile}{\nevercompilegabc}
-\DeclareOption{forcecompile}{\forcecompilegabc}
-\DeclareOption{autocompile}{\autocompilegabc}
+\DeclareVoidOption{nevercompile}{\nevercompilegabc}
+\DeclareVoidOption{forcecompile}{\forcecompilegabc}
+\DeclareVoidOption{autocompile}{\autocompilegabc}
 
 \ExecuteOptions{nevercompile}
-\ProcessOptions\relax
+\ProcessKeyvalOptions*
 
 % we hide lines only under LaTeX
 \GreHideAltLines

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -49,15 +49,30 @@
   \greerror{Error: this document must be compiled with LuaTeX (lualatex)}%
 \fi%
 
-\newif\ifgredebug\gredebugfalse
-\def\gre@debug#1{%
-  \ifgredebug%
-    \typeout{GregorioTex debug: #1}%
-  \else%
-    \relax%
-  \fi%
+\def\gre@debugmsg{\@ifnextchar[{\gre@debugsub}{\gre@debugnosub}}%
+\def\gre@debugnosub#1{\gre@debugsub[all]{#1}}%
+\def\gre@debugsub[#1]#2{%
+  \IfStrEq{\gre@debug}{}{}
+    %false
+    {\IfStrEq{#1}{all}%
+      %true
+      {\typeout{GregorioTeX debug: #2}}%
+      %false
+      {\IfStrEq{\gre@debug}{all}%
+        %true
+        {\typeout{GregorioTeX debug: (#1) #2}}%
+        %false
+        {\IfSubStr{\gre@debug}{#1}%
+          %true
+          {\typeout{GregorioTeX debug: (#1) #2}}%
+          %false
+          {\relax}%
+        }%
+      }%
+    }%
 }%
-\AtBeginDocument{\gre@debug{GregorioTeX is in debug mode.  Debug messages will be printed to the log.}}%
+    
+\AtBeginDocument{\gre@debugmsg{GregorioTeX is in debug mode, \gre@debug\space messages will be printed to the log.}}%
 
 % Since TeXLive 2009, the extra primitives of LuaTeX have a luatex prefix, and are not
 % available without prefix. We mostly rely on \directlua that is still available
@@ -286,7 +301,7 @@
 }%
 
 \def\greupdatelinewidth{%
-  \gre@debug{ifdim additionalleftspace = 0pt}%
+  \gre@debugmsg[ifdim]{ additionalleftspace = 0pt}%
   \ifdim\gre@dimen@additionalleftspace=0pt%
   \else %
     \gre@dimen@temp@five=\gre@dimen@stafflinewidth %
@@ -305,17 +320,17 @@
   % if it is a big initial we print it on the second line 
   \ifnum\grebiginitial=0\relax %
     \setbox\GreInitial=\hbox{\greinitialformat{#1}}%
-    \gre@debug{ifdim manualinitialwidth = 0pt}%
+    \gre@debugmsg[ifdim]{ manualinitialwidth = 0pt}%
     \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\GreInitial %
     \else%
       \greinitialformat{\global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth}%
     \fi%
-    \gre@debug{ifdim wd(GreAboveinitialfirstbox) > initialwidth}%
+    \gre@debugmsg[ifdim]{ wd(GreAboveinitialfirstbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialfirstbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialfirstbox%
     \fi%
-    \gre@debug{ifdim wd(GreAboveinitialsecondbox) > initialwidth}%
+    \gre@debugmsg[ifdim]{ wd(GreAboveinitialsecondbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialsecondbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialsecondbox%
     \fi%
@@ -328,17 +343,17 @@
     \advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight %
     \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
     \setbox\GreInitial=\hbox{\grebiginitialformat{#1}}%
-    \gre@debug{ifdim manualinitialwidth = 0pt}%
+    \gre@debugmsg[ifdim]{ manualinitialwidth = 0pt}%
     \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\GreInitial %
     \else%
       \grebiginitialformat{\global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth}%
     \fi%
-    \gre@debug{ifdim wd(GreAboveinitialfirstbox) > initialwidth}%
+    \gre@debugmsg[ifdim]{ wd(GreAboveinitialfirstbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialfirstbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialfirstbox%
     \fi%
-    \gre@debug{ifdim wd(GreAboveinitialsecondbox) > initialwidth}%
+    \gre@debugmsg[ifdim]{ wd(GreAboveinitialsecondbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialsecondbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialsecondbox%
     \fi%
@@ -360,7 +375,7 @@
   \hskip\gre@dimen@temp@four %
   \global\advance\gre@dimen@initialwidth by \gre@dimen@temp@four%
   % then we center the first box above the initial, if there is one
-  \gre@debug{ifdim wd(GreAboveinitialfirstbox) = 0pt}%
+  \gre@debugmsg[ifdim]{ wd(GreAboveinitialfirstbox) = 0pt}%
   \ifdim\wd\GreAboveinitialfirstbox=0 pt\relax %
   \else %
     \gre@dimen@temp@five=\gre@dimen@initialwidth %
@@ -374,7 +389,7 @@
     \setbox\GreAboveinitialfirstbox=\hbox{}%
   \fi %
   % then we center the second box above the initial, if there is one
-  \gre@debug{ifdim wd(GreAboveinitialsecondbox) = 0pt}%
+  \gre@debugmsg[ifdim]{ wd(GreAboveinitialsecondbox) = 0pt}%
   \ifdim\wd\GreAboveinitialsecondbox=0 pt\relax %
   \else %
     \gre@dimen@temp@five=\gre@dimen@initialwidth %
@@ -531,17 +546,17 @@
 % typesets the text above the line
 \def\gretypesettextabovelines#1{%
   \greabovelinestextstyle{%
-    \gre@debug{Raise alt text: \gre@dimen@abovelinestextraise}%
+    \gre@debugmsg{Raise alt text: \gre@dimen@abovelinestextraise}%
     \global\gre@dimen@temp@five=\gre@dimen@abovelinestextraise\relax%
   } %
-  \gre@debug{Raise alt text: \the\gre@dimen@temp@five}%
+  \gre@debugmsg{Raise alt text: \the\gre@dimen@temp@five}%
   \advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight %
   \advance\gre@dimen@temp@five by 4\gre@dimen@interstafflinespace %
   \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext %
   \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
   \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext %
   \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace %
-  \gre@debug{Raise alt text: \the\gre@dimen@temp@five}%
+  \gre@debugmsg{Raise alt text: \the\gre@dimen@temp@five}%
   \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\greabovelinestextstyle{#1}\hss}%
   \relax %
 }%
@@ -819,9 +834,9 @@
 % when it is not necessary
 % It doesn't seem to be used, so it's a good candidate for deprecation!
 \def\grenolastline{%
-  \gre@debug{ifdim enddifference > 0pt}%
+  \gre@debugmsg[ifdim]{ enddifference > 0pt}%
   \ifdim\gre@dimen@enddifference > 0 pt %
-    \gre@debug{ifdim nextbegindifference > 0pt}%
+    \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
     \ifdim\gre@skip@nextbegindifference > 0 pt %
       \gre@skip@temp@four = \gre@skip@interwordspacenotes%
       \hskip\gre@skip@temp@four %
@@ -830,7 +845,7 @@
       \hskip\gre@skip@temp@four %
     \fi %
   \else%(enddifference < Opt)
-    \gre@debug{ifdim nextbegindifference < 0pt}%
+    \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
     \ifdim\gre@skip@nextbegindifference < 0 pt %
       \gre@skip@temp@four = \gre@skip@interwordspacetext%
       \hskip\gre@skip@temp@four %
@@ -850,9 +865,9 @@
 \def\greendofword#1{%
   \grepenalty{\greendofwordpenalty }%
   \ifnum#1=1\relax %
-    \gre@debug{ifdim enddifference > 0pt}%
+    \gre@debugmsg[ifdim]{ enddifference > 0pt}%
     \ifdim\gre@dimen@enddifference > 0 pt %
-      \gre@debug{ifdim nextbegindifference > 0pt}%
+      \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
       \ifdim\gre@skip@nextbegindifference > 0 pt %
         \gre@skip@temp@four = \gre@skip@interwordspacenotes%
         \grehskip\gre@skip@temp@four %
@@ -861,7 +876,7 @@
         \grehskip\gre@skip@temp@four %
       \fi %
     \else %(enddifference < Opt)
-      \gre@debug{ifdim nextbegindifference < 0pt}%
+      \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
       \ifdim\gre@skip@nextbegindifference < 0 pt %
         \gre@skip@temp@four = \gre@skip@interwordspacetext%
         \grehskip\gre@skip@temp@four %
@@ -911,9 +926,9 @@
       \fi %
     \fi %
     \grehskip\gre@skip@temp@four %
-    \gre@debug{  endbeforebar: hskip \gre@skip@temp@four }%
+    \gre@debugmsg{  endbeforebar: hskip \gre@skip@temp@four }%
   \else %
-    \gre@debug{  endbeforebar: no hskip}%
+    \gre@debugmsg{  endbeforebar: no hskip}%
   \fi %
   \grenobreak %
   %\global\gre@dimen@enddifference=0pt 
@@ -924,9 +939,9 @@
 \def\greendafterbar#1{%
   \grepenalty{\greendafterbarpenalty }\relax %
   \ifnum#1=1\relax %
-    \gre@debug{ifdim enddifference > 0pt}%
+    \gre@debugmsg[ifdim]{ enddifference > 0pt}%
     \ifdim\gre@dimen@enddifference > 0 pt %
-      \gre@debug{ifdim nextbegindifference > 0pt}%
+      \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
       \ifdim\gre@skip@nextbegindifference > 0 pt %
         \gre@skip@temp@four = \gre@skip@notebarspace%
         \grehskip\gre@skip@temp@four %
@@ -935,7 +950,7 @@
         \grehskip\gre@skip@temp@four %
       \fi %
     \else%(enddifference < Opt)
-      \gre@debug{ifdim nextbegindifference < 0pt}%
+      \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
       \ifdim\gre@skip@nextbegindifference < 0 pt %
         \gre@skip@temp@four = \gre@skip@textbartextspace%
         \grehskip\gre@skip@temp@four %
@@ -1313,13 +1328,13 @@
 
 \def\gre@includescore#1{%
   \ifcase\gre@compilegabc% case 0, never compile
-    \gre@debug{Refusing to compile #1}%
+    \gre@debugmsg{Refusing to compile #1}%
     \input #1%
   \or% case 1, auto compile
-    \gre@debug{Auto compile #1}%
+    \gre@debugmsg{Auto compile #1}%
     \directlua{gregoriotex.include_score([[#1]], nil)}%
   \or% case 2, force compile
-    \gre@debug{Forced to compile #1}%
+    \gre@debugmsg{Forced to compile #1}%
     \directlua{gregoriotex.include_score([[#1]], true)}%
   \fi%
   \relax%
@@ -1351,15 +1366,15 @@
 % f - force the compilation of the score before including it
 \def\gre@includescorewithoption[#1]#2{%
   \ifx #1n\relax%
-    \gre@debug{Override not compiling #2}%
+    \gre@debugmsg{Override not compiling #2}%
     \input #2%
   \else%
     \ifx #1f\relax%
-      \gre@debug{Override force compiling #2}%
+      \gre@debugmsg{Override force compiling #2}%
       \directlua{gregoriotex.include_score([[#2]], true)}%
     \else%
       \ifx #1a\relax%
-        \gre@debug{Override auto compiling #2}%
+        \gre@debugmsg{Override auto compiling #2}%
         \directlua{gregoriotex.include_score([[#2]], nil)}%
       \else%
         \greerror{Unrecognized option [#1] for \protect\includescore}%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -49,14 +49,12 @@
   \greerror{Error: this document must be compiled with LuaTeX (lualatex)}%
 \fi%
 
-\def\gre@debugmsg{\@ifnextchar[{\gre@debugsub}{\gre@debugnosub}}%
-\def\gre@debugnosub#1{\gre@debugsub[all]{#1}}%
-\def\gre@debugsub[#1]#2{%
+\def\gre@debugmsg#1#2{%
   \IfStrEq{\gre@debug}{}{}
     %false
     {\IfStrEq{#1}{all}%
       %true
-      {\typeout{GregorioTeX debug: #2}}%
+      {\greerror{Debug error: ‘all’ is not a permitted keyword}}%
       %false
       {\IfStrEq{\gre@debug}{all}%
         %true
@@ -72,7 +70,7 @@
     }%
 }%
     
-\AtBeginDocument{\gre@debugmsg{GregorioTeX is in debug mode, \gre@debug\space messages will be printed to the log.}}%
+\AtBeginDocument{\IfStrEq{\gre@debug}{}{}{\typeout{GregorioTeX is in debug mode}\typeout{\gre@debug\space messages will be printed to the log.}}}%
 
 % Since TeXLive 2009, the extra primitives of LuaTeX have a luatex prefix, and are not
 % available without prefix. We mostly rely on \directlua that is still available
@@ -301,7 +299,7 @@
 }%
 
 \def\greupdatelinewidth{%
-  \gre@debugmsg[ifdim]{ additionalleftspace = 0pt}%
+  \gre@debugmsg{ifdim}{ additionalleftspace = 0pt}%
   \ifdim\gre@dimen@additionalleftspace=0pt%
   \else %
     \gre@dimen@temp@five=\gre@dimen@stafflinewidth %
@@ -320,17 +318,17 @@
   % if it is a big initial we print it on the second line 
   \ifnum\grebiginitial=0\relax %
     \setbox\GreInitial=\hbox{\greinitialformat{#1}}%
-    \gre@debugmsg[ifdim]{ manualinitialwidth = 0pt}%
+    \gre@debugmsg{ifdim}{ manualinitialwidth = 0pt}%
     \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\GreInitial %
     \else%
       \greinitialformat{\global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth}%
     \fi%
-    \gre@debugmsg[ifdim]{ wd(GreAboveinitialfirstbox) > initialwidth}%
+    \gre@debugmsg{ifdim}{ wd(GreAboveinitialfirstbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialfirstbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialfirstbox%
     \fi%
-    \gre@debugmsg[ifdim]{ wd(GreAboveinitialsecondbox) > initialwidth}%
+    \gre@debugmsg{ifdim}{ wd(GreAboveinitialsecondbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialsecondbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialsecondbox%
     \fi%
@@ -343,17 +341,17 @@
     \advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight %
     \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
     \setbox\GreInitial=\hbox{\grebiginitialformat{#1}}%
-    \gre@debugmsg[ifdim]{ manualinitialwidth = 0pt}%
+    \gre@debugmsg{ifdim}{ manualinitialwidth = 0pt}%
     \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\GreInitial %
     \else%
       \grebiginitialformat{\global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth}%
     \fi%
-    \gre@debugmsg[ifdim]{ wd(GreAboveinitialfirstbox) > initialwidth}%
+    \gre@debugmsg{ifdim}{ wd(GreAboveinitialfirstbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialfirstbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialfirstbox%
     \fi%
-    \gre@debugmsg[ifdim]{ wd(GreAboveinitialsecondbox) > initialwidth}%
+    \gre@debugmsg{ifdim}{ wd(GreAboveinitialsecondbox) > initialwidth}%
     \ifdim\wd\GreAboveinitialsecondbox>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\GreAboveinitialsecondbox%
     \fi%
@@ -375,7 +373,7 @@
   \hskip\gre@dimen@temp@four %
   \global\advance\gre@dimen@initialwidth by \gre@dimen@temp@four%
   % then we center the first box above the initial, if there is one
-  \gre@debugmsg[ifdim]{ wd(GreAboveinitialfirstbox) = 0pt}%
+  \gre@debugmsg{ifdim}{ wd(GreAboveinitialfirstbox) = 0pt}%
   \ifdim\wd\GreAboveinitialfirstbox=0 pt\relax %
   \else %
     \gre@dimen@temp@five=\gre@dimen@initialwidth %
@@ -389,7 +387,7 @@
     \setbox\GreAboveinitialfirstbox=\hbox{}%
   \fi %
   % then we center the second box above the initial, if there is one
-  \gre@debugmsg[ifdim]{ wd(GreAboveinitialsecondbox) = 0pt}%
+  \gre@debugmsg{ifdim}{ wd(GreAboveinitialsecondbox) = 0pt}%
   \ifdim\wd\GreAboveinitialsecondbox=0 pt\relax %
   \else %
     \gre@dimen@temp@five=\gre@dimen@initialwidth %
@@ -546,17 +544,17 @@
 % typesets the text above the line
 \def\gretypesettextabovelines#1{%
   \greabovelinestextstyle{%
-    \gre@debugmsg{Raise alt text: \gre@dimen@abovelinestextraise}%
+    \gre@debugmsg{spacing}{Raise alt text: \gre@dimen@abovelinestextraise}%
     \global\gre@dimen@temp@five=\gre@dimen@abovelinestextraise\relax%
   } %
-  \gre@debugmsg{Raise alt text: \the\gre@dimen@temp@five}%
+  \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
   \advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight %
   \advance\gre@dimen@temp@five by 4\gre@dimen@interstafflinespace %
   \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext %
   \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
   \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext %
   \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace %
-  \gre@debugmsg{Raise alt text: \the\gre@dimen@temp@five}%
+  \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
   \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\greabovelinestextstyle{#1}\hss}%
   \relax %
 }%
@@ -834,9 +832,9 @@
 % when it is not necessary
 % It doesn't seem to be used, so it's a good candidate for deprecation!
 \def\grenolastline{%
-  \gre@debugmsg[ifdim]{ enddifference > 0pt}%
+  \gre@debugmsg{ifdim}{ enddifference > 0pt}%
   \ifdim\gre@dimen@enddifference > 0 pt %
-    \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
+    \gre@debugmsg{ifdim}{ nextbegindifference > 0pt}%
     \ifdim\gre@skip@nextbegindifference > 0 pt %
       \gre@skip@temp@four = \gre@skip@interwordspacenotes%
       \hskip\gre@skip@temp@four %
@@ -845,7 +843,7 @@
       \hskip\gre@skip@temp@four %
     \fi %
   \else%(enddifference < Opt)
-    \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
+    \gre@debugmsg{ifdim}{ nextbegindifference < 0pt}%
     \ifdim\gre@skip@nextbegindifference < 0 pt %
       \gre@skip@temp@four = \gre@skip@interwordspacetext%
       \hskip\gre@skip@temp@four %
@@ -865,9 +863,9 @@
 \def\greendofword#1{%
   \grepenalty{\greendofwordpenalty }%
   \ifnum#1=1\relax %
-    \gre@debugmsg[ifdim]{ enddifference > 0pt}%
+    \gre@debugmsg{ifdim}{ enddifference > 0pt}%
     \ifdim\gre@dimen@enddifference > 0 pt %
-      \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
+      \gre@debugmsg{ifdim}{ nextbegindifference > 0pt}%
       \ifdim\gre@skip@nextbegindifference > 0 pt %
         \gre@skip@temp@four = \gre@skip@interwordspacenotes%
         \grehskip\gre@skip@temp@four %
@@ -876,7 +874,7 @@
         \grehskip\gre@skip@temp@four %
       \fi %
     \else %(enddifference < Opt)
-      \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
+      \gre@debugmsg{ifdim}{ nextbegindifference < 0pt}%
       \ifdim\gre@skip@nextbegindifference < 0 pt %
         \gre@skip@temp@four = \gre@skip@interwordspacetext%
         \grehskip\gre@skip@temp@four %
@@ -926,9 +924,9 @@
       \fi %
     \fi %
     \grehskip\gre@skip@temp@four %
-    \gre@debugmsg{  endbeforebar: hskip \gre@skip@temp@four }%
+    \gre@debugmsg{spacing}{  endbeforebar: hskip \gre@skip@temp@four }%
   \else %
-    \gre@debugmsg{  endbeforebar: no hskip}%
+    \gre@debugmsg{spacing}{  endbeforebar: no hskip}%
   \fi %
   \grenobreak %
   %\global\gre@dimen@enddifference=0pt 
@@ -939,9 +937,9 @@
 \def\greendafterbar#1{%
   \grepenalty{\greendafterbarpenalty }\relax %
   \ifnum#1=1\relax %
-    \gre@debugmsg[ifdim]{ enddifference > 0pt}%
+    \gre@debugmsg{ifdim}{ enddifference > 0pt}%
     \ifdim\gre@dimen@enddifference > 0 pt %
-      \gre@debugmsg[ifdim]{ nextbegindifference > 0pt}%
+      \gre@debugmsg{ifdim}{ nextbegindifference > 0pt}%
       \ifdim\gre@skip@nextbegindifference > 0 pt %
         \gre@skip@temp@four = \gre@skip@notebarspace%
         \grehskip\gre@skip@temp@four %
@@ -950,7 +948,7 @@
         \grehskip\gre@skip@temp@four %
       \fi %
     \else%(enddifference < Opt)
-      \gre@debugmsg[ifdim]{ nextbegindifference < 0pt}%
+      \gre@debugmsg{ifdim}{ nextbegindifference < 0pt}%
       \ifdim\gre@skip@nextbegindifference < 0 pt %
         \gre@skip@temp@four = \gre@skip@textbartextspace%
         \grehskip\gre@skip@temp@four %
@@ -1328,13 +1326,13 @@
 
 \def\gre@includescore#1{%
   \ifcase\gre@compilegabc% case 0, never compile
-    \gre@debugmsg{Refusing to compile #1}%
+    \gre@debugmsg{compile}{Refusing to compile #1}%
     \input #1%
   \or% case 1, auto compile
-    \gre@debugmsg{Auto compile #1}%
+    \gre@debugmsg{compile}{Auto compile #1}%
     \directlua{gregoriotex.include_score([[#1]], nil)}%
   \or% case 2, force compile
-    \gre@debugmsg{Forced to compile #1}%
+    \gre@debugmsg{compile}{Forced to compile #1}%
     \directlua{gregoriotex.include_score([[#1]], true)}%
   \fi%
   \relax%
@@ -1366,15 +1364,15 @@
 % f - force the compilation of the score before including it
 \def\gre@includescorewithoption[#1]#2{%
   \ifx #1n\relax%
-    \gre@debugmsg{Override not compiling #2}%
+    \gre@debugmsg{compile}{Override not compiling #2}%
     \input #2%
   \else%
     \ifx #1f\relax%
-      \gre@debugmsg{Override force compiling #2}%
+      \gre@debugmsg{compile}{Override force compiling #2}%
       \directlua{gregoriotex.include_score([[#2]], true)}%
     \else%
       \ifx #1a\relax%
-        \gre@debugmsg{Override auto compiling #2}%
+        \gre@debugmsg{compile}{Override auto compiling #2}%
         \directlua{gregoriotex.include_score([[#2]], nil)}%
       \else%
         \greerror{Unrecognized option [#1] for \protect\includescore}%


### PR DESCRIPTION
`\gre@debug` becomes `\gre@debugmsg` in code.
The message function can now take two arguments.  The first, optional, is a keyword, the second, required, is the message.  If the keyword appears in the list of keywords stored in `\gre@debug` then the message is printed to the log.  If no keyword is given (or keyword is `all`) then debug message will always be printed to the log when debug is active.
`\gre@debug` is created via the debug option by the `kvoptions` package.  Syntax is `debug` (print all debug messages) `debug=keyword` (print only those messages associated with keyword, or `debug={list,of,keywords}` (print those messages associated with any of the keywords in the list).
As demonstration, all `ifdim` debug messages are now associated with that keyword.