### PR TITLE
Increase default intersyllablespacenotes

### DIFF
--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -112,7 +112,7 @@
 \gresetdim{interwordspacenotes}{0.27 cm plus 0.15 cm minus 0.05 cm}{1}%
 % minimal space between notes of the same syllable.
 % Warning: always keep minus to 0; also keep plus very low, or some words won't be hyphenated
-\gresetdim{intersyllablespacenotes}{0.17 cm plus 0.04cm minus 0cm}{1}%
+\gresetdim{intersyllablespacenotes}{0.24 cm plus 0.04cm minus 0cm}{1}%
 % minimal space between letters of different words. Makes sense to have
 % the same plus and minus as interwordspacenotes.
 \gresetdim{interwordspacetext}{0.38 cm plus 0.15 cm minus 0.05 cm}{1}%


### PR DESCRIPTION
With 0.17 cm, spaces inter syllables are sometimes too small. Here, 0.24 cm is suggested.