### PR TITLE
Added the ability to use nabc for a choral sign.

### DIFF
--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -149,6 +149,7 @@ static inline void add_alteration(const gregorio_type type) {
 %x texverbglyph
 %x texverbelement
 %x choralsign
+%x choralnabc
 %x alt
 %x comments
 %x overbrace
@@ -168,6 +169,9 @@ static inline void add_alteration(const gregorio_type type) {
     }
 <INITIAL>\[cs: {
         BEGIN(choralsign);
+    }
+<INITIAL>\[cn: {
+        BEGIN(choralnabc);
     }
 <INITIAL>\[ob:[01]; {
         char_for_brace = gabc_notes_determination_text[4]-'0';
@@ -252,7 +256,11 @@ static inline void add_alteration(const gregorio_type type) {
     }
 <choralsign>[^\]]+ {
         gregorio_add_cs_to_note(&current_note,
-                strdup(gabc_notes_determination_text));
+                strdup(gabc_notes_determination_text), false);
+    }
+<choralnabc>[^\]]+ {
+        gregorio_add_cs_to_note(&current_note,
+                strdup(gabc_notes_determination_text), true);
     }
 <texverbnote>[^\]]+ {
         gregorio_add_texverb_to_note(&current_note,
@@ -270,7 +278,7 @@ static inline void add_alteration(const gregorio_type type) {
         gregorio_add_texverb_as_note(&current_note,
                 strdup(gabc_notes_determination_text), GRE_ALT);
     }
-<texverbnote,texverbglyph,texverbelement,choralsign,alt,overcurlyaccentusbrace,overcurlybrace,overbrace,underbrace>\] {
+<texverbnote,texverbglyph,texverbelement,choralsign,choralnabc,alt,overcurlyaccentusbrace,overcurlybrace,overbrace,underbrace>\] {
         BEGIN(INITIAL);
     }
 \{  {

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2048,6 +2048,25 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
     return 0;
 }
 
+static inline void write_low_choral_sign(FILE *const f,
+        const gregorio_note *const note, int special)
+{
+    fprintf(f, "\\grelowchoralsign{%d}{%s%s%s}{%d}%%\n",
+            pitch_value(note->u.note.pitch),
+            note->choral_sign_is_nabc? "\\gregorionabcchar{" : "",
+            note->choral_sign, note->choral_sign_is_nabc? "}" : "", special);
+}
+
+static inline void write_high_choral_sign(FILE *const f,
+        const gregorio_note *const note, int pitch_offset)
+{
+    fprintf(f, "\\grehighchoralsign{%d}{%s%s%s}{\\greoCase%s}%%\n",
+            pitch_value(note->u.note.pitch + pitch_offset),
+            note->choral_sign_is_nabc? "\\gregorionabcchar{" : "",
+            note->choral_sign, note->choral_sign_is_nabc? "}" : "",
+            note->gtex_offset_case);
+}
+
 static void gregoriotex_write_choral_sign(FILE *f, gregorio_glyph *glyph,
         gregorio_note *current_note, bool low)
 {
@@ -2068,35 +2087,25 @@ static void gregoriotex_write_choral_sign(FILE *f, gregorio_glyph *glyph,
         if (is_on_a_line(current_note->u.note.pitch)) {
             if (kind_of_pes && current_note->u.note.pitch -
                     current_note->next->u.note.pitch == -1) {
-                fprintf(f, "\\grelowchoralsign{%d}{%s}{1}%%\n",
-                        pitch_value(current_note->u.note.pitch),
-                        current_note->choral_sign);
+                write_low_choral_sign(f, current_note, 1);
                 return;
             }
             if (current_note->previous
                     && (current_note->previous->signs == _PUNCTUM_MORA
                             || current_note->previous->signs ==
                             _V_EPISEMUS_PUNCTUM_MORA)) {
-                fprintf(f, "\\grelowchoralsign{%d}{%s}{1}%%\n",
-                        pitch_value(current_note->u.note.pitch),
-                        current_note->choral_sign);
+                write_low_choral_sign(f, current_note, 1);
                 return;
             }
         }
 
-        fprintf(f, "\\grelowchoralsign{%d}{%s}{0}%%\n",
-                pitch_value(current_note->u.note.pitch),
-                current_note->choral_sign);
+        write_low_choral_sign(f, current_note, 0);
     } else {
         // let's cheat a little
         if (is_on_a_line(current_note->u.note.pitch)) {
-            fprintf(f, "\\grehighchoralsign{%d}{%s}{\\greoCase%s}%%\n",
-                    pitch_value(current_note->u.note.pitch),
-                    current_note->choral_sign, current_note->gtex_offset_case);
+            write_high_choral_sign(f, current_note, 0);
         } else {
-            fprintf(f, "\\grehighchoralsign{%d}{%s}{\\greoCase%s}%%\n",
-                    pitch_value(current_note->u.note.pitch + 2),
-                    current_note->choral_sign, current_note->gtex_offset_case);
+            write_high_choral_sign(f, current_note, 2);
         }
     }
 }

--- a/src/struct.c
+++ b/src/struct.c
@@ -236,10 +236,12 @@ void gregorio_add_texverb_to_note(gregorio_note **current_note, char *str)
     }
 }
 
-void gregorio_add_cs_to_note(gregorio_note **current_note, char *str)
+void gregorio_add_cs_to_note(gregorio_note *const*const current_note,
+        char *const str, const bool nabc)
 {
     if (*current_note) {
         (*current_note)->choral_sign = str;
+        (*current_note)->choral_sign_is_nabc = nabc;
     }
 }
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -419,6 +419,7 @@ typedef struct gregorio_note {
     bool is_lower_note:1;
     bool is_upper_note:1;
     ENUM_BITFIELD(gregorio_vposition) mora_vposition:2;
+    bool choral_sign_is_nabc:1;
 } gregorio_note;
 
 /*
@@ -787,7 +788,8 @@ void gregorio_add_texverb_as_note(gregorio_note **current_note, char *str,
 void gregorio_add_nlba_as_note(gregorio_note **current_note,
         gregorio_nlba type);
 void gregorio_add_texverb_to_note(gregorio_note **current_note, char *str);
-void gregorio_add_cs_to_note(gregorio_note **current_note, char *str);
+void gregorio_add_cs_to_note(gregorio_note *const*current_note, char *str,
+        bool nabc);
 void gregorio_add_misc_element(gregorio_element **current_element,
         gregorio_type type, gregorio_misc_element_info info, char *texverb);
 void gregorio_reinitialize_alterations(char alterations[][13],


### PR DESCRIPTION
Submitted for your approval and/or review.

This adds the ability to use nabc easily in a choral sign by using `[cn:nabc]` where you would previously have had to use `[cs:\gregorionabcchar{nabc}]`.

Feel free to reject it if you don't like the idea.