### PR TITLE
Added missing virga character reference and episemus.

### DIFF
--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -519,6 +519,7 @@ def hepisemus(widths):
     write_hepisemus(widths, get_width(widths, 'QuilismaLineTR'), 'HEpisemusQuilismaLineTR')
     write_hepisemus(widths, get_width(widths, 'PunctumSmall'), 'HEpisemusHighPes')
     write_hepisemus(widths, get_width(widths, 'Oriscus'), 'HEpisemusOriscus')
+    write_hepisemus(widths, get_width(widths, 'Virga'), 'HEpisemusVirga')
     write_hepisemus(widths, get_width(widths, 'VirgaLineBR'), 'HEpisemusVirgaLineBR')
     write_hepisemus(widths, get_width(widths, 'OriscusLineTR'), 'HEpisemusOriscusLineTR')
     write_hepisemus(widths, get_width(widths, 'PunctumLineBR'), 'HEpisemusPunctumLineBR')

--- a/tex/gregoriotex-chars.tex
+++ b/tex/gregoriotex-chars.tex
@@ -46,6 +46,7 @@
 \def\gre@char@punctuminclinatumdem{\grecpPunctumInclinatumAuctus}%
 \def\gre@char@lineapunctum{\grecpLineaPunctum}%
 \def\gre@char@peshigh{\grecpPunctumSmall}%
+\def\gre@char@virga{\grecpVirga}%
 \def\gre@char@virgaaucta{\grecpVirgaReversaDescendens}%
 \def\gre@char@punctum@line@br{\grecpPunctumLineBR}%
 \def\gre@char@punctum@line@tr{\grecpPunctumLineTR}%
@@ -112,6 +113,7 @@
 \def\gre@char@he@punctumauctus@line@bl{\grecpHEpisemusPunctumAuctusLineBL}%
 \def\gre@char@he@flexus{\grecpHEpisemusFlexusDeminutus}%
 \def\gre@char@he@initio{\grecpHEpisemusDebilis}%
+\def\gre@char@he@virga{\grecpHEpisemusVirga}%
 \def\gre@char@he@virga@line@br{\grecpHEpisemusVirgaLineBR}%
 \def\gre@char@he@inclinatum{\grecpHEpisemusInclinatum}%
 \def\gre@char@he@inclinatumdem{\grecpHEpisemusInclinatumDeminutus}%


### PR DESCRIPTION
The virga character reference and corresponding horizontal episemus were missing from #375.

@eroux I will merge this so that I can continue working, but please review it and correct it if necessary.