### PR TITLE
Remove unused glyphs for #357

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The default extension `gregorio` (the executable program) will use when it produces GregorioTeX files has been changed from `.tex` to `.gtex`.  Any calls to `\includescore` that use the old extension should be changed appropriately.
 
 ### Added
-- The ability to substitute an arbitrary glyph for one used by GregorioTeX.  This adds five macros: `\grechangeglyph` to make a score glyph substitution, `\greresetglyph` to remove a score glyph substitution, `\gredefvariant` for (re-)defining an arbitrary score glyph, `\gredefsymbol` for (re-)defining an arbitrary non-score glyph that scales with the text, and `\gredefsizedsymbol` for (re-)defining an arbitary non-score glyph that requires a point-size to be specified.  See GregorioRef.pdf for full details.
+- The ability to substitute an arbitrary glyph for one used by GregorioTeX.  This adds four macros: `\grechangeglyph` to make a score glyph substitution, `\greresetglyph` to remove a score glyph substitution, `\gredefsymbol` for (re-)defining an arbitrary non-score glyph that scales with the text, and `\gredefsizedsymbol` for (re-)defining an arbitary non-score glyph that requires a point-size to be specified.  See GregorioRef.pdf for full details.
 - Support for `lualatex -recorder`.  Autocompiled gabc and gtex files will now be properly recorded so that programs like `latexmk -recorder` can detect the need to rebuild the PDF when a gabc file changes.
 
 ### Removed

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -198,18 +198,6 @@ form, use the following:\par\medskip
   \greresetglyph{TorculusResupinus*}
 \end{latexcode}
 
-\macroname{\textbackslash gredefvariant}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex.tex}
-Defines (or redefines) a TeX control sequence to be a GregorioTeX-like
-score glyph.  This is a lower-level macro whose purpose is to redefine
-GregorioTeX control sequences with variant glyphs.
-
-\begin{argtable}
-  \#1 & string & The name of the TeX control sequence (without leading backslash).\\
-  \#2 & string & The name of the font to use.\\
-  \#3 & number & The code point of the glyph to use.\\
-  & string & The name of the glyph to use.
-\end{argtable}
-
 \macroname{\textbackslash gredefsymbol}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-symbols.tex}
 Defines (or redefines) a TeX control sequence to be a non-score symbol.
 If defined this way, the symbol will scale with the text font.

--- a/fonts/greciliae-base.sfd
+++ b/fonts/greciliae-base.sfd
@@ -41,7 +41,7 @@ NameList: Adobe Glyph List
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 40 8 2
+WinInfo: 64 8 2
 Grid
 148 1300 m 0
  148 -700 l 0
@@ -49,7 +49,7 @@ Grid
  17.75 -700 l 0
 EndSplineSet
 TeXData: 1 0 0 346030 173015 115343 0 1048576 115343 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 379 136
+BeginChars: 379 135
 
 StartChar: Punctum
 Encoding: 0 -1 0
@@ -1442,30 +1442,8 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: AuctumDuplex
-Encoding: 63 -1 63
-Width: 71
-VWidth: 2679
-Flags: HW
-HStem: -409 15 -94 15 221 15 536 15
-LayerCount: 2
-Fore
-SplineSet
-35.75 32.25 m 0
- 17.7314 32.25 0 47.3789 0 68 c 0
- 0 88.6553 17.7227 103.75 35.75 103.75 c 0
- 53.7686 103.75 71.5 88.6211 71.5 68 c 0
- 71.5 47.3447 53.7773 32.25 35.75 32.25 c 0
-35.75 346.25 m 0
- 17.7314 346.25 0 361.379 0 382 c 0
- 0 402.655 17.7227 417.75 35.75 417.75 c 0
- 53.7686 417.75 71.5 402.621 71.5 382 c 0
- 71.5 361.345 53.7773 346.25 35.75 346.25 c 0
-EndSplineSet
-EndChar
-
 StartChar: VEpisemus
-Encoding: 64 -1 64
+Encoding: 64 -1 63
 Width: 34
 VWidth: 2048
 Flags: HW
@@ -1484,7 +1462,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumDeminutus
-Encoding: 65 -1 65
+Encoding: 65 -1 64
 Width: 83
 VWidth: 2612
 Flags: HW
@@ -1503,7 +1481,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemus_base
-Encoding: 66 -1 66
+Encoding: 66 -1 65
 Width: 1
 VWidth: 2048
 Flags: HW
@@ -1520,7 +1498,7 @@ EndSplineSet
 EndChar
 
 StartChar: CustosUpMedium
-Encoding: 67 -1 67
+Encoding: 67 -1 66
 Width: 74
 VWidth: 2660
 Flags: HW
@@ -1541,7 +1519,7 @@ EndSplineSet
 EndChar
 
 StartChar: CustosDownMedium
-Encoding: 68 -1 68
+Encoding: 68 -1 67
 Width: 73
 VWidth: 2412
 Flags: HW
@@ -1562,7 +1540,7 @@ EndSplineSet
 EndChar
 
 StartChar: Accentus
-Encoding: 69 -1 69
+Encoding: 69 -1 68
 Width: 6
 Flags: HW
 HStem: -652.764 23.94 -150.024 23.94 352.716 23.94 855.456 23.94
@@ -1582,7 +1560,7 @@ EndSplineSet
 EndChar
 
 StartChar: AccentusReversus
-Encoding: 70 -1 70
+Encoding: 70 -1 69
 Width: 6
 Flags: HW
 HStem: -652.764 23.94 -150.024 23.94 352.716 23.94 855.456 23.94
@@ -1602,7 +1580,7 @@ EndSplineSet
 EndChar
 
 StartChar: SemicirculusReversus
-Encoding: 71 -1 71
+Encoding: 71 -1 70
 Width: 125
 VWidth: 1583
 Flags: W
@@ -1622,7 +1600,7 @@ Validated: 1
 EndChar
 
 StartChar: Semicirculus
-Encoding: 72 -1 72
+Encoding: 72 -1 71
 Width: 124
 VWidth: 1606
 Flags: W
@@ -1642,7 +1620,7 @@ Validated: 1
 EndChar
 
 StartChar: Circulus
-Encoding: 73 -1 73
+Encoding: 73 -1 72
 Width: 124
 VWidth: 1594
 Flags: W
@@ -1665,7 +1643,7 @@ Validated: 1
 EndChar
 
 StartChar: CClefChange
-Encoding: 74 -1 74
+Encoding: 74 -1 73
 Width: 166
 VWidth: 2575
 Flags: HW
@@ -1691,7 +1669,7 @@ EndSplineSet
 EndChar
 
 StartChar: FClefChange
-Encoding: 75 -1 75
+Encoding: 75 -1 74
 Width: 322
 VWidth: 2503
 Flags: HW
@@ -1726,8 +1704,8 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: Circumflexus
-Encoding: 76 -1 76
+StartChar: VEpisemus.circumflexus
+Encoding: 76 -1 75
 Width: 108
 VWidth: 2048
 Flags: W
@@ -1751,7 +1729,7 @@ Validated: 33
 EndChar
 
 StartChar: PunctumCavum
-Encoding: 77 -1 77
+Encoding: 77 -1 76
 Width: 166
 VWidth: 2612
 Flags: HW
@@ -1777,7 +1755,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctum
-Encoding: 78 -1 78
+Encoding: 78 -1 77
 Width: 266
 VWidth: 2048
 Flags: HW
@@ -1810,7 +1788,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctumCavum
-Encoding: 79 -1 79
+Encoding: 79 -1 78
 Width: 266
 VWidth: 2048
 Flags: HW
@@ -1850,7 +1828,7 @@ EndSplineSet
 EndChar
 
 StartChar: phigh
-Encoding: 80 -1 80
+Encoding: 80 -1 79
 Width: 155
 VWidth: 2537
 Flags: HW
@@ -1870,7 +1848,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemusleft
-Encoding: 81 -1 81
+Encoding: 81 -1 80
 Width: 1
 VWidth: 2048
 Flags: HW
@@ -1887,7 +1865,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemusright
-Encoding: 82 -1 82
+Encoding: 82 -1 81
 Width: 2
 VWidth: 2048
 Flags: HW
@@ -1904,7 +1882,7 @@ EndSplineSet
 EndChar
 
 StartChar: mpdeminutus
-Encoding: 83 -1 83
+Encoding: 83 -1 82
 Width: 168
 VWidth: 2048
 Flags: HW
@@ -1928,7 +1906,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumAscendens
-Encoding: 84 -1 84
+Encoding: 84 -1 83
 Width: 166
 VWidth: 1149
 Flags: HW
@@ -1948,7 +1926,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumDescendens
-Encoding: 85 -1 85
+Encoding: 85 -1 84
 Width: 166
 VWidth: 1342
 Flags: HW
@@ -1967,7 +1945,7 @@ EndSplineSet
 EndChar
 
 StartChar: mnbdeminutus
-Encoding: 86 -1 86
+Encoding: 86 -1 85
 Width: 168
 VWidth: 2048
 Flags: HW
@@ -1990,7 +1968,7 @@ EndSplineSet
 EndChar
 
 StartChar: mnbpdeminutus
-Encoding: 87 -1 87
+Encoding: 87 -1 86
 Width: 168
 VWidth: 2048
 Flags: HW
@@ -2012,7 +1990,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb1
-Encoding: 88 -1 88
+Encoding: 88 -1 87
 Width: 503
 VWidth: 2553
 Flags: HW
@@ -2032,7 +2010,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb2
-Encoding: 89 -1 89
+Encoding: 89 -1 88
 Width: 628
 VWidth: 2575
 Flags: HW
@@ -2052,7 +2030,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb3
-Encoding: 90 -1 90
+Encoding: 90 -1 89
 Width: 628
 VWidth: 2556
 Flags: HW
@@ -2074,7 +2052,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb4
-Encoding: 91 -1 91
+Encoding: 91 -1 90
 Width: 628
 VWidth: 2500
 Flags: HW
@@ -2095,7 +2073,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb5
-Encoding: 92 -1 92
+Encoding: 92 -1 91
 Width: 931
 VWidth: 2048
 Flags: HW
@@ -2115,7 +2093,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumForMeasurement
-Encoding: 93 -1 93
+Encoding: 93 -1 92
 Width: 155
 VWidth: 2537
 Flags: HW
@@ -2134,7 +2112,7 @@ EndSplineSet
 EndChar
 
 StartChar: p2base
-Encoding: 94 -1 94
+Encoding: 94 -1 93
 Width: 166
 VWidth: 2613
 Flags: HW
@@ -2160,7 +2138,7 @@ EndSplineSet
 EndChar
 
 StartChar: PesOneNothing
-Encoding: 95 -1 95
+Encoding: 95 -1 94
 Width: 166
 VWidth: 2613
 Flags: HW
@@ -2190,7 +2168,7 @@ EndSplineSet
 EndChar
 
 StartChar: rvlbase
-Encoding: 96 -1 96
+Encoding: 96 -1 95
 Width: 166
 VWidth: 2637
 Flags: HW
@@ -2214,7 +2192,7 @@ EndSplineSet
 EndChar
 
 StartChar: msdeminutus
-Encoding: 97 -1 97
+Encoding: 97 -1 96
 Width: 168
 VWidth: 2048
 Flags: HW
@@ -2239,7 +2217,7 @@ EndSplineSet
 EndChar
 
 StartChar: mademinutus
-Encoding: 98 -1 98
+Encoding: 98 -1 97
 Width: 168
 VWidth: 2048
 Flags: HW
@@ -2264,7 +2242,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumCavum.caeciliae
-Encoding: 99 -1 99
+Encoding: 99 -1 98
 Width: 166
 VWidth: 2612
 Flags: HW
@@ -2288,7 +2266,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctumCavum.caeciliae
-Encoding: 100 -1 100
+Encoding: 100 -1 99
 Width: 266
 VWidth: 2048
 Flags: W
@@ -2326,7 +2304,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumCavumHole.caeciliae
-Encoding: 101 -1 101
+Encoding: 101 -1 100
 Width: 166
 VWidth: 2612
 Flags: W
@@ -2343,7 +2321,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctumCavumHole.caeciliae
-Encoding: 102 -1 102
+Encoding: 102 -1 101
 Width: 266
 VWidth: 2048
 Flags: W
@@ -2360,7 +2338,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumCavumHole
-Encoding: 103 -1 103
+Encoding: 103 -1 102
 Width: 166
 VWidth: 2612
 Flags: HW
@@ -2379,7 +2357,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctumCavumHole
-Encoding: 104 -1 104
+Encoding: 104 -1 103
 Width: 266
 VWidth: 2048
 Flags: HW
@@ -2398,7 +2376,7 @@ EndSplineSet
 EndChar
 
 StartChar: NaturalHole
-Encoding: 105 -1 105
+Encoding: 105 -1 104
 Width: 108
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2414,7 +2392,7 @@ EndSplineSet
 EndChar
 
 StartChar: FlatHole
-Encoding: 106 -1 106
+Encoding: 106 -1 105
 Width: 162
 VWidth: 2587
 Flags: HW
@@ -2433,7 +2411,7 @@ EndSplineSet
 EndChar
 
 StartChar: odbase
-Encoding: 107 -1 107
+Encoding: 107 -1 106
 Width: 168
 VWidth: 2612
 Flags: HW
@@ -2456,7 +2434,7 @@ EndSplineSet
 EndChar
 
 StartChar: DivisioDominican
-Encoding: 108 -1 108
+Encoding: 108 -1 107
 Width: 18
 VWidth: 2048
 Flags: HW
@@ -2473,7 +2451,7 @@ EndSplineSet
 EndChar
 
 StartChar: DivisioDominicanAlt
-Encoding: 109 -1 109
+Encoding: 109 -1 108
 Width: 18
 VWidth: 2048
 Flags: HW
@@ -2490,7 +2468,7 @@ EndSplineSet
 EndChar
 
 StartChar: Sharp
-Encoding: 110 -1 110
+Encoding: 110 -1 109
 Width: 258
 VWidth: 2048
 Flags: HW
@@ -2552,7 +2530,7 @@ EndSplineSet
 EndChar
 
 StartChar: SharpHole
-Encoding: 111 -1 111
+Encoding: 111 -1 110
 Width: 258
 VWidth: 2048
 Flags: HW
@@ -2569,7 +2547,7 @@ EndSplineSet
 EndChar
 
 StartChar: Linea
-Encoding: 112 -1 112
+Encoding: 112 -1 111
 Width: 431
 VWidth: 2612
 Flags: HW
@@ -2596,7 +2574,7 @@ EndSplineSet
 EndChar
 
 StartChar: RoundBrace
-Encoding: 113 -1 113
+Encoding: 113 -1 112
 Width: 937
 VWidth: 2048
 Flags: HW
@@ -2621,7 +2599,7 @@ EndSplineSet
 EndChar
 
 StartChar: CurlyBrace
-Encoding: 114 -1 114
+Encoding: 114 -1 113
 Width: 1006
 VWidth: 2048
 Flags: HW
@@ -2648,7 +2626,7 @@ EndSplineSet
 EndChar
 
 StartChar: BarBrace
-Encoding: 115 -1 115
+Encoding: 115 -1 114
 Width: 591
 VWidth: 2048
 Flags: HW
@@ -2673,7 +2651,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusDeminutus
-Encoding: 116 -1 116
+Encoding: 116 -1 115
 Width: 168
 VWidth: 2612
 Flags: HW
@@ -2695,7 +2673,7 @@ EndSplineSet
 EndChar
 
 StartChar: obase4
-Encoding: 117 -1 117
+Encoding: 117 -1 116
 Width: 166
 VWidth: 2537
 Flags: W
@@ -2719,7 +2697,7 @@ EndSplineSet
 EndChar
 
 StartChar: obase8
-Encoding: 118 -1 118
+Encoding: 118 -1 117
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -2745,7 +2723,7 @@ EndSplineSet
 EndChar
 
 StartChar: VirgaReversaDescendens
-Encoding: 119 -1 119
+Encoding: 119 -1 118
 Width: 166
 VWidth: 2689
 Flags: HW
@@ -2768,7 +2746,7 @@ EndSplineSet
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens
-Encoding: 120 -1 120
+Encoding: 120 -1 119
 Width: 166
 VWidth: 2689
 Flags: HW
@@ -2791,7 +2769,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase2
-Encoding: 121 -1 121
+Encoding: 121 -1 120
 Width: 166
 VWidth: 2637
 Flags: HW
@@ -2815,7 +2793,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase3
-Encoding: 122 -1 122
+Encoding: 122 -1 121
 Width: 166
 VWidth: 2637
 Flags: HW
@@ -2839,7 +2817,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase4
-Encoding: 123 -1 123
+Encoding: 123 -1 122
 Width: 166
 VWidth: 2637
 Flags: HW
@@ -2863,7 +2841,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase5
-Encoding: 124 -1 124
+Encoding: 124 -1 123
 Width: 166
 VWidth: 2637
 Flags: HW
@@ -2887,7 +2865,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase1
-Encoding: 125 -1 125
+Encoding: 125 -1 124
 Width: 166
 VWidth: 2637
 Flags: HW
@@ -2909,7 +2887,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusScapusLongqueue
-Encoding: 126 -1 126
+Encoding: 126 -1 125
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -2933,7 +2911,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusScapus
-Encoding: 127 -1 127
+Encoding: 127 -1 126
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -2957,7 +2935,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase1
-Encoding: 128 -1 128
+Encoding: 128 -1 127
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -2981,7 +2959,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase2
-Encoding: 129 -1 129
+Encoding: 129 -1 128
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -3007,7 +2985,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase3
-Encoding: 130 -1 130
+Encoding: 130 -1 129
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -3033,7 +3011,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase4
-Encoding: 131 -1 131
+Encoding: 131 -1 130
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -3059,7 +3037,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase5
-Encoding: 132 -1 132
+Encoding: 132 -1 131
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -3085,7 +3063,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslbase
-Encoding: 133 -1 133
+Encoding: 133 -1 132
 Width: 166
 VWidth: 2537
 Flags: HW
@@ -3111,7 +3089,7 @@ EndSplineSet
 EndChar
 
 StartChar: StrophaAucta
-Encoding: 134 -1 134
+Encoding: 134 -1 133
 Width: 172
 VWidth: 2048
 Flags: HW
@@ -3133,7 +3111,7 @@ EndSplineSet
 EndChar
 
 StartChar: Stropha
-Encoding: 135 -1 135
+Encoding: 135 -1 134
 Width: 172
 VWidth: 2048
 Flags: W

--- a/fonts/gregorio-base.sfd
+++ b/fonts/gregorio-base.sfd
@@ -41,7 +41,7 @@ NameList: Adobe Glyph List
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 112 8 2
+WinInfo: 64 8 2
 Grid
 142 1300 m 0
  142 -700 l 0
@@ -49,7 +49,7 @@ Grid
  22 -700 l 0
 EndSplineSet
 TeXData: 1 0 0 346030 173015 115343 0 1048576 115343 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 375 130
+BeginChars: 375 129
 
 StartChar: Punctum
 Encoding: 0 -1 0
@@ -1455,30 +1455,8 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: AuctumDuplex
-Encoding: 63 -1 63
-Width: 71
-VWidth: 2679
-Flags: HW
-HStem: -409 15 -94 15 221 15 536 15
-LayerCount: 2
-Fore
-SplineSet
-35.75 16.25 m 4
- 17.7314 16.25 0 31.3789 0 52 c 4
- 0 72.6553 17.7227 87.75 35.75 87.75 c 4
- 53.7686 87.75 71.5 72.6211 71.5 52 c 4
- 71.5 31.3447 53.7773 16.25 35.75 16.25 c 4
-35.75 346.25 m 4
- 17.7314 346.25 0 361.379 0 382 c 4
- 0 402.655 17.7227 417.75 35.75 417.75 c 4
- 53.7686 417.75 71.5 402.621 71.5 382 c 4
- 71.5 361.345 53.7773 346.25 35.75 346.25 c 4
-EndSplineSet
-EndChar
-
 StartChar: VEpisemus
-Encoding: 64 -1 64
+Encoding: 64 -1 63
 Width: 40
 VWidth: 2048
 Flags: HW
@@ -1497,7 +1475,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumDeminutus
-Encoding: 65 -1 65
+Encoding: 65 -1 64
 Width: 110
 VWidth: 2048
 Flags: HW
@@ -1517,7 +1495,7 @@ Validated: 33
 EndChar
 
 StartChar: hepisemus_base
-Encoding: 66 -1 66
+Encoding: 66 -1 65
 Width: 1
 VWidth: 2048
 Flags: HW
@@ -1534,7 +1512,7 @@ EndSplineSet
 EndChar
 
 StartChar: PesOneNothing
-Encoding: 67 -1 67
+Encoding: 67 -1 66
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -1559,7 +1537,7 @@ Validated: 33
 EndChar
 
 StartChar: CustosUpMedium
-Encoding: 68 -1 68
+Encoding: 68 -1 67
 Width: 85
 VWidth: 2048
 Flags: HW
@@ -1578,7 +1556,7 @@ EndSplineSet
 EndChar
 
 StartChar: CustosDownMedium
-Encoding: 69 -1 69
+Encoding: 69 -1 68
 Width: 85
 VWidth: 2048
 Flags: HW
@@ -1598,7 +1576,7 @@ Validated: 33
 EndChar
 
 StartChar: Accentus
-Encoding: 70 -1 70
+Encoding: 70 -1 69
 Width: 99
 VWidth: 1594
 Flags: W
@@ -1620,7 +1598,7 @@ Validated: 1
 EndChar
 
 StartChar: AccentusReversus
-Encoding: 71 -1 71
+Encoding: 71 -1 70
 Width: 99
 VWidth: 1594
 Flags: W
@@ -1642,7 +1620,7 @@ Validated: 1
 EndChar
 
 StartChar: SemicirculusReversus
-Encoding: 72 -1 72
+Encoding: 72 -1 71
 Width: 125
 VWidth: 1583
 Flags: W
@@ -1662,7 +1640,7 @@ Validated: 1
 EndChar
 
 StartChar: Semicirculus
-Encoding: 73 -1 73
+Encoding: 73 -1 72
 Width: 124
 VWidth: 1606
 Flags: W
@@ -1682,7 +1660,7 @@ Validated: 1
 EndChar
 
 StartChar: Circulus
-Encoding: 74 -1 74
+Encoding: 74 -1 73
 Width: 124
 VWidth: 1594
 Flags: W
@@ -1705,7 +1683,7 @@ Validated: 1
 EndChar
 
 StartChar: CClefChange
-Encoding: 75 -1 75
+Encoding: 75 -1 74
 Width: 140
 VWidth: 2048
 Flags: HW
@@ -1734,7 +1712,7 @@ Validated: 1
 EndChar
 
 StartChar: FClefChange
-Encoding: 76 -1 76
+Encoding: 76 -1 75
 Width: 321
 VWidth: 2048
 Flags: HW
@@ -1768,8 +1746,8 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: Circumflexus
-Encoding: 77 -1 77
+StartChar: VEpisemus.circumflexus
+Encoding: 77 -1 76
 Width: 108
 VWidth: 2048
 Flags: W
@@ -1793,7 +1771,7 @@ Validated: 33
 EndChar
 
 StartChar: PunctumCavum
-Encoding: 78 -1 78
+Encoding: 78 -1 77
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -1820,7 +1798,7 @@ Validated: 1
 EndChar
 
 StartChar: LineaPunctum
-Encoding: 79 -1 79
+Encoding: 79 -1 78
 Width: 266
 VWidth: 2048
 Flags: HW
@@ -1854,7 +1832,7 @@ Validated: 1
 EndChar
 
 StartChar: LineaPunctumCavum
-Encoding: 80 -1 80
+Encoding: 80 -1 79
 Width: 266
 VWidth: 2048
 Flags: HW
@@ -1895,7 +1873,7 @@ Validated: 1
 EndChar
 
 StartChar: phigh
-Encoding: 81 -1 81
+Encoding: 81 -1 80
 Width: 154
 VWidth: 2048
 Flags: HW
@@ -1915,7 +1893,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemusleft
-Encoding: 82 -1 82
+Encoding: 82 -1 81
 Width: 1
 VWidth: 2048
 Flags: HW
@@ -1932,7 +1910,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemusright
-Encoding: 83 -1 83
+Encoding: 83 -1 82
 Width: 2
 VWidth: 2048
 Flags: HW
@@ -1949,7 +1927,7 @@ EndSplineSet
 EndChar
 
 StartChar: mpdeminutus
-Encoding: 84 -1 84
+Encoding: 84 -1 83
 Width: 186
 VWidth: 2048
 Flags: HW
@@ -1972,7 +1950,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumDescendens
-Encoding: 85 -1 85
+Encoding: 85 -1 84
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -1994,7 +1972,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumAscendens
-Encoding: 86 -1 86
+Encoding: 86 -1 85
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2016,7 +1994,7 @@ EndSplineSet
 EndChar
 
 StartChar: mnbdeminutus
-Encoding: 87 -1 87
+Encoding: 87 -1 86
 Width: 186
 VWidth: 2048
 Flags: HW
@@ -2037,7 +2015,7 @@ EndSplineSet
 EndChar
 
 StartChar: mnbpdeminutus
-Encoding: 88 -1 88
+Encoding: 88 -1 87
 Width: 186
 VWidth: 2048
 Flags: HW
@@ -2058,7 +2036,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb1
-Encoding: 89 -1 89
+Encoding: 89 -1 88
 Width: 340
 VWidth: 2048
 Flags: HW
@@ -2078,7 +2056,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb2
-Encoding: 90 -1 90
+Encoding: 90 -1 89
 Width: 428
 VWidth: 2048
 Flags: HW
@@ -2098,7 +2076,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb3
-Encoding: 91 -1 91
+Encoding: 91 -1 90
 Width: 586
 VWidth: 2048
 Flags: HW
@@ -2118,7 +2096,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb4
-Encoding: 92 -1 92
+Encoding: 92 -1 91
 Width: 670
 VWidth: 2048
 Flags: HW
@@ -2138,7 +2116,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb5
-Encoding: 93 -1 93
+Encoding: 93 -1 92
 Width: 931
 VWidth: 2048
 Flags: HW
@@ -2158,7 +2136,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumForMeasurement
-Encoding: 94 -1 94
+Encoding: 94 -1 93
 Width: 154
 VWidth: 2048
 Flags: HW
@@ -2177,7 +2155,7 @@ EndSplineSet
 EndChar
 
 StartChar: p2base
-Encoding: 95 -1 95
+Encoding: 95 -1 94
 Width: 164
 VWidth: 2048
 Flags: W
@@ -2197,7 +2175,7 @@ EndSplineSet
 EndChar
 
 StartChar: rvlbase
-Encoding: 96 -1 96
+Encoding: 96 -1 95
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2220,7 +2198,7 @@ EndSplineSet
 EndChar
 
 StartChar: msdeminutus
-Encoding: 97 -1 97
+Encoding: 97 -1 96
 Width: 186
 VWidth: 2048
 Flags: HW
@@ -2243,7 +2221,7 @@ EndSplineSet
 EndChar
 
 StartChar: mademinutus
-Encoding: 98 -1 98
+Encoding: 98 -1 97
 Width: 186
 VWidth: 2048
 Flags: HW
@@ -2266,7 +2244,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumCavumHole
-Encoding: 99 -1 99
+Encoding: 99 -1 98
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2285,7 +2263,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctumCavumHole
-Encoding: 100 -1 100
+Encoding: 100 -1 99
 Width: 266
 VWidth: 2048
 Flags: HW
@@ -2304,7 +2282,7 @@ EndSplineSet
 EndChar
 
 StartChar: FlatHole
-Encoding: 101 -1 101
+Encoding: 101 -1 100
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2321,7 +2299,7 @@ EndSplineSet
 EndChar
 
 StartChar: NaturalHole
-Encoding: 102 -1 102
+Encoding: 102 -1 101
 Width: 201
 VWidth: 2048
 Flags: HW
@@ -2338,7 +2316,7 @@ EndSplineSet
 EndChar
 
 StartChar: odbase
-Encoding: 103 -1 103
+Encoding: 103 -1 102
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2365,7 +2343,7 @@ EndSplineSet
 EndChar
 
 StartChar: DivisioDominican
-Encoding: 104 -1 104
+Encoding: 104 -1 103
 Width: 22
 VWidth: 2048
 Flags: HW
@@ -2382,7 +2360,7 @@ EndSplineSet
 EndChar
 
 StartChar: DivisioDominicanAlt
-Encoding: 105 -1 105
+Encoding: 105 -1 104
 Width: 22
 VWidth: 2048
 Flags: HW
@@ -2399,7 +2377,7 @@ EndSplineSet
 EndChar
 
 StartChar: Sharp
-Encoding: 106 -1 106
+Encoding: 106 -1 105
 Width: 258
 VWidth: 2048
 Flags: W
@@ -2461,7 +2439,7 @@ EndSplineSet
 EndChar
 
 StartChar: SharpHole
-Encoding: 107 -1 107
+Encoding: 107 -1 106
 Width: 258
 VWidth: 2048
 Flags: W
@@ -2478,7 +2456,7 @@ EndSplineSet
 EndChar
 
 StartChar: Linea
-Encoding: 108 -1 108
+Encoding: 108 -1 107
 Width: 431
 VWidth: 2612
 Flags: W
@@ -2505,7 +2483,7 @@ EndSplineSet
 EndChar
 
 StartChar: RoundBrace
-Encoding: 109 -1 109
+Encoding: 109 -1 108
 Width: 937
 VWidth: 2048
 Flags: W
@@ -2530,7 +2508,7 @@ EndSplineSet
 EndChar
 
 StartChar: CurlyBrace
-Encoding: 110 -1 110
+Encoding: 110 -1 109
 Width: 1006
 VWidth: 2048
 Flags: W
@@ -2557,7 +2535,7 @@ EndSplineSet
 EndChar
 
 StartChar: BarBrace
-Encoding: 111 -1 111
+Encoding: 111 -1 110
 Width: 591
 VWidth: 2048
 Flags: W
@@ -2582,7 +2560,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusDeminutus
-Encoding: 112 -1 112
+Encoding: 112 -1 111
 Width: 187
 VWidth: 2048
 Flags: HW
@@ -2610,7 +2588,7 @@ EndSplineSet
 EndChar
 
 StartChar: obase4
-Encoding: 113 -1 113
+Encoding: 113 -1 112
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2637,7 +2615,7 @@ EndSplineSet
 EndChar
 
 StartChar: obase8
-Encoding: 114 -1 114
+Encoding: 114 -1 113
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2663,7 +2641,7 @@ EndSplineSet
 EndChar
 
 StartChar: VirgaReversaDescendens
-Encoding: 115 -1 115
+Encoding: 115 -1 114
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2685,7 +2663,7 @@ EndSplineSet
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens
-Encoding: 116 -1 116
+Encoding: 116 -1 115
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2707,7 +2685,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase2
-Encoding: 117 -1 117
+Encoding: 117 -1 116
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2730,7 +2708,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase3
-Encoding: 118 -1 118
+Encoding: 118 -1 117
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2753,7 +2731,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase4
-Encoding: 119 -1 119
+Encoding: 119 -1 118
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2776,7 +2754,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase5
-Encoding: 120 -1 120
+Encoding: 120 -1 119
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2799,7 +2777,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase1
-Encoding: 121 -1 121
+Encoding: 121 -1 120
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2820,7 +2798,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusScapusLongqueue
-Encoding: 122 -1 122
+Encoding: 122 -1 121
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2847,7 +2825,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusScapus
-Encoding: 123 -1 123
+Encoding: 123 -1 122
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2875,7 +2853,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase1
-Encoding: 124 -1 124
+Encoding: 124 -1 123
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2902,7 +2880,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase2
-Encoding: 125 -1 125
+Encoding: 125 -1 124
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2930,7 +2908,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase3
-Encoding: 126 -1 126
+Encoding: 126 -1 125
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2958,7 +2936,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase4
-Encoding: 127 -1 127
+Encoding: 127 -1 126
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -2986,7 +2964,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase5
-Encoding: 128 -1 128
+Encoding: 128 -1 127
 Width: 164
 VWidth: 2048
 Flags: HW
@@ -3014,7 +2992,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslbase
-Encoding: 129 -1 129
+Encoding: 129 -1 128
 Width: 164
 VWidth: 2048
 Flags: HW

--- a/fonts/parmesan-base.sfd
+++ b/fonts/parmesan-base.sfd
@@ -41,7 +41,7 @@ NameList: Adobe Glyph List
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 112 8 2
+WinInfo: 64 8 2
 Grid
 170 1300 m 0
  170 -700 l 0
@@ -49,7 +49,7 @@ Grid
  22 -700 l 0
 EndSplineSet
 TeXData: 1 0 0 346030 173015 115343 0 1048576 115343 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 375 130
+BeginChars: 375 129
 
 StartChar: Punctum
 Encoding: 0 -1 0
@@ -1470,30 +1470,8 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: AuctumDuplex
-Encoding: 63 -1 63
-Width: 71
-VWidth: 2679
-Flags: HW
-HStem: -409 15 -94 15 221 15 536 15
-LayerCount: 2
-Fore
-SplineSet
-35.75 16.25 m 4
- 17.7314 16.25 0 31.3789 0 52 c 4
- 0 72.6553 17.7227 87.75 35.75 87.75 c 4
- 53.7686 87.75 71.5 72.6211 71.5 52 c 4
- 71.5 31.3447 53.7773 16.25 35.75 16.25 c 4
-35.75 346.25 m 4
- 17.7314 346.25 0 361.379 0 382 c 4
- 0 402.655 17.7227 417.75 35.75 417.75 c 4
- 53.7686 417.75 71.5 402.621 71.5 382 c 4
- 71.5 361.345 53.7773 346.25 35.75 346.25 c 4
-EndSplineSet
-EndChar
-
 StartChar: VEpisemus
-Encoding: 64 -1 64
+Encoding: 64 -1 63
 Width: 36
 VWidth: 1384
 Flags: HW
@@ -1512,7 +1490,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumDeminutus
-Encoding: 65 -1 65
+Encoding: 65 -1 64
 Width: 97
 VWidth: 2048
 Flags: HW
@@ -1533,7 +1511,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemus_base
-Encoding: 66 -1 66
+Encoding: 66 -1 65
 Width: 1
 VWidth: 2048
 Flags: HW
@@ -1550,7 +1528,7 @@ EndSplineSet
 EndChar
 
 StartChar: PesOneNothing
-Encoding: 67 -1 67
+Encoding: 67 -1 66
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -1577,7 +1555,7 @@ EndSplineSet
 EndChar
 
 StartChar: CustosUpMedium
-Encoding: 68 -1 68
+Encoding: 68 -1 67
 Width: 76
 VWidth: 1124
 Flags: HW
@@ -1599,7 +1577,7 @@ EndSplineSet
 EndChar
 
 StartChar: CustosDownMedium
-Encoding: 69 -1 69
+Encoding: 69 -1 68
 Width: 76
 VWidth: 1155
 Flags: HW
@@ -1621,7 +1599,7 @@ EndSplineSet
 EndChar
 
 StartChar: Accentus
-Encoding: 70 -1 70
+Encoding: 70 -1 69
 Width: 99
 VWidth: 1594
 Flags: HW
@@ -1642,7 +1620,7 @@ EndSplineSet
 EndChar
 
 StartChar: AccentusReversus
-Encoding: 71 -1 71
+Encoding: 71 -1 70
 Width: 99
 VWidth: 1594
 Flags: HW
@@ -1663,7 +1641,7 @@ EndSplineSet
 EndChar
 
 StartChar: SemicirculusReversus
-Encoding: 72 -1 72
+Encoding: 72 -1 71
 Width: 125
 VWidth: 1583
 Flags: HW
@@ -1682,7 +1660,7 @@ EndSplineSet
 EndChar
 
 StartChar: Semicirculus
-Encoding: 73 -1 73
+Encoding: 73 -1 72
 Width: 124
 VWidth: 1606
 Flags: HW
@@ -1701,7 +1679,7 @@ EndSplineSet
 EndChar
 
 StartChar: Circulus
-Encoding: 74 -1 74
+Encoding: 74 -1 73
 Width: 124
 VWidth: 1594
 Flags: HW
@@ -1723,7 +1701,7 @@ EndSplineSet
 EndChar
 
 StartChar: CClefChange
-Encoding: 75 -1 75
+Encoding: 75 -1 74
 Width: 143
 VWidth: 1107
 Flags: W
@@ -1751,7 +1729,7 @@ EndSplineSet
 EndChar
 
 StartChar: FClefChange
-Encoding: 76 -1 76
+Encoding: 76 -1 75
 Width: 299
 VWidth: 1119
 Flags: W
@@ -1790,8 +1768,8 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: Circumflexus
-Encoding: 77 -1 77
+StartChar: VEpisemus.circumflexus
+Encoding: 77 -1 76
 Width: 108
 VWidth: 2048
 Flags: HW
@@ -1814,7 +1792,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumCavum
-Encoding: 78 -1 78
+Encoding: 78 -1 77
 Width: 161
 VWidth: 1139
 Flags: HW
@@ -1843,7 +1821,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctum
-Encoding: 79 -1 79
+Encoding: 79 -1 78
 Width: 258
 VWidth: 1139
 Flags: HW
@@ -1878,7 +1856,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctumCavum
-Encoding: 80 -1 80
+Encoding: 80 -1 79
 Width: 258
 VWidth: 1139
 Flags: HW
@@ -1921,7 +1899,7 @@ EndSplineSet
 EndChar
 
 StartChar: phigh
-Encoding: 81 -1 81
+Encoding: 81 -1 80
 Width: 151
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -1941,7 +1919,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemusleft
-Encoding: 82 -1 82
+Encoding: 82 -1 81
 Width: 1
 VWidth: 2048
 Flags: HW
@@ -1958,7 +1936,7 @@ EndSplineSet
 EndChar
 
 StartChar: hepisemusright
-Encoding: 83 -1 83
+Encoding: 83 -1 82
 Width: 2
 VWidth: 2048
 Flags: HW
@@ -1975,7 +1953,7 @@ EndSplineSet
 EndChar
 
 StartChar: mpdeminutus
-Encoding: 84 -1 84
+Encoding: 84 -1 83
 Width: 161
 Flags: HW
 HStem: 536.497 15 221.497 15 -93.503 15 -408.503 15
@@ -1995,7 +1973,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumDescendens
-Encoding: 85 -1 85
+Encoding: 85 -1 84
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2017,7 +1995,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumAscendens
-Encoding: 86 -1 86
+Encoding: 86 -1 85
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2039,7 +2017,7 @@ EndSplineSet
 EndChar
 
 StartChar: mnbdeminutus
-Encoding: 87 -1 87
+Encoding: 87 -1 86
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2059,7 +2037,7 @@ EndSplineSet
 EndChar
 
 StartChar: mnbpdeminutus
-Encoding: 88 -1 88
+Encoding: 88 -1 87
 Width: 161
 Flags: HW
 HStem: 536.058 15 221.058 15 -93.9416 15 -408.942 15
@@ -2079,7 +2057,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb1
-Encoding: 89 -1 89
+Encoding: 89 -1 88
 Width: 340
 VWidth: 2048
 Flags: HW
@@ -2099,7 +2077,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb2
-Encoding: 90 -1 90
+Encoding: 90 -1 89
 Width: 428
 VWidth: 2048
 Flags: HW
@@ -2119,7 +2097,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb3
-Encoding: 91 -1 91
+Encoding: 91 -1 90
 Width: 586
 VWidth: 2048
 Flags: HW
@@ -2139,7 +2117,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb4
-Encoding: 92 -1 92
+Encoding: 92 -1 91
 Width: 670
 VWidth: 2048
 Flags: HW
@@ -2159,7 +2137,7 @@ EndSplineSet
 EndChar
 
 StartChar: porrectusflexusnb5
-Encoding: 93 -1 93
+Encoding: 93 -1 92
 Width: 931
 VWidth: 2048
 Flags: HW
@@ -2179,7 +2157,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumForMeasurement
-Encoding: 94 -1 94
+Encoding: 94 -1 93
 Width: 151
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2199,7 +2177,7 @@ EndSplineSet
 EndChar
 
 StartChar: p2base
-Encoding: 95 -1 95
+Encoding: 95 -1 94
 Width: 161
 Flags: W
 HStem: 536.228 15 221.228 15 -93.7716 15 -408.772 15
@@ -2219,7 +2197,7 @@ EndSplineSet
 EndChar
 
 StartChar: rvlbase
-Encoding: 96 -1 96
+Encoding: 96 -1 95
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2241,7 +2219,7 @@ EndSplineSet
 EndChar
 
 StartChar: msdeminutus
-Encoding: 97 -1 97
+Encoding: 97 -1 96
 Width: 161
 Flags: HW
 HStem: 536.058 15 221.058 15 -93.9416 15 -408.942 15
@@ -2263,7 +2241,7 @@ EndSplineSet
 EndChar
 
 StartChar: mademinutus
-Encoding: 98 -1 98
+Encoding: 98 -1 97
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2285,7 +2263,7 @@ EndSplineSet
 EndChar
 
 StartChar: PunctumCavumHole
-Encoding: 99 -1 99
+Encoding: 99 -1 98
 Width: 161
 VWidth: 1139
 Flags: HW
@@ -2304,7 +2282,7 @@ EndSplineSet
 EndChar
 
 StartChar: LineaPunctumCavumHole
-Encoding: 100 -1 100
+Encoding: 100 -1 99
 Width: 258
 VWidth: 1139
 Flags: HW
@@ -2323,7 +2301,7 @@ EndSplineSet
 EndChar
 
 StartChar: NaturalHole
-Encoding: 101 -1 101
+Encoding: 101 -1 100
 Width: 141
 VWidth: 1129
 Flags: HW
@@ -2340,7 +2318,7 @@ EndSplineSet
 EndChar
 
 StartChar: FlatHole
-Encoding: 102 -1 102
+Encoding: 102 -1 101
 Width: 159
 VWidth: 1120
 Flags: HW
@@ -2359,7 +2337,7 @@ EndSplineSet
 EndChar
 
 StartChar: odbase
-Encoding: 103 -1 103
+Encoding: 103 -1 102
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2383,7 +2361,7 @@ EndSplineSet
 EndChar
 
 StartChar: DivisioDominican
-Encoding: 104 -1 104
+Encoding: 104 -1 103
 Width: 22
 VWidth: 2048
 Flags: W
@@ -2400,7 +2378,7 @@ EndSplineSet
 EndChar
 
 StartChar: DivisioDominicanAlt
-Encoding: 105 -1 105
+Encoding: 105 -1 104
 Width: 22
 VWidth: 2048
 Flags: W
@@ -2417,7 +2395,7 @@ EndSplineSet
 EndChar
 
 StartChar: Sharp
-Encoding: 106 -1 106
+Encoding: 106 -1 105
 Width: 258
 VWidth: 2048
 Flags: W
@@ -2479,7 +2457,7 @@ EndSplineSet
 EndChar
 
 StartChar: SharpHole
-Encoding: 107 -1 107
+Encoding: 107 -1 106
 Width: 258
 VWidth: 2048
 Flags: W
@@ -2496,7 +2474,7 @@ EndSplineSet
 EndChar
 
 StartChar: Linea
-Encoding: 108 -1 108
+Encoding: 108 -1 107
 Width: 431
 VWidth: 2612
 Flags: W
@@ -2523,7 +2501,7 @@ EndSplineSet
 EndChar
 
 StartChar: RoundBrace
-Encoding: 109 -1 109
+Encoding: 109 -1 108
 Width: 937
 VWidth: 2048
 Flags: W
@@ -2548,7 +2526,7 @@ EndSplineSet
 EndChar
 
 StartChar: CurlyBrace
-Encoding: 110 -1 110
+Encoding: 110 -1 109
 Width: 1006
 VWidth: 2048
 Flags: W
@@ -2575,7 +2553,7 @@ EndSplineSet
 EndChar
 
 StartChar: BarBrace
-Encoding: 111 -1 111
+Encoding: 111 -1 110
 Width: 591
 VWidth: 2048
 Flags: W
@@ -2600,7 +2578,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusDeminutus
-Encoding: 112 -1 112
+Encoding: 112 -1 111
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2624,7 +2602,7 @@ EndSplineSet
 EndChar
 
 StartChar: obase4
-Encoding: 113 -1 113
+Encoding: 113 -1 112
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2647,7 +2625,7 @@ EndSplineSet
 EndChar
 
 StartChar: obase8
-Encoding: 114 -1 114
+Encoding: 114 -1 113
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2675,7 +2653,7 @@ EndSplineSet
 EndChar
 
 StartChar: VirgaReversaDescendens
-Encoding: 115 -1 115
+Encoding: 115 -1 114
 Width: 141
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2699,7 +2677,7 @@ EndSplineSet
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens
-Encoding: 116 -1 116
+Encoding: 116 -1 115
 Width: 141
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2723,7 +2701,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase2
-Encoding: 117 -1 117
+Encoding: 117 -1 116
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2745,7 +2723,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase3
-Encoding: 118 -1 118
+Encoding: 118 -1 117
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2767,7 +2745,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase4
-Encoding: 119 -1 119
+Encoding: 119 -1 118
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2789,7 +2767,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase5
-Encoding: 120 -1 120
+Encoding: 120 -1 119
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2811,7 +2789,7 @@ EndSplineSet
 EndChar
 
 StartChar: vbase1
-Encoding: 121 -1 121
+Encoding: 121 -1 120
 Width: 161
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2832,7 +2810,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusScapusLongqueue
-Encoding: 122 -1 122
+Encoding: 122 -1 121
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2856,7 +2834,7 @@ EndSplineSet
 EndChar
 
 StartChar: OriscusScapus
-Encoding: 123 -1 123
+Encoding: 123 -1 122
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2880,7 +2858,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase1
-Encoding: 124 -1 124
+Encoding: 124 -1 123
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2904,7 +2882,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase2
-Encoding: 125 -1 125
+Encoding: 125 -1 124
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
@@ -2930,7 +2908,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase3
-Encoding: 126 -1 126
+Encoding: 126 -1 125
 Width: 192
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2956,7 +2934,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase4
-Encoding: 127 -1 127
+Encoding: 127 -1 126
 Width: 192
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -2982,7 +2960,7 @@ EndSplineSet
 EndChar
 
 StartChar: osbase5
-Encoding: 128 -1 128
+Encoding: 128 -1 127
 Width: 192
 Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
@@ -3008,7 +2986,7 @@ EndSplineSet
 EndChar
 
 StartChar: oslbase
-Encoding: 129 -1 129
+Encoding: 129 -1 128
 Width: 192
 Flags: HW
 HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1

--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -224,8 +224,6 @@ DIRECT_GLYPH_NAMES = [
     'DivisioMaior',
     'PunctumDeminutus',
     'AuctumMora',
-    'AuctumDuplex',
-    'Circumflexus',
     'Punctum',
     'PunctumInclinatum',
     'Stropha',
@@ -242,6 +240,7 @@ DIRECT_GLYPH_NAMES = [
     'PunctumInclinatumAuctus',
     'PunctumInclinatumDeminutus',
     'VEpisemus',
+    'VEpisemus.circumflexus',
     'PunctumCavum',
     'LineaPunctum',
     'LineaPunctumCavum',
@@ -278,6 +277,9 @@ DIRECT_GLYPH_NAMES = [
     'PesQuilismaOneNothing',
 ]
 
+# This will be populated by initialize_glyphs
+COMMON_DIRECT_VARIANTS = {}
+
 def initialize_glyphs():
     "Builds the first glyphs."
     global newfont, oldfont, font_name
@@ -291,17 +293,21 @@ def initialize_glyphs():
         oldfont.copy()
         newfont.paste()
         set_glyph_name(name)
+        if name.find('.') > 0:
+            COMMON_DIRECT_VARIANTS[name] = True
 
 def copy_variant_glyphs():
     "Copies the variant glyphs."
     global newfont, oldfont
     for glyph in oldfont.glyphs():
-        if glyph.isWorthOutputting() and glyph.glyphname.find(".") > 0:
+        name = glyph.glyphname
+        if (glyph.isWorthOutputting() and name.find(".") > 0 and
+                name not in COMMON_DIRECT_VARIANTS):
             new_glyph()
             oldfont.selection.select(glyph)
             oldfont.copy()
             newfont.paste()
-            set_glyph_name(glyph.glyphname)
+            set_glyph_name(name)
 
 def get_lengths(fontname):
     "Initialize widths depending on the font."
@@ -436,7 +442,7 @@ L_INITIO_DEBILIS_ASCENDENS  = 'InitioDebilisAscendens'
 L_INITIO_DEBILIS_DESCENDENS = 'InitioDebilisDescendens'
 
 def simple_paste(src):
-    "Copy and past a glyph."
+    "Copy and paste a glyph."
     global oldfont, newfont, glyphnumber
     oldfont.selection.select(src)
     oldfont.copy()

--- a/tex/gregoriotex-chars.tex
+++ b/tex/gregoriotex-chars.tex
@@ -19,80 +19,78 @@
 
 \gre@declarefileversion{gregoriotex-chars.tex}{4.0.0-rc1}% GREGORIO_VERSION
 
-\def\gregoriostylecharoffset#1{\the\numexpr 66 + #1 \relax}
-
 % bars
-\let\gre@char@divisiomaior=\grecpDivisioMaior\relax %
-\let\gre@char@virgula=\grecpVirgula\relax %
-\let\gre@char@divisiominima=\grecpDivisioMinima\relax %
-\let\gre@char@divisiominor=\grecpDivisioMinor\relax %
-\let\gre@char@divisiodominican=\grecpDivisioDominican\relax %
-\let\gre@char@divisiodominicanalt=\grecpDivisioDominicanAlt\relax %
+\def\gre@char@divisiomaior{\grecpDivisioMaior}%
+\def\gre@char@virgula{\grecpVirgula}%
+\def\gre@char@divisiominima{\grecpDivisioMinima}%
+\def\gre@char@divisiominor{\grecpDivisioMinor}%
+\def\gre@char@divisiodominican{\grecpDivisioDominican}%
+\def\gre@char@divisiodominicanalt{\grecpDivisioDominicanAlt}%
 
-\let\gre@char@punctumcavum=\grecpPunctumCavum\relax %
-\let\gre@char@lineapunctumcavum=\grecpLineaPunctumCavum\relax %
-\let\gre@char@punctumcavumhole=\grecpPunctumCavumHole\relax %
-\let\gre@char@lineapunctumcavumhole=\grecpLineaPunctumCavumHole\relax %
+\def\gre@char@punctumcavum{\grecpPunctumCavum}%
+\def\gre@char@lineapunctumcavum{\grecpLineaPunctumCavum}%
+\def\gre@char@punctumcavumhole{\grecpPunctumCavumHole}%
+\def\gre@char@lineapunctumcavumhole{\grecpLineaPunctumCavumHole}%
 
 % notes (to compute different widths)
-\let\gre@char@smallpunctum=\grecpPunctumDeminutus\relax %
-\let\gre@char@punctum=\grecpPunctum\relax %
-\let\gre@char@punctuminclinatum=\grecpPunctumInclinatum\relax %
-\let\gre@char@stropha=\grecpStropha\relax %
-\let\gre@char@strophaaucta=\grecpStrophaAucta\relax %
-\let\gre@char@quilisma=\grecpQuilisma\relax %
-\let\gre@char@oriscus=\grecpOriscus\relax %
-\let\gre@char@oriscusauctus=\grecpOriscusReversus\relax %
-\let\gre@char@punctuminclinatumdem=\grecpPunctumInclinatumAuctus\relax %
-\let\gre@char@lineapunctum=\grecpLineaPunctum\relax %
-\let\gre@char@peshigh=\grecpPunctumForMeasurement\relax %
-\let\gre@char@pesinitauctus=\grecpPesQuadratumTwoInitioDebilisDescendens\relax %
-\let\gre@char@pesinitauctusone=\grecpPesQuadratumOneInitioDebilisDescendens\relax %
-\let\gre@char@flexus=\grecpPesQuadratumLongqueueThreeNothing\relax %
-\let\gre@char@flexusone=\grecpPesQuadratumLongqueueOneNothing\relax %
-\let\gre@char@flexusdeminutus=\grecpFlexusTwoDeminutus\relax %
-\let\gre@char@flexusaltone=\grecpFlexusNobarOneNothing\relax %
-\let\gre@char@flexusalt=\grecpFlexusNobarTwoNothing\relax %
-\let\gre@char@torculus=\grecpTorculusOneTwoNothing\relax %
-\let\gre@char@torculusdeminutus=\grecpTorculusTwoTwoDeminutus\relax %
-\let\gre@char@porrectus@one=\grecpPorrectusOneOneNothing\relax %
-\let\gre@char@porrectus@two=\grecpPorrectusTwoOneNothing\relax %
-\let\gre@char@porrectus@three=\grecpPorrectusThreeOneNothing\relax %
-\let\gre@char@porrectus@four=\grecpPorrectusFourOneNothing\relax %
-\let\gre@char@porrectus@five=\grecpPorrectusFiveOneNothing\relax %
+\def\gre@char@smallpunctum{\grecpPunctumDeminutus}%
+\def\gre@char@punctum{\grecpPunctum}%
+\def\gre@char@punctuminclinatum{\grecpPunctumInclinatum}%
+\def\gre@char@stropha{\grecpStropha}%
+\def\gre@char@strophaaucta{\grecpStrophaAucta}%
+\def\gre@char@quilisma{\grecpQuilisma}%
+\def\gre@char@oriscus{\grecpOriscus}%
+\def\gre@char@oriscusauctus{\grecpOriscusReversus}%
+\def\gre@char@punctuminclinatumdem{\grecpPunctumInclinatumAuctus}%
+\def\gre@char@lineapunctum{\grecpLineaPunctum}%
+\def\gre@char@peshigh{\grecpPunctumForMeasurement}%
+\def\gre@char@pesinitauctus{\grecpPesQuadratumTwoInitioDebilisDescendens}%
+\def\gre@char@pesinitauctusone{\grecpPesQuadratumOneInitioDebilisDescendens}%
+\def\gre@char@flexus{\grecpPesQuadratumLongqueueThreeNothing}%
+\def\gre@char@flexusone{\grecpPesQuadratumLongqueueOneNothing}%
+\def\gre@char@flexusdeminutus{\grecpFlexusTwoDeminutus}%
+\def\gre@char@flexusaltone{\grecpFlexusNobarOneNothing}%
+\def\gre@char@flexusalt{\grecpFlexusNobarTwoNothing}%
+\def\gre@char@torculus{\grecpTorculusOneTwoNothing}%
+\def\gre@char@torculusdeminutus{\grecpTorculusTwoTwoDeminutus}%
+\def\gre@char@porrectus@one{\grecpPorrectusOneOneNothing}%
+\def\gre@char@porrectus@two{\grecpPorrectusTwoOneNothing}%
+\def\gre@char@porrectus@three{\grecpPorrectusThreeOneNothing}%
+\def\gre@char@porrectus@four{\grecpPorrectusFourOneNothing}%
+\def\gre@char@porrectus@five{\grecpPorrectusFiveOneNothing}%
 
 % signs
-\let\gre@char@curlybrace=\grecpCurlyBrace\relax %
-\let\gre@char@barbrace=\grecpBarBrace\relax %
-\let\gre@char@brace=\grecpRoundBrace\relax %
-\let\gre@char@linea=\grecpLinea\relax %
-\let\gre@char@vepisemus=\grecpVEpisemus\relax %
-\let\gre@char@accentus=\grecpAccentus\relax %
-\let\gre@char@semicirculus=\grecpSemicirculus\relax %
-\let\gre@char@circulus=\grecpCirculus\relax %
-\let\gre@char@reversedaccentus=\grecpAccentusReversus\relax %
-\let\gre@char@reversedsemicirculus=\grecpSemicirculusReversus\relax %
+\def\gre@char@curlybrace{\grecpCurlyBrace}%
+\def\gre@char@barbrace{\grecpBarBrace}%
+\def\gre@char@brace{\grecpRoundBrace}%
+\def\gre@char@linea{\grecpLinea}%
+\def\gre@char@vepisemus{\grecpVEpisemus}%
+\def\gre@char@accentus{\grecpAccentus}%
+\def\gre@char@semicirculus{\grecpSemicirculus}%
+\def\gre@char@circulus{\grecpCirculus}%
+\def\gre@char@reversedaccentus{\grecpAccentusReversus}%
+\def\gre@char@reversedsemicirculus{\grecpSemicirculusReversus}%
 
 % horizontal episemus
-\let\gre@char@he@punctum=\grecpHEpisemusPunctum\relax %
-\let\gre@char@he@flexus=\grecpHEpisemusFlexusDeminutus\relax %
-\let\gre@char@he@initio=\grecpHEpisemusDebilis\relax %
-\let\gre@char@he@inclinatum=\grecpHEpisemusInclinatum\relax %
-\let\gre@char@he@inclinatumdem=\grecpHEpisemusInclinatumDeminutus\relax %
-\let\gre@char@he@stropha=\grecpHEpisemusStropha\relax %
-\let\gre@char@he@porrectus@one=\grecpHEpisemusPorrectusOne\relax %
-\let\gre@char@he@porrectus@two=\grecpHEpisemusPorrectusTwo\relax %
-\let\gre@char@he@porrectus@three=\grecpHEpisemusPorrectusThree\relax %
-\let\gre@char@he@porrectus@four=\grecpHEpisemusPorrectusFour\relax %
-\let\gre@char@he@porrectus@five=\grecpHEpisemusPorrectusFive\relax %
-\let\gre@char@he@porrectusfl@one=\grecpHEpisemusPorrectusFlexusOne\relax %
-\let\gre@char@he@porrectusfl@two=\grecpHEpisemusPorrectusFlexusTwo\relax %
-\let\gre@char@he@porrectusfl@three=\grecpHEpisemusPorrectusFlexusThree\relax %
-\let\gre@char@he@porrectusfl@four=\grecpHEpisemusPorrectusFlexusFour\relax %
-\let\gre@char@he@porrectusfl@five=\grecpHEpisemusPorrectusFlexusFive\relax %
-\let\gre@char@he@quilisma=\grecpHEpisemusQuilisma\relax %
-\let\gre@char@he@oriscus=\grecpHEpisemusOriscus\relax %
-\let\gre@char@he@smallpunctum=\grecpHEpisemusHighPes\relax % seems wrong
+\def\gre@char@he@punctum{\grecpHEpisemusPunctum}%
+\def\gre@char@he@flexus{\grecpHEpisemusFlexusDeminutus}%
+\def\gre@char@he@initio{\grecpHEpisemusDebilis}%
+\def\gre@char@he@inclinatum{\grecpHEpisemusInclinatum}%
+\def\gre@char@he@inclinatumdem{\grecpHEpisemusInclinatumDeminutus}%
+\def\gre@char@he@stropha{\grecpHEpisemusStropha}%
+\def\gre@char@he@porrectus@one{\grecpHEpisemusPorrectusOne}%
+\def\gre@char@he@porrectus@two{\grecpHEpisemusPorrectusTwo}%
+\def\gre@char@he@porrectus@three{\grecpHEpisemusPorrectusThree}%
+\def\gre@char@he@porrectus@four{\grecpHEpisemusPorrectusFour}%
+\def\gre@char@he@porrectus@five{\grecpHEpisemusPorrectusFive}%
+\def\gre@char@he@porrectusfl@one{\grecpHEpisemusPorrectusFlexusOne}%
+\def\gre@char@he@porrectusfl@two{\grecpHEpisemusPorrectusFlexusTwo}%
+\def\gre@char@he@porrectusfl@three{\grecpHEpisemusPorrectusFlexusThree}%
+\def\gre@char@he@porrectusfl@four{\grecpHEpisemusPorrectusFlexusFour}%
+\def\gre@char@he@porrectusfl@five{\grecpHEpisemusPorrectusFlexusFive}%
+\def\gre@char@he@quilisma{\grecpHEpisemusQuilisma}%
+\def\gre@char@he@oriscus{\grecpHEpisemusOriscus}%
+\def\gre@char@he@smallpunctum{\grecpHEpisemusHighPes}% seems wrong
 
 \def\greflatchar{\gregoriofont\grecpFlat}%
 \def\greflatholechar{\gregoriofont\grecpFlatHole}%

--- a/tex/gregoriotex-chars.tex
+++ b/tex/gregoriotex-chars.tex
@@ -94,79 +94,98 @@
 \let\gre@char@he@oriscus=\grecpHEpisemusOriscus\relax %
 \let\gre@char@he@smallpunctum=\grecpHEpisemusHighPes\relax % seems wrong
 
-
+\def\greflatchar{\gregoriofont\grecpFlat}%
+\def\greflatholechar{\gregoriofont\grecpFlatHole}%
+\def\grenaturalchar{\gregoriofont\grecpNatural}%
+\def\grenaturalholechar{\gregoriofont\grecpNaturalHole}%
+\def\gresharpchar{\gregoriofont\grecpSharp}%
+\def\gresharpholechar{\gregoriofont\grecpSharpHole}%
+\def\grecclefchar{\gregoriofont\grecpCClef}%
+\def\grefclefchar{\gregoriofont\grecpFClef}%
+\def\greincclefchar{\gregoriofont\grecpCClefChange}%
+\def\greinfclefchar{\gregoriofont\grecpFClefChange}%
+\def\grepunctummorachar{\gregoriofont\grecpAuctumMora}%
+\def\greverticalepisemuschar{\gregoriofont\grecpVEpisemus}%
+\def\grecustotoplongchar{\gregoriofont\grecpCustosUpLong}%
+\def\grecustotopshortchar{\gregoriofont\grecpCustosUpShort}%
+\def\grecustotopmiddlechar{\gregoriofont\grecpCustosUpMedium}%
+\def\grecustobottomlongchar{\gregoriofont\grecpCustosDownLong}%
+\def\grecustobottomshortchar{\gregoriofont\grecpCustosDownShort}%
+\def\grecustobottommiddlechar{\gregoriofont\grecpCustosDownMedium}%
+\def\greabovebarbracechar{\gregoriofont\grecpBarBrace}%
+\def\grepunctumchar{\gregoriofont\grecpPunctum}%
 
 %%%%%%%%%%%%%%%%%
 % macros for the different styles%
 %%%%%%%%%%%%%%%%%
 
 \def\greusedefaultstyle{%
-\xdef\greflatchar{\noexpand\gregoriofont\grecpFlat}%
-\xdef\greflatholechar{\noexpand\gregoriofont\grecpFlatHole}%
-\xdef\grenaturalchar{\noexpand\gregoriofont\grecpNatural}%
-\xdef\grenaturalholechar{\noexpand\gregoriofont\grecpNaturalHole}%
-\xdef\gresharpchar{\noexpand\gregoriofont\grecpSharp}%
-\xdef\gresharpholechar{\noexpand\gregoriofont\grecpSharpHole}%
-\xdef\grecclefchar{\noexpand\gregoriofont\grecpCClef}%
-\xdef\grefclefchar{\noexpand\gregoriofont\grecpFClef}%
-\xdef\greincclefchar{\noexpand\gregoriofont\grecpCClefChange}%
-\xdef\greinfclefchar{\noexpand\gregoriofont\grecpFClefChange}%
-\xdef\grepunctummorachar{\noexpand\gregoriofont\grecpAuctumMora}%
-\xdef\greverticalepisemuschar{\noexpand\gregoriofont\grecpVEpisemus}%
-\xdef\grecustotoplongchar{\noexpand\gregoriofont\grecpCustosUpLong}%
-\xdef\grecustotopshortchar{\noexpand\gregoriofont\grecpCustosUpShort}%
-\xdef\grecustotopmiddlechar{\noexpand\gregoriofont\grecpCustosUpMedium}%
-\xdef\grecustobottomlongchar{\noexpand\gregoriofont\grecpCustosDownLong}%
-\xdef\grecustobottomshortchar{\noexpand\gregoriofont\grecpCustosDownShort}%
-\xdef\grecustobottommiddlechar{\noexpand\gregoriofont\grecpCustosDownMedium}%
-\xdef\greabovebarbracechar{\noexpand\gregoriofont\grecpBarBrace}%
-\xdef\grepunctumchar{\noexpand\gregoriofont\grecpPunctum}%
+\greresetglyph{Flat}%
+\greresetglyph{FlatHole}%
+\greresetglyph{Natural}%
+\greresetglyph{NaturalHole}%
+\greresetglyph{Sharp}%
+\greresetglyph{SharpHole}%
+\greresetglyph{CClef}%
+\greresetglyph{FClef}%
+\greresetglyph{CClefChange}%
+\greresetglyph{FClefChange}%
+\greresetglyph{AuctumMora}%
+\greresetglyph{VEpisemus}%
+\greresetglyph{CustosUpLong}%
+\greresetglyph{CustosUpShort}%
+\greresetglyph{CustosUpMedium}%
+\greresetglyph{CustosDownLong}%
+\greresetglyph{CustosDownShort}%
+\greresetglyph{CustosDownMedium}%
+\greresetglyph{BarBrace}%
+\greresetglyph{Punctum}%
 \relax %
 }%
 
 \def\greusemedicaeastyle{%
-\greusestylecommon %
-\gredefvariant{grecustotoplongchar}{greextra}{MedicaeaCustosUpLong}%
-\gredefvariant{grecustotopshortchar}{greextra}{MedicaeaCustosUpShort}%
-\gredefvariant{grecustotopmiddlechar}{greextra}{MedicaeaCustosUpMedium}%
-\gredefvariant{grecustobottomlongchar}{greextra}{MedicaeaCustosDownLong}%
-\gredefvariant{grecustobottomshortchar}{greextra}{MedicaeaCustosDownShort}%
-\gredefvariant{grecustobottommiddlechar}{greextra}{MedicaeaCustosDownMedium}%
-\gredefvariant{grecclefchar}{greextra}{MedicaeaCClef}%
-\gredefvariant{grefclefchar}{greextra}{MedicaeaFClef}%
-\gredefvariant{greincclefchar}{greextra}{MedicaeaCClefChange}%
-\gredefvariant{greinfclefchar}{greextra}{MedicaeaFClefChange}%
-\gredefvariant{greflatchar}{greextra}{MedicaeaFlat}%
-\gredefvariant{greflatholechar}{greextra}{MedicaeaFlatHole}%
+\greusedefaultstyle\greusestylecommon %
+\grechangeglyph{CustosUpLong}{greextra}{MedicaeaCustosUpLong}%
+\grechangeglyph{CustosUpShort}{greextra}{MedicaeaCustosUpShort}%
+\grechangeglyph{CustosUpMedium}{greextra}{MedicaeaCustosUpMedium}%
+\grechangeglyph{CustosDownLong}{greextra}{MedicaeaCustosDownLong}%
+\grechangeglyph{CustosDownShort}{greextra}{MedicaeaCustosDownShort}%
+\grechangeglyph{CustosDownMedium}{greextra}{MedicaeaCustosDownMedium}%
+\grechangeglyph{CClef}{greextra}{MedicaeaCClef}%
+\grechangeglyph{FClef}{greextra}{MedicaeaFClef}%
+\grechangeglyph{CClefChange}{greextra}{MedicaeaCClefChange}%
+\grechangeglyph{FClefChange}{greextra}{MedicaeaFClefChange}%
+\grechangeglyph{Flat}{greextra}{MedicaeaFlat}%
+\grechangeglyph{FlatHole}{greextra}{MedicaeaFlatHole}%
 \relax %
 }%
 
 \def\greusehufnagelstyle{%
-\greusestylecommon %
-\gredefvariant{grecustotoplongchar}{greextra}{HufnagelCustosUpLong}%
-\gredefvariant{grecustotopshortchar}{greextra}{HufnagelCustosUpShort}%
-\gredefvariant{grecustotopmiddlechar}{greextra}{HufnagelCustosUpMedium}%
-\gredefvariant{grecustobottomlongchar}{greextra}{HufnagelCustosDownLong}%
-\gredefvariant{grecustobottomshortchar}{greextra}{HufnagelCustosDownShort}%
-\gredefvariant{grecustobottommiddlechar}{greextra}{HufnagelCustosDownMedium}%
-\gredefvariant{grecclefchar}{greextra}{HufnagelCClef}%
-\gredefvariant{grefclefchar}{greextra}{HufnagelFClef}%
-\gredefvariant{greincclefchar}{greextra}{HufnagelCClefChange}%
-\gredefvariant{greinfclefchar}{greextra}{HufnagelFClefChange}%
-\gredefvariant{greflatchar}{greextra}{HufnagelFlat}%
-\gredefvariant{greflatholechar}{greextra}{HufnagelFlatHole}%
+\greusedefaultstyle\greusestylecommon %
+\grechangeglyph{CustosUpLong}{greextra}{HufnagelCustosUpLong}%
+\grechangeglyph{CustosUpShort}{greextra}{HufnagelCustosUpShort}%
+\grechangeglyph{CustosUpMedium}{greextra}{HufnagelCustosUpMedium}%
+\grechangeglyph{CustosDownLong}{greextra}{HufnagelCustosDownLong}%
+\grechangeglyph{CustosDownShort}{greextra}{HufnagelCustosDownShort}%
+\grechangeglyph{CustosDownMedium}{greextra}{HufnagelCustosDownMedium}%
+\grechangeglyph{CClef}{greextra}{HufnagelCClef}%
+\grechangeglyph{FClef}{greextra}{HufnagelFClef}%
+\grechangeglyph{CClefChange}{greextra}{HufnagelCClefChange}%
+\grechangeglyph{FClefChange}{greextra}{HufnagelFClefChange}%
+\grechangeglyph{Flat}{greextra}{HufnagelFlat}%
+\grechangeglyph{FlatHole}{greextra}{HufnagelFlatHole}%
 \relax %
 }%
 
 \def\greusemensuralstyle{%
-\greusestylecommon %
-\gredefvariant{grecustotoplongchar}{greextra}{MensuralCustosUpLong}%
-\gredefvariant{grecustotopshortchar}{greextra}{MensuralCustosUpShort}%
-\gredefvariant{grecustotopmiddlechar}{greextra}{MensuralCustosUpMedium}%
-\gredefvariant{grecustobottomlongchar}{greextra}{MensuralCustosDownLong}%
-\gredefvariant{grecustobottomshortchar}{greextra}{MensuralCustosDownShort}%
-\gredefvariant{grecustobottommiddlechar}{greextra}{MensuralCustosDownMedium}%
-\gredefvariant{greflatchar}{greextra}{MensuralFlat}%
-\gredefvariant{greflatholechar}{greextra}{MensuralFlatHole}%
+\greusedefaultstyle\greusestylecommon %
+\grechangeglyph{CustosUpLong}{greextra}{MensuralCustosUpLong}%
+\grechangeglyph{CustosUpShort}{greextra}{MensuralCustosUpShort}%
+\grechangeglyph{CustosUpMedium}{greextra}{MensuralCustosUpMedium}%
+\grechangeglyph{CustosDownLong}{greextra}{MensuralCustosDownLong}%
+\grechangeglyph{CustosDownShort}{greextra}{MensuralCustosDownShort}%
+\grechangeglyph{CustosDownMedium}{greextra}{MensuralCustosDownMedium}%
+\grechangeglyph{Flat}{greextra}{MensuralFlat}%
+\grechangeglyph{FlatHole}{greextra}{MensuralFlatHole}%
 \relax %
 }%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -663,6 +663,23 @@
   \relax %
 }%
 
+% Macros for using variant glyphs
+
+% Changes a gregorio code point to a variant glyph
+% #1 = the name of the gregorio code point
+% #2 = font name
+% #3 = glyph name, glyph variant name (preceded by .), or code point
+\def\grechangeglyph#1#2#3{%
+  \directlua{gregoriotex.init_variant_font([[#2]],true)}%
+  \directlua{gregoriotex.change_score_glyph([[#1]],[[#2]],[[#3]])}%
+}%
+
+% Resets a gregorio code point to its default setting
+% #1 = the name of the gregorio code point
+\def\greresetglyph#1{%
+  \directlua{gregoriotex.reset_score_glyph([[#1]])}%
+}%
+
 {%
   \directlua{gregoriotex.init_variant_font('greciliae', true)}%
   \directlua{gregoriotex.map_font('greciliae', 'cp')}%
@@ -1377,32 +1394,6 @@
 % the gtex file will be forced into the document and will not be
 % checked by the lua function 'include_score'. This does not bypass
 % the API version test done by '\gregoriotexapiversion'.
-
-% Macros for using variant glyphs
-
-% Defines a variant into the given control sequence name
-% #1 = control sequence name
-% #2 = font name
-% #3 = glyph name or code point
-\def\gredefvariant#1#2#3{%
-  \directlua{gregoriotex.init_variant_font([[#2]],true)}%
-  \directlua{gregoriotex.def_score_glyph([[#1]],[[#2]],[[#3]])}%
-}%
-
-% Changes a gregorio code point to a variant glyph
-% #1 = the name of the gregorio code point
-% #2 = font name
-% #3 = glyph name, glyph variant name (preceded by .), or code point
-\def\grechangeglyph#1#2#3{%
-  \directlua{gregoriotex.init_variant_font([[#2]],true)}%
-  \directlua{gregoriotex.change_score_glyph([[#1]],[[#2]],[[#3]])}%
-}%
-
-% Resets a gregorio code point to its default setting
-% #1 = the name of the gregorio code point
-\def\greresetglyph#1{%
-  \directlua{gregoriotex.reset_score_glyph([[#1]])}%
-}%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% some hyphen definitions

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1676,23 +1676,26 @@
 %% macros for typesetting punctum cavum
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\def\grepunctumcavumchar{\gregoriofont\gre@char@punctumcavum}%
+\def\grelineapunctumcavumchar{\gregoriofont\gre@char@lineapunctumcavum}%
+\def\grepunctumcavumholechar{\gregoriofont\gre@char@punctumcavumhole}%
+\def\grelineapunctumcavumholechar{\gregoriofont\gre@char@lineapunctumcavumhole}%
+
 \def\UseAlternatePunctumCavum{%
-\gredefvariant{grepunctumcavumchar}{greciliae}{PunctumCavum.caeciliae}%
-\gredefvariant{grelineapunctumcavumchar}{greciliae}{LineaPunctumCavum.caeciliae}%
-\gredefvariant{grepunctumcavumholechar}{greciliae}{PunctumCavumHole.caeciliae}%
-\gredefvariant{grelineapunctumcavumholechar}{greciliae}{LineaPunctumCavumHole.caeciliae}%
+\grechangeglyph{PunctumCavum}{greciliae}{PunctumCavum.caeciliae}%
+\grechangeglyph{LineaPunctumCavum}{greciliae}{LineaPunctumCavum.caeciliae}%
+\grechangeglyph{PunctumCavumHole}{greciliae}{PunctumCavumHole.caeciliae}%
+\grechangeglyph{LineaPunctumCavumHole}{greciliae}{LineaPunctumCavumHole.caeciliae}%
 \relax %
 }%
 
 \def\UseNormalPunctumCavum{%
-\gdef\grepunctumcavumchar{\gregoriofont\gre@char@punctumcavum}%
-\gdef\grelineapunctumcavumchar{\gregoriofont\gre@char@lineapunctumcavum}%
-\gdef\grepunctumcavumholechar{\gregoriofont\gre@char@punctumcavumhole}%
-\gdef\grelineapunctumcavumholechar{\gregoriofont\gre@char@lineapunctumcavumhole}%
+\greresetglyph{PunctumCavum}%
+\greresetglyph{LineaPunctumCavum}%
+\greresetglyph{PunctumCavumHole}%
+\greresetglyph{LineaPunctumCavumHole}%
 \relax %
 }%
-
-\UseNormalPunctumCavum%
 
 \def\grepunctumcavum#1#2#3#4#5{%
   \setbox\GreTempwidth=\hbox{\grepunctumcavumchar}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1682,10 +1682,10 @@
 \def\grelineapunctumcavumholechar{\gregoriofont\gre@char@lineapunctumcavumhole}%
 
 \def\UseAlternatePunctumCavum{%
-\grechangeglyph{PunctumCavum}{greciliae}{PunctumCavum.caeciliae}%
-\grechangeglyph{LineaPunctumCavum}{greciliae}{LineaPunctumCavum.caeciliae}%
-\grechangeglyph{PunctumCavumHole}{greciliae}{PunctumCavumHole.caeciliae}%
-\grechangeglyph{LineaPunctumCavumHole}{greciliae}{LineaPunctumCavumHole.caeciliae}%
+\grechangeglyph{PunctumCavum}{greciliae}{.caeciliae}%
+\grechangeglyph{LineaPunctumCavum}{greciliae}{.caeciliae}%
+\grechangeglyph{PunctumCavumHole}{greciliae}{.caeciliae}%
+\grechangeglyph{LineaPunctumCavumHole}{greciliae}{.caeciliae}%
 \relax %
 }%
 

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -366,16 +366,13 @@ local function def_glyph(csname, font_name, glyph, font_table, setter)
   setter(csname, font_csname, char)
 end
 
-local function def_score_glyph(csname, font_name, glyph)
-  def_glyph(csname, font_name, glyph, score_fonts, set_score_glyph)
-end
-
 local function change_single_score_glyph(glyph_name, font_name, replacement)
   if font_name == '*' then
     def_glyph('grecp'..glyph_name, 'greciliae', replacement, score_fonts,
         set_common_score_glyph)
   else
-    def_score_glyph('grecp'..glyph_name, font_name, replacement)
+    def_glyph('grecp'..glyph_name, font_name, replacement, score_fonts,
+        set_score_glyph)
   end
 end
 
@@ -455,7 +452,6 @@ gregoriotex.check_font_version   = check_font_version
 gregoriotex.get_gregorioversion  = get_gregorioversion
 gregoriotex.map_font             = map_font
 gregoriotex.init_variant_font    = init_variant_font
-gregoriotex.def_score_glyph      = def_score_glyph
 gregoriotex.change_score_glyph   = change_score_glyph
 gregoriotex.reset_score_glyph    = reset_score_glyph
 gregoriotex.scale_score_fonts    = scale_score_fonts


### PR DESCRIPTION
Fixes #357

Additionally, I found an issue using the `Circumflexus` (now `VEpisemus.circumflexus`) because of the need to redefine macros created by the `\gredefvariant` macro in addition to using `\grechangeglyph`.  I eliminated `\gredefvariant` and now everything should be done strictly through `\grechangeglyph`.