### PR TITLE
Fixed make distcheck.  Fixes #412.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -18,29 +18,27 @@
 # GregorioRef.tex must be the first source file
 SRCFILES = GregorioRef.tex Command_Index_gregorio.tex \
 		   Command_Index_internal.tex Command_Index_User.tex \
-		   Appendix_Font_Tables.tex GregorioRef.lua
-NABCSRCFILES = GregorioNabcRef.tex ../examples/FactusEst.gabc
+		   Appendix_Font_Tables.tex GregorioRef.lua factus.gabc
+NABCSRCFILES = GregorioNabcRef.tex veni.gabc
 
-GregorioRef-@FILENAME_VERSION@.pdf: $(SRCFILES) factus.gtex
+# I know these rules looks wrong, but they must not depend on anything that
+# gets generated or make distcheck will fail.
+
+GregorioRef-@FILENAME_VERSION@.pdf: $(SRCFILES)
+	make -C ../src gregorio
+	../src/gregorio -o factus.gtex $(<D)/factus.gabc
 	TEXINPUTS=$(<D):$(<D)/../tex: LUAINPUTS=$(<D):$(<D)/../tex: \
 		 TEXFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -recorder -pdf \
 		 -pdflatex='lualatex --shell-escape %O %S' \
 		 -jobname=GregorioRef-@FILENAME_VERSION@ $<
 
-GregorioNabcRef-@FILENAME_VERSION@.pdf: $(NABCSRCFILES) veni.gtex
+GregorioNabcRef-@FILENAME_VERSION@.pdf: $(NABCSRCFILES)
+	make -C ../src gregorio
+	../src/gregorio -o veni.gtex $(<D)/veni.gabc
 	TEXINPUTS=$(<D):$(<D)/../tex: LUAINPUTS=$(<D):$(<D)/../tex: \
 		 TEXFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -recorder -pdf \
 		 -pdflatex='lualatex --shell-escape %O %S' \
 		 -jobname=GregorioNabcRef-@FILENAME_VERSION@ $<
-
-../src/gregorio:
-	make -C ../src gregorio
-
-factus.gtex: factus.gabc ../src/gregorio
-	../src/gregorio -o $@ $<
-
-veni.gtex: veni.gabc ../src/gregorio
-	../src/gregorio -o $@ $<
 
 doc: GregorioRef-$(FILENAME_VERSION).pdf GregorioNabcRef-$(FILENAME_VERSION).pdf
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -21,7 +21,7 @@ SRCFILES = GregorioRef.tex Command_Index_gregorio.tex \
 		   Appendix_Font_Tables.tex GregorioRef.lua factus.gabc
 NABCSRCFILES = GregorioNabcRef.tex veni.gabc
 
-# I know these rules looks wrong, but they must not depend on anything that
+# I know these rules look wrong, but they must not depend on anything that
 # gets generated or make distcheck will fail.
 
 GregorioRef-@FILENAME_VERSION@.pdf: $(SRCFILES)


### PR DESCRIPTION
I know the rules look wrong, but if anything depends on something generated, it will be regenerated and `make distcheck` will fail.