### PR TITLE
Have \gabcsnippet work in restricted \write18 mode

### DIFF
--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -281,24 +281,18 @@ local function include_score(input_file, force_gabccompile)
 end
 
 local function direct_gabc(gabc, header)
-  local gabccode = 'name:direct-gabc;\n'..(header or '')..'\n%%%%\n'..gabc
-  local f = io.popen('echo "'..gabccode..'" | gregorio -sS', 'r')
-  -- In shell-restricted mode, with gregorio (and even echo) allowed,
-  -- the previous command doesn't work ; in that case, use a temporary file.
-  if f == nil then
-    tmpname = os.tmpname()
-    local p = io.popen('gregorio -s -o '..tmpname, 'w')
-    if p == nil then
-      err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname..".\n"
-      .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
-    end
-    p:write(gabccode)
-    p:close()
-    f = io.open(tmpname)
+  tmpname = os.tmpname()
+  local p = io.popen('gregorio -s -o '..tmpname, 'w')
+  if p == nil then
+    err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname..".\n"
+    .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
   end
+  p:write('name:direct-gabc;\n'..(header or '')..'\n%%%%\n'..gabc)
+  p:close()
+  f = io.open(tmpname)
   tex.print(f:read("*a"):explode('\n'))
   f:close()
-  if tmpname then os.remove(tmpname) end
+  os.remove(tmpname)
 end
 
 local function check_font_version()

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -288,6 +288,10 @@ local function direct_gabc(gabc, header)
   if f == nil then
     tmpname = os.tmpname()
     local p = io.popen('gregorio -s -o '..tmpname, 'w')
+    if p == nil then
+      err("\nSomething went wrong when executing\n    'gregorio -sS'.\n"
+      .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
+    end
     p:write('name:tmp;\n%%%%\n'..entree)
     p:close()
     f = io.open(tmpname)

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -286,15 +286,15 @@ local function direct_gabc(gabc, header)
   -- In shell-restricted mode, with gregorio (and even echo) allowed,
   -- the previous command doesn't work ; in that case, use a temporary file.
   if f == nil then
-    local tmpname = os.tmpname()..'.gabc'
-    local tmp = io.open(tmpname, 'w')
-    tmp:write(gabccode)
-    tmp:close()
-    tex.print('\\input{|"gregorio -S '..tmpname..'"}')
-  else
-    tex.print(f:read("*a"):explode('\n'))
-    f:close()
+    tmpname = os.tmpname()
+    local p = io.popen('gregorio -s -o '..tmpname, 'w')
+    p:write('name:tmp;\n%%%%\n'..entree)
+    p:close()
+    f = io.open(tmpname)
   end
+  tex.print(f:read("*a"):explode('\n'))
+  f:close()
+  if tmpname then os.remove(tmpname) end
 end
 
 local function check_font_version()

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -292,7 +292,7 @@ local function direct_gabc(gabc, header)
       err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname".\n"
       .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
     end
-    p:write('name:tmp;\n%%%%\n'..entree)
+    p:write('name:tmp;\n%%%%\n'..gabccode)
     p:close()
     f = io.open(tmpname)
   end

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -289,7 +289,7 @@ local function direct_gabc(gabc, header)
     tmpname = os.tmpname()
     local p = io.popen('gregorio -s -o '..tmpname, 'w')
     if p == nil then
-      err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname".\n"
+      err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname..".\n"
       .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
     end
     p:write(gabccode)

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -289,7 +289,7 @@ local function direct_gabc(gabc, header)
     tmpname = os.tmpname()
     local p = io.popen('gregorio -s -o '..tmpname, 'w')
     if p == nil then
-      err("\nSomething went wrong when executing\n    'gregorio -sS'.\n"
+      err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname".\n"
       .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
     end
     p:write('name:tmp;\n%%%%\n'..entree)

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -292,7 +292,7 @@ local function direct_gabc(gabc, header)
       err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname".\n"
       .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
     end
-    p:write('name:tmp;\n%%%%\n'..gabccode)
+    p:write(gabccode)
     p:close()
     f = io.open(tmpname)
   end


### PR DESCRIPTION
In shell-restricted mode, even when `echo` and `gregorio` are allowed, direct use of
gregorio with `io.popen` doesn't work ; this change makes use of a temporary file in that case.

There is a problem though : I don't know how to remove the temporary file after passing `'\\input{|"gregorio -S '..tmpname..'"}'` to the tex document ; if I put `os.remove(tmpname)` just after `tex.print` (line 293), it seems it's removed "too quick".