### PR TITLE
Added verbatim and special character handling to the first syllable code.

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -1066,10 +1066,27 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
         gregorio_insert_style_before(ST_T_BEGIN, ST_FIRST_SYLLABLE,
                 current_character);
         do {
-            if (current_character->is_character && !marked_syllable_iniital) {
+            if (!marked_syllable_iniital && (current_character->is_character
+                        || (current_character->cos.s.type == ST_T_BEGIN
+                            && (current_character->cos.s.style == ST_VERBATIM
+                                || current_character->cos.s.style
+                                == ST_SPECIAL_CHAR
+                                )
+                            )
+                    )) {
                 marked_syllable_iniital = true;
                 gregorio_insert_style_before(ST_T_BEGIN,
                         ST_FIRST_SYLLABLE_INITIAL, current_character);
+                if (!current_character->is_character) {
+                    // skip past the verbatim or special character
+                    if (current_character->next_character) {
+                        current_character = current_character->next_character;
+                    }
+                    while (current_character->next_character
+                            && current_character->is_character) {
+                        current_character = current_character->next_character;
+                    }
+                }
                 gregorio_insert_style_after(ST_T_END, ST_FIRST_SYLLABLE_INITIAL,
                         &current_character);
             } else {


### PR DESCRIPTION
This is a bug fix for #450.

I have run the tests and they seem to be fine after adjustment for the bug fix.  I will merge this immediately so that @rpspringuel can continue testing, but please review as time permits.

@rpspringuel: This should fix the bug I mentioned in gregorio-test issue 2, but I don't know if it will solve your segfault issue.  This may just be a fix for a "nearby" bug to the segfault, but it does have the potential to correct the segfault because of the convoluted nature of `gregorio_rebuild_characters` in `characters.c`.  You will need updated test expectations will I will push immediately after merging this.