### PR TITLE
Missing argument in shebang for fontforge

### DIFF
--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env fontforge -script
+#!/usr/bin/env fontforge -script -lang=py
 # coding=utf-8
 # pylint: disable=too-many-branches, too-many-arguments, too-many-lines
 # pylint: disable=import-error, no-member

--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env fontforge -script -lang=py
+#!/usr/bin/env fontforge -lang=py -script
 # coding=utf-8
 # pylint: disable=too-many-branches, too-many-arguments, too-many-lines
 # pylint: disable=import-error, no-member


### PR DESCRIPTION
At least on a Mac following the website instructions, fontforge needs to be told that the script is written in python before it will process it.  Oddly, this only appears to apply to `squarize.py`, not `convertsfdtottf.py`.