### PR TITLE
Changed GregorioRef date to %d-%b-%Y so date components are obvious.

### DIFF
--- a/VersionManager.py
+++ b/VersionManager.py
@@ -31,9 +31,12 @@ import argparse
 import subprocess
 import time
 import os
+import locale
 from datetime import date
 
 from distutils.util import strtobool
+
+locale.setlocale(locale.LC_TIME, 'C')
 
 os.chdir(sys.path[0])
 
@@ -179,7 +182,7 @@ def replace_version(version_obj):
                     result.append(re.sub(r'(\d+\/\d+/\d+)', today.strftime("%Y/%m/%d"), newline, 1))
                 elif 'PARSE_VERSION_DATE' in line:
                     newline = re.sub(r'(\d+\.\d+\.\d+(?:[-+~]\w+)*)', newver, line, 1)
-                    result.append(re.sub(r'(\d+\/\d+/\d+)', today.strftime("%d/%m/%y"), newline, 1))
+                    result.append(re.sub(r'(\d+\-[A-Z][a-z][a-z]-\d+)', today.strftime("%d-%b-%Y"), newline, 1))
                 elif 'PARSE_VERSION_FILE_NEXTLINE' in line:
                     result.append(line)
                     following_line_filename = True

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -74,7 +74,7 @@
 
     \vspace{1cm}
 
-    \large Version \textbf{4.0.0-rc1}, 26/04/15 %% PARSE_VERSION_DATE
+    \large Version \textbf{4.0.0-rc1}, 26-Apr-2015 %% PARSE_VERSION_DATE
 
     \vspace{1cm}
 


### PR DESCRIPTION
Using %d/%m/%y can leave the date components ambiguous depending on where you live, so I propose changing it to %d-%b-%Y (with `LC_TIME` set to `'C'`).  Feel free to close this request without merging if you disagree.