### PR TITLE
Fix when two consecutive newlines in gabcsnippet

### DIFF
--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -287,7 +287,7 @@ local function direct_gabc(gabc, header)
     err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname..".\n"
     .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
   end
-  p:write('name:direct-gabc;\n'..(header or '')..'\n%%%%\n'..gabc)
+  p:write('name:direct-gabc;\n'..(header or '')..'\n%%%%\n'..gabc:gsub('\\par ', '\n'))
   p:close()
   f = io.open(tmpname)
   tex.print(f:read("*a"):explode('\n'))


### PR DESCRIPTION
When there are two consecutive newlines in gabcsnippet, they're translated to `\par` before going to lua.

This corrects that by replacing `\par` by `\n`.