### PR TITLE
Added the ability to force a vertical episema to appear above/below the note.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `[ub:x:y mm]` tag, similar to `[ob:x:y mm]`, but for braces under notes.
 - The ability to substitute an arbitrary glyph for one used by GregorioTeX.  This adds four macros: `\grechangeglyph` to make a score glyph substitution, `\greresetglyph` to remove a score glyph substitution, `\gredefsymbol` for (re-)defining an arbitrary non-score glyph that scales with the text, and `\gredefsizedsymbol` for (re-)defining an arbitary non-score glyph that requires a point-size to be specified.  See GregorioRef.pdf for full details.
 - Support for `lualatex -recorder`.  Autocompiled gabc and gtex files will now be properly recorded so that programs like `latexmk -recorder` can detect the need to rebuild the PDF when a gabc file changes.
+- A vertical episema may now be forced to appear above or below a note.  In gabc, use `'0` for the vertical episema to appear below and `'1` for the vertical episema to appear above (see [#385](https://github.com/gregorio-project/gregorio/issues/385)).
 
 ### Removed
 - GregorioXML and OpusTeX output

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -1037,6 +1037,14 @@ void dump_write_score(FILE *f, gregorio_score *score)
                                 fprintf(f, "         signs                  %d (%s)\n",
                                         note->signs, dump_signs(note->signs));
                             }
+                            if (note->signs & _V_EPISEMUS && note->v_episemus_height) {
+                                if (note->v_episemus_height < note->u.note.pitch) {
+                                    fprintf(f, "         v episemus forced      BELOW\n");
+                                }
+                                else {
+                                    fprintf(f, "         v episemus forced      ABOVE\n");
+                                }
+                            }
                             if (note->special_sign) {
                                 fprintf(f, "         special sign           %d (%s)\n",
                                         note->special_sign,

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -96,6 +96,19 @@ static void add_h_episemus(void) {
                 &nbof_isolated_episemus);
 }
 
+static void add_v_episemus(void) {
+    gregorio_vposition vposition = VPOS_AUTO;
+    switch(gabc_notes_determination_text[1]) {
+    case '0':
+        vposition = VPOS_BELOW;
+        break;
+    case '1':
+        vposition = VPOS_ABOVE;
+        break;
+    }
+    gregorio_add_sign(current_note, _V_EPISEMUS, vposition);
+}
+
 %}
 
 %option stack
@@ -425,14 +438,14 @@ r5  {
         lex_add_note(1, gregorio_det_shape(gabc_notes_determination_text[1]),
                 _NO_SIGN, L_INITIO_DEBILIS);
     }
-\'  {
-        gregorio_add_sign(current_note, _V_EPISEMUS);
+\'[01]?  {
+        add_v_episemus();
     }
 _[0-5]* {
         add_h_episemus();
     }
 \.  {
-        gregorio_add_sign(current_note, _PUNCTUM_MORA);
+        gregorio_add_sign(current_note, _PUNCTUM_MORA, VPOS_AUTO);
     }
 ~   {
         gregorio_add_liquescentia(current_note, L_DEMINUTUS);

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -359,6 +359,17 @@ static void gabc_hepisemus(FILE *f, char *prefix, bool connect,
     }
 }
 
+static char *vepisemus_position(gregorio_note *note)
+{
+    if (!note->v_episemus_height) {
+        return "";
+    }
+    if (note->v_episemus_height < note->u.note.pitch) {
+        return "0";
+    }
+    return "1";
+}
+
 /*
  * 
  * The function that writes one gregorio_note.
@@ -485,13 +496,13 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         fprintf(f, "..");
         break;
     case _V_EPISEMUS:
-        fprintf(f, "'");
+        fprintf(f, "'%s", vepisemus_position(note));
         break;
     case _V_EPISEMUS_PUNCTUM_MORA:
-        fprintf(f, "'.");
+        fprintf(f, "'%s.", vepisemus_position(note));
         break;
     case _V_EPISEMUS_AUCTUM_DUPLEX:
-        fprintf(f, "'..");
+        fprintf(f, "'%s..", vepisemus_position(note));
         break;
     default:
         break;

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -836,11 +836,19 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
     }
 
     if (note->signs & _V_EPISEMUS) {
-        note->v_episemus_height = note->u.note.pitch + (int)v_episemus;
-        if ((v_episemus == VPOS_BELOW && v_episemus_below_is_lower)
-                || v_episemus == VPOS_ABOVE) {
-            // above is always higher because of GregorioTeX's design
-            note->v_episemus_height += (int)v_episemus;
+        if (note->v_episemus_height) {
+            if (note->v_episemus_height > note->u.note.pitch) {
+                // above is always higher because of GregorioTeX's design
+                note->v_episemus_height += (int)VPOS_ABOVE;
+            }
+        }
+        else {
+            note->v_episemus_height = note->u.note.pitch + (int)v_episemus;
+            if ((v_episemus == VPOS_BELOW && v_episemus_below_is_lower)
+                    || v_episemus == VPOS_ABOVE) {
+                // above is always higher because of GregorioTeX's design
+                note->v_episemus_height += (int)v_episemus;
+            }
         }
     }
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -465,7 +465,8 @@ void gregorio_add_h_episemus(gregorio_note *note,
     }
 }
 
-void gregorio_add_sign(gregorio_note *note, gregorio_sign sign)
+void gregorio_add_sign(gregorio_note *note, gregorio_sign sign,
+        gregorio_vposition vposition)
 {
     if (!note) {
         // error
@@ -490,6 +491,7 @@ void gregorio_add_sign(gregorio_note *note, gregorio_sign sign)
             break;
         }
         break;
+
     case _V_EPISEMUS:
         switch (note->signs) {
         case _NO_SIGN:
@@ -504,6 +506,12 @@ void gregorio_add_sign(gregorio_note *note, gregorio_sign sign)
         default:
             break;
         }
+
+        if (note->type == GRE_NOTE && vposition) {
+            note->v_episemus_height = note->u.note.pitch + vposition;
+        }
+        break;
+
     default:
         break;
     }

--- a/src/struct.h
+++ b/src/struct.h
@@ -748,7 +748,8 @@ void gregorio_position_h_episemus_below(gregorio_note *note, char height,
 void gregorio_add_h_episemus(gregorio_note *note, grehepisemus_size size,
         gregorio_vposition vposition, bool disable_bridge,
         unsigned int *nbof_isolated_episemus);
-void gregorio_add_sign(gregorio_note *note, gregorio_sign sign);
+void gregorio_add_sign(gregorio_note *note, gregorio_sign sign,
+        gregorio_vposition vposition);
 void gregorio_add_liquescentia(gregorio_note *note,
         gregorio_liquescentia liquescentia);
 void gregorio_add_voice_info(gregorio_voice_info **current_voice_info);

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -536,12 +536,15 @@
   \if m\grefirstcar#1\endgrefirstchar %
     \gre@count@temp@three=\number 14%
   \fi%
-  % n and o is only useful for horizontal episemus and rare signs (signs below k have m as first argument, and above have n)
+  % n, o, and p are only useful for horizontal episemus and rare signs (signs below k have m as first argument, and above have n)
   \if n\grefirstcar#1\endgrefirstchar %
     \gre@count@temp@three=\number 15%
   \fi%
-  \if n\grefirstcar#1\endgrefirstchar %
+  \if o\grefirstcar#1\endgrefirstchar %
     \gre@count@temp@three=\number 16%
+  \fi%
+  \if p\grefirstcar#1\endgrefirstchar %
+    \gre@count@temp@three=\number 17%
   \fi%
   % if there is not line... we don't consider notes are on lines
   \ifnum\greremovelinescount=1\relax %


### PR DESCRIPTION
Fixes #385.

One thing I noticed is that the output looks a little funny when a horizontal episema appears above a vertical episema.  The horizontal episema is always pushed up into the next space.  This looks even stranger when there is no line above the vertical episema (i.e., `(m'1_1)`).  Somehow, things are handled properly (or at least better) when the horizontal episema is below the vertical episema (i.e., `(a'0_0)`).  Does anyone know where/how/why the below-case works or any other clues as to how I should proceed?