### PR TITLE
Choosing a better default initial size

### DIFF
--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -45,12 +45,12 @@
 \definecolor{grebackgroundcolor}{RGB}{255,255,255}%
 
 \def\greinitialformat#1{%
-  \begin{huge}#1\end{huge}%
+  {\fontsize{40}{40}\selectfont #1}%
   \relax %
 }
 
 \def\grebiginitialformat#1{%
-  \begin{Huge}#1\end{Huge}%
+  {\fontsize{80}{80}\selectfont #1}%
   \relax %
 }
 


### PR DESCRIPTION
Instead of using `huge` and `Huge` in LaTeX, we define default initial sizes of 40pt and 80pt (for normal and big initials respectively).  If fonts are infinitely scalable, then this makes the appearance of the defaults nicer.  If fonts are not infinitely scalable, then LaTeX will automatically use the closest available size and put warnings in the log file.

Addresses #249 