### PR TITLE
Enabled 'z' to force-justify the last line of a score.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The dot in a space directly above a punctum in a descending neume is now placed slightly higher in the space (see [#386](https://github.com/gregorio-project/gregorio/issues/386) and [Gna! bug 21737](https://gna.org/bugs/?21737)).
 - Choral signs are now positioned correctly around porrectus and torculus resupinus (see [#387](https://github.com/gregorio-project/gregorio/issues/387) and [Gna! bug 22025](https://gna.org/bugs/?22025)).
 - Gregorio will now try harder to select an appropriate pitch for an automatic custos (`z0`) on a clef change (see [#446](https://github.com/gregorio-project/gregorio/issues/446)).  If results are not satisfactory, use a manual custos (`+`) to select a pitch manually.
+- The final line of a score may now be forced to be fully justified (rather than ragged) by appending a `z` to the final `:` or `::` of the score (see [#43](https://github.com/gregorio-project/gregorio/issues/43)).
 
 ### Changed
 - The spacing algorithm has completely changed, expect your scores to look quite different (better we hope).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The dot in a space directly above a punctum in a descending neume is now placed slightly higher in the space (see [#386](https://github.com/gregorio-project/gregorio/issues/386) and [Gna! bug 21737](https://gna.org/bugs/?21737)).
 - Choral signs are now positioned correctly around porrectus and torculus resupinus (see [#387](https://github.com/gregorio-project/gregorio/issues/387) and [Gna! bug 22025](https://gna.org/bugs/?22025)).
 - Gregorio will now try harder to select an appropriate pitch for an automatic custos (`z0`) on a clef change (see [#446](https://github.com/gregorio-project/gregorio/issues/446)).  If results are not satisfactory, use a manual custos (`+`) to select a pitch manually.
-- The final line of a score may now be forced to be fully justified (rather than ragged) by appending a `z` to the final `:` or `::` of the score (see [#43](https://github.com/gregorio-project/gregorio/issues/43)).
 
 ### Changed
 - The spacing algorithm has completely changed, expect your scores to look quite different (better we hope).
@@ -46,6 +45,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Support for `lualatex -recorder`.  Autocompiled gabc and gtex files will now be properly recorded so that programs like `latexmk -recorder` can detect the need to rebuild the PDF when a gabc file changes.
 - A vertical episema may now be forced to appear above or below a note.  In gabc, use `'0` for the vertical episema to appear below and `'1` for the vertical episema to appear above (see [#385](https://github.com/gregorio-project/gregorio/issues/385)).
 - The first syllable and first letter of the first syllable that is *not* interpreted as the initial of the score are now passed to macros that allow them to be styled from TeX.  The first syllable is passed to `\GreFirstSyllable#1` and the first letter of the first syllable is passed to `\GreFirstSyllableInitial#1`.
+- The final line of a score may now be forced to be fully justified (rather than ragged) using `\grejustifiedlastline` before including the score.  Use `\greraggedlastline` to switch back to a ragged last line.  See [#43](https://github.com/gregorio-project/gregorio/issues/43).
 
 ### Removed
 - GregorioXML and OpusTeX output

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2627,18 +2627,6 @@ static void handle_final_bar(FILE *f, char *type, gregorio_syllable *syllable)
             }
             break;
 
-        case GRE_END_OF_LINE:
-            switch (element->u.misc.unpitched.info.sub_type) {
-            case GRE_END_OF_PAR:
-                fprintf(f, "\\grenewparline %%\n");
-                break;
-
-            default:
-                fprintf(f, "\\grenewline %%\n");
-                break;
-            }
-            break;
-
         default:
             // do nothing
             break;

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2627,6 +2627,18 @@ static void handle_final_bar(FILE *f, char *type, gregorio_syllable *syllable)
             }
             break;
 
+        case GRE_END_OF_LINE:
+            switch (element->u.misc.unpitched.info.sub_type) {
+            case GRE_END_OF_PAR:
+                fprintf(f, "\\grenewparline %%\n");
+                break;
+
+            default:
+                fprintf(f, "\\grenewline %%\n");
+                break;
+            }
+            break;
+
         default:
             // do nothing
             break;

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -777,10 +777,20 @@
 %% other macros
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\newif\ifgre@justifylastline%
+\gre@justifylastlinefalse%
+
+\def\grejustifiedlastline{\gre@justifylastlinetrue\relax}%
+\def\greraggedlastline{\gre@justifylastlinefalse\relax}%
+
 % gregorioattr (see its definition in gregorio-syllable) is 0 when we are in a score, and unset when we are not
 
 %macro called at the beginning of a score
 \def\begingregorioscore{%
+  \ifgre@justifylastline%
+    \xdef\gre@save@parfillskip{\the\parfillskip}
+    \parfillskip=0pt plus 0pt minus 0pt\relax%
+  \fi %
   % not sure it's perfect to put that here, but it's the only way I found to make it work....
   \setgregoriofont{\gregoriofontname}%
   \ifnum\greusestylefont=1\relax %
@@ -842,6 +852,9 @@
   \gre@skip@temp@three=0pt%
   \gre@skip@temp@four=0pt%
   \directlua{gregoriotex.atScoreEnd()}%
+  \ifgre@justifylastline%
+    \parfillskip=\gre@save@parfillskip\relax%
+  \fi %
   \relax%
 }%
 


### PR DESCRIPTION
Fixes #43.

In implementing this, I found a bug in the way elements are "cut", which I think I've fixed.  The tests pass, except for one which ended with a 'Z', and whose result is acceptable.

This is ready for review.