### PR TITLE
Changing redlines to use gregoriocolor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
   - `beforechoralsignspace` is now `beforelowchoralsignspace`.
   - `lowchoralsignshift` is now `choralsigndownshift`.
   - `highchoralsignshift` is now `choralsignupshift` and its sign is now inverted.
+- `\grecoloredlines` now takes a single argument, a named color, instead of the three components of an RGB color.  As a result, `\redlines` can now use `gregoriocolor`, making the red staff lines consistent with the text, even when the user teaks `gregoriocolor`.  Addresses [#21787 on the old tracker](https://gna.org/bugs/index.php?21787).
 
 ### Added
 - With thanks to Jakub Jelínek, St. Gallen style adiastematic notation is now handled through [nabc syntax](http://gregoriochant.org/dokuwiki/doku.php/language) (see GregorioNabcRef.pdf for details and [the new example](examples/FactusEst.gabc)). Only one line above the notes is currently handled. This is a preview, backward incompatible change are possible in future releases.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,6 +48,10 @@ Note: `3`, `4`, and `5` encompass a new feature and are listed here only for com
 - `lowchoralsignshift` has been renamed to `choralsigndownshift`.
 - `highchoralsignshift` has been renamed to `choralsignupshift` and its sign inverted.
 
+### Colored lines
+
+Since `\grecoloredlines` now takes a named color as it's argument, if you were using it to custom color your lines, you must now define a named color using `\definecolor{yourcolorname}{RGB}{#,#,#}` and then pass that color to the command: `\grecoloredlines{yourcolorname}`.  The `\redlines` command continues to work as it did before, but will now respond to a change to `gregoriocolor` the way colored text does.
+
 ## 3.0
 ### TeX Live 2013
 

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -54,6 +54,8 @@
 %% We now redefine some things in a more LaTeX friendly way.
 
 \definecolor{grebackgroundcolor}{RGB}{255,255,255}%
+\definecolor{gregoriocolor}{RGB}{229,53,44}
+
 
 \def\greinitialformat#1{%
   {\fontsize{40}{40}\selectfont #1}%
@@ -90,23 +92,21 @@
   \relax %
 }
 
-\definecolor{gregoriocolor}{RGB}{229,53,44}
-
 \def\grecolored#1{%
   {%
     \color{gregoriocolor}#1%
   }%
 }
 
-\def\grecoloredlines#1#2#3{%
+\def\grecoloredlines#1{%
   \GreSetStaffLinesFormat{%
-    \color[RGB]{#1,#2,#3}%
+    \color[named]{#1}%
   }%
   \relax %
 }
 
 \def\greredlines{%
-  \grecoloredlines{229}{53}{44}%
+  \grecoloredlines{gregoriocolor}%
   \relax %
 }
 


### PR DESCRIPTION
Addresses [#21787 on old tracker](https://gna.org/bugs/index.php?21787)
This is one of a bunch of changes which I had rolled into texrenaming.  I'm now pulling those changes out individually to separate the functionality changes from the application of the naming conventions.