### PR TITLE
Space around bars : reduce negative tolerance

### DIFF
--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -137,13 +137,13 @@
 \gresetdim{punctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{1}%
 % space for the bars (inside syllables)
 %first for virgula and divisio minima
-\gresetdim{spacearoundsmallbar}{0.1823 cm plus 0.22787 cm minus 0.03469 cm}{1}%
+\gresetdim{spacearoundsmallbar}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
 %then divisio minor
-\gresetdim{spacearoundminor}{0.1823 cm plus 0.22787 cm minus 0.03469 cm}{1}%
+\gresetdim{spacearoundminor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
 %divisio major
-\gresetdim{spacearoundmaior}{0.1823 cm plus 0.22787 cm minus 0.03469 cm}{1}%
+\gresetdim{spacearoundmaior}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
 %divisio finalis
-\gresetdim{spacearoundfinalis}{0.1823 cm plus 0.22787 cm minus 0.03469 cm}{1}%
+\gresetdim{spacearoundfinalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
 %a special space for finalis, for when it is the last glyph
 \gresetdim{spacebeforefinalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{1}%
 % additional space that will appear around bars that are preceded by a custo and followed by a key.


### PR DESCRIPTION
After previous change, there where other clashes yet. As default space around bars within syllables is already quite small, this PR suggests reducing negative tolerance to nearly nothing.