### PR TITLE
Fix for #70 and some porrectus episemus bugfixes

### DIFF
--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -503,26 +503,34 @@ def hepisemus(widths):
     write_hepisemus(widths, get_width(widths, 'PunctumLineTR'), 'HEpisemusPunctumLineTR')
     write_hepisemus(widths, get_width(widths, 'PunctumLineBLBR'), 'HEpisemusPunctumLineBLBR')
     write_hepisemus(widths, get_width(widths, 'PunctumAuctusLineBL'), 'HEpisemusPunctumAuctusLineBL')
+    reduction = 0.75 * get_width(widths, 'Punctum')
     for i in range(1, MAX_INTERVAL+1):
-        write_hepisemus(widths, get_width(widths, "porrectus%d"%i), 'HEpisemusPorrectus%s' % AMBITUS[i])
+        write_hepisemus(widths, get_width(widths, "porrectus%d"%i),
+                'HEpisemusPorrectus%s' % AMBITUS[i], reduction)
     for i in range(1, MAX_INTERVAL+1):
         if glyph_exists("porrectusam1%d"%i, oldfont):
-            write_hepisemus(widths, get_width(widths, "porrectusam1%d"%i), 'HEpisemusPorrectusAmOne%s' % AMBITUS[i])
+            write_hepisemus(widths, get_width(widths, "porrectusam1%d"%i),
+                    'HEpisemusPorrectusAmOne%s' % AMBITUS[i], reduction)
         else:
-            write_hepisemus(widths, get_width(widths, "porrectus%d"%i), 'HEpisemusPorrectusAmOne%s' % AMBITUS[i])
+            write_hepisemus(widths, get_width(widths, "porrectus%d"%i),
+                    'HEpisemusPorrectusAmOne%s' % AMBITUS[i], reduction)
+    # porrectus flexus does not get reduced because the note after is to the right
     for i in range(1, MAX_INTERVAL+1):
-        write_hepisemus(widths, get_width(widths, "porrectusflexus%d"%i), 'HEpisemusPorrectusFlexus%s' % AMBITUS[i])
+        write_hepisemus(widths, get_width(widths, "porrectusflexus%d"%i),
+                'HEpisemusPorrectusFlexus%s' % AMBITUS[i])
 
-def write_hepisemus(widths, shape_width, glyphname):
+def write_hepisemus(widths, shape_width, glyphname, reduction=0):
     "Writes the horizontal episemus glyphs."
     global HEPISEMUS_ADDITIONAL_WIDTH
     new_glyph()
     simple_paste("hepisemus_base")
-    scale(shape_width + 2*HEPISEMUS_ADDITIONAL_WIDTH, 1)
+    drawn_width = shape_width - reduction
+    scale(drawn_width + 2*HEPISEMUS_ADDITIONAL_WIDTH, 1)
     move(-HEPISEMUS_ADDITIONAL_WIDTH, 0)
     paste_and_move("hepisemusleft", -HEPISEMUS_ADDITIONAL_WIDTH, 0)
     paste_and_move("hepisemusright",
-                   shape_width + HEPISEMUS_ADDITIONAL_WIDTH, 0)
+                   drawn_width + HEPISEMUS_ADDITIONAL_WIDTH, 0)
+    # use the original width for the glyph for the sake of ledger lines
     set_width(shape_width)
     end_glyph(glyphname)
 

--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -503,7 +503,7 @@ def hepisemus(widths):
     write_hepisemus(widths, get_width(widths, 'PunctumLineTR'), 'HEpisemusPunctumLineTR')
     write_hepisemus(widths, get_width(widths, 'PunctumLineBLBR'), 'HEpisemusPunctumLineBLBR')
     write_hepisemus(widths, get_width(widths, 'PunctumAuctusLineBL'), 'HEpisemusPunctumAuctusLineBL')
-    reduction = 0.75 * get_width(widths, 'Punctum')
+    reduction = get_width(widths, 'PunctumSmall')
     for i in range(1, MAX_INTERVAL+1):
         write_hepisemus(widths, get_width(widths, "porrectus%d"%i),
                 'HEpisemusPorrectus%s' % AMBITUS[i], reduction)

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1638,8 +1638,7 @@ static inline void number_note_before_last_note(gregorio_glyph *current_glyph,
 static inline void number_last_note(gregorio_glyph *current_glyph, char *number,
         char num)
 {
-    if (current_glyph->u.notes.liquescentia == L_DEMINUTUS_INITIO_DEBILIS
-            || current_glyph->u.notes.liquescentia == L_DEMINUTUS) {
+    if (current_glyph->u.notes.liquescentia & L_DEMINUTUS) {
         /*
          * may seem strange, but it is unlogical to typeset a small horizontal
          * episemus at the end of a flexus deminutus 
@@ -1702,6 +1701,23 @@ static inline void normal_height_top(gtex_sign_type sign_type,
     }
 }
 
+// for the last note in a porrectus or torculus resupinus
+static inline void normal_height_ending_porrectus(gtex_sign_type sign_type,
+        gregorio_note *current_note, char *height)
+{
+    if (sign_type == ST_H_EPISEMUS) {
+        if (current_note->previous && current_note->previous->h_episemus_type
+                && current_note->previous->previous
+                && current_note->previous->previous->h_episemus_type) {
+            *height = current_note->h_episemus_top_note + 1;
+        } else {
+            *height = current_note->u.note.pitch + 1;
+        }
+    } else {
+        *height = current_note->u.note.pitch + 2;
+    }
+}
+
 // case of one note and then one lower, when the sign is on the first
 static inline void height_layered_notes(gtex_sign_type sign_type,
         gregorio_note *current_note, char *height)
@@ -1736,6 +1752,26 @@ static inline void normal_height_bottom(gtex_sign_type sign_type,
                 && (!current_note->next
                         || simple_htype(current_note->next->h_episemus_type) ==
                         H_NO_EPISEMUS)) {
+            *height = current_note->u.note.pitch - 1;
+            if (bottom) {
+                *bottom = true;
+            }
+        } else {
+            *height = current_note->h_episemus_top_note + 1;
+        }
+    } else {
+        *height = current_note->u.note.pitch - 1;
+    }
+}
+
+// for the bottom note of a porrectus or the "porrectus part" of a torculus resupinus
+static inline void normal_height_bottom_porrectus(gtex_sign_type sign_type,
+        gregorio_note *current_note, char *height, bool * bottom)
+{
+    if (sign_type == ST_H_EPISEMUS) {
+        if ((!current_note->previous
+                        || simple_htype(current_note->previous->
+                                h_episemus_type) == H_NO_EPISEMUS)) {
             *height = current_note->u.note.pitch - 1;
             if (bottom) {
                 *bottom = true;
@@ -1979,6 +2015,7 @@ static void gregoriotex_find_sign_number(gregorio_glyph *current_glyph,
         }
         break;
     case T_TORCULUS_RESUPINUS:
+        done = true;
         switch (i) {
         case 1:
             if (current_glyph->u.notes.liquescentia >= L_INITIO_DEBILIS) {
@@ -2099,26 +2136,16 @@ static void gregoriotex_find_sign_number(gregorio_glyph *current_glyph,
                 normal_height_long_first(sign_type, current_note, height);
             }
             break;
-        case 3:
-            // you might think number_note_before_last_note more appropriate,
-            // but 
-            // in the current fonts the third note of the torculus resupinus
-            // is v aligned with the last note
-            number_last_note(current_glyph, number, 18);
-            if (current_glyph->u.notes.liquescentia ==
-                    L_DEMINUTUS_INITIO_DEBILIS
-                    || current_glyph->u.notes.liquescentia == L_DEMINUTUS) {
-                height_layered_notes(sign_type, current_note, height);
-            } else {
-                normal_height_bottom(sign_type, current_note, height, bottom);
-            }
-            break;
         default:
-            number_last_note(current_glyph, number, 18);
-            normal_height_top(sign_type, current_note, height);
+            --i;
+            done = false;
             break;
         }
-        break;
+
+        if (done) {
+            break;
+        }
+        // else fallthrough to the next case!
     case T_PORRECTUS:
         switch (i) {
         case HEPISEMUS_FIRST_TWO:
@@ -2151,20 +2178,27 @@ static void gregoriotex_find_sign_number(gregorio_glyph *current_glyph,
             }
             break;
         case 2:
-            if ((current_glyph->u.notes.liquescentia ==
-                            L_DEMINUTUS_INITIO_DEBILIS
-                            || current_glyph->u.notes.liquescentia ==
-                            L_DEMINUTUS)
-                    && current_note->next) {
+            if (current_glyph->u.notes.liquescentia & L_DEMINUTUS) {
                 *number = 3;
+            } else if (current_glyph->u.notes.liquescentia
+                    & (L_AUCTUS_ASCENDENS|L_AUCTUS_DESCENDENS|L_AUCTA)) {
+                *number = 2;
             } else {
                 *number = 0;
             }
-            normal_height_bottom(sign_type, current_note, height, bottom);
+            normal_height_bottom_porrectus(sign_type, current_note, height, bottom);
             break;
         default:               // case 3
-            number_last_note(current_glyph, number, 18);
-            normal_height_top(sign_type, current_note, height);
+            if (current_glyph->u.notes.liquescentia == L_DEMINUTUS
+                    && current_note->previous->h_episemus_type
+                    && current_note->previous->previous->h_episemus_type) {
+                // if the previous note had an episemus, make this one a
+                // full sized episemus so that it melts into the previous
+                *number = 0;
+            } else {
+                number_last_note(current_glyph, number, 18);
+            }
+            normal_height_ending_porrectus(sign_type, current_note, height);
             break;
         }
         break;
@@ -3060,8 +3094,6 @@ static void gregoriotex_write_signs(FILE *f, gtex_type type,
                     current_note->next->h_episemus_top_note =
                             current_note->next->next->u.note.pitch;
                 }
-                // prevents additional useless episemus
-                current_note->next->next->h_episemus_type = H_NO_EPISEMUS;
                 gregoriotex_write_hepisemus(f, glyph, element,
                         HEPISEMUS_FIRST_TWO, type, current_note);
                 block_hepisemus = 1;
@@ -3080,8 +3112,6 @@ static void gregoriotex_write_signs(FILE *f, gtex_type type,
                         current_note->next->h_episemus_top_note =
                                 current_note->next->next->u.note.pitch;
                     }
-                    // prevents additional useless episemus
-                    current_note->next->next->h_episemus_type = H_NO_EPISEMUS;
                     gregoriotex_write_hepisemus(f, glyph, element,
                             HEPISEMUS_FIRST_TWO, type, current_note);
                     block_hepisemus = 1;

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1803,6 +1803,37 @@ static inline void normal_height_bottom_pes(gtex_sign_type sign_type,
 // hepisemus) number, according to the gregoriotex convention (described in
 // gregoriotex.tex)
 // this function is REALLY a pain in the ass, but it is sadly necessary
+/*
+ *
+ * For the first note of a porrectus (flexus), this table summarizes the sign
+ * number (amb2 is the ambitus after the diagonal stroke):
+ *
+ *  Porrectus  | Porrectus  | Porrectus | Porrectus
+ *  non-auctus | non-auctus | auctus    | Flexus
+ *  amb2=1     | amb2>1     |           |
+ * ------------+------------+-----------+-----------
+ *  9          | 8          | 10        | 10
+ *
+ * For the second note of a torculus resupinus (flexus), this table summarizes
+ * the number (amb1 is the ambitus before the diagonal stroke and amb2 is the
+ * ambitus after the diagonal stroke):
+ *
+ *                      | Torculus   | Torculus   | Torculus  | Torculus
+ *                      | Resupinus  | Resupinus  | Resupinus | Resupinus
+ *                      | non-auctus | non-auctus | auctus    | Flexus
+ *                      | amb2=1     | amb2>1     |           |
+ * --------+------------+------------+------------+-----------+-----------
+ *  amb1=1 | Punctum    | 36         | 22         | 43        | 43
+ *  amb1=1 | I. Debilis | 33         | 23         | 40        | 40
+ *  amb1=1 | Quilisma   | 37         | 30         | 44        | 44
+ *  amb1=1 | Oriscus    | 38         | 31         | 45        | 45
+ * --------+------------+------------+------------+-----------+-----------
+ *  amb1>1 | Punctum    | 32         | 21         | 39        | 39
+ *  amb1>1 | I. Debilis | 33         | 23         | 40        | 40
+ *  amb1>1 | Quilisma   | 34         | 28         | 41        | 41
+ *  amb1>1 | Oriscus    | 35         | 29         | 42        | 42
+ *
+ */
 static void gregoriotex_find_sign_number(gregorio_glyph *current_glyph,
         int i, gtex_type type, gtex_sign_type sign_type,
         gregorio_note *current_note, char *number, char *height, bool * bottom)


### PR DESCRIPTION
These are two commits primarily to address #70.

While testing, I noticed some weirdness with the heights of horizontal episemus decorating porrectus and torculus resupinus figures.  See the following tests in gregorio-tests to see the difference:

- gabc-output/glyphs/torculus_resupinus_quilisma.gabc
- gabc-output/glyphs/porrectus.gabc
- gabc-output/glyphs/torculus_resupinus.gabc
- gabc-output/glyphs/torculus_resupinus_flexus.gabc

I made some semi-educated decisions around positioning the episemus on the final two notes of a porrectus or torculus resupinus, which may be wrong, so please review these changes carefully before accepting them, and please let me know if I should change anything.

A few notes:
- The widths of the porrectus and ambitus-one porrectus episemus glyphs are the same as they were, but the figure within the glyph is reduced horizontally by the size of `PunctumSmall` and left-aligned.  This is the essential fix for #70.  I did this so that thee calculations for what modern notation calls ledger lines will be correct.
- In the same way that torculus resupinus flexus falls through into porrectus flexus (in the C switch statement), torculus resupinus now falls through into porrectus.  Thus the tail handling (of the "porrectus part") should be identical.
- In the "porrectus part" of high-low-high, if the episemus is on the low note, it will always be below and right-aligned with the vertical stem unless there is also an episemus on the first high note.  Auctus figures (with the head to the right of the stem) should now be taken into account correctly.
- If the all three notes of a "porrectus part" have episema and the final high note is a deminutus, it will draw a punctum-sized episemus to ensure that the episema melt together properly.
- There are still some anomlies like `(d_h_g_j)`: the height of the episemus above `hg` is in a different place than the episemus above `d`.  In the older code, the episema would be at same height, but actually end up below the `i` note.  I will look into this on another day unless someone beats me to it.