### PR TITLE
Centering scheme deprecation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `\greabovelinestextstyle`, if you were redefining this command, use `\grechangeformat{abovelinestext}...` instead
 - `\grelowchoralsignstyle`, if you were redefining this command, use `\grechangeformat{lowchoralsign}...` instead
 - `\grehighchoralsignstyle`, if you were redefining this command, use `\grechangeformat{highchoralsign}...` instead
+- `centering-scheme` gabc header, supplanted by `\grelyriccentering` in TeX.  See GregorioRef for syntax.
 
 ### Removed
 - GregorioXML and OpusTeX output

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -74,6 +74,11 @@ Examples: Let's say you previously had the following in your LaTeX document:
 This would have made the text which was wrapped with `<alt></alt>` in your gabc file appear small and italicized in your score.  To update this to the new system you would replace the above line with the following:
     \grechangestyle{abovelinetext}{\small\it}
 
+### Centering scheme
+
+The gabc `centering-scheme` header is now deprecated and will disappear soon.  Use the `\grelyriccentering` command from TeX instead.  If you were using `centering-scheme: latine;` in gabc, now use `\grelyriccentering{vowel}` in the TeX file that includes the gabc.  If you were using `centering-scheme: english;` in gabc, now use `\grelyriccentering{syllable}` in the TeX file that includes the gabc.
+
+Using the gabc header will, in this release, do that for you, but it will produce a deprecation warning.  This header will no longer be available in the next release.
     
 
 ## 3.0

--- a/src/characters.c
+++ b/src/characters.c
@@ -241,7 +241,7 @@ gregorio_character *gregorio_first_text(gregorio_score *score)
     gregorio_syllable *current_syllable;
     if (!score || !score->first_syllable) {
         gregorio_message(_("unable to find the first letter of the score"),
-                "gregorio_first_text", ERROR, 0);
+                "gregorio_first_text", VERBOSITY_ERROR, 0);
         return NULL;
     }
     current_syllable = score->first_syllable;
@@ -253,7 +253,7 @@ gregorio_character *gregorio_first_text(gregorio_score *score)
     }
 
     gregorio_message(_("unable to find the first letter of the score"),
-            "gregorio_first_text", ERROR, 0);
+            "gregorio_first_text", VERBOSITY_ERROR, 0);
     return NULL;
 }
 
@@ -649,7 +649,6 @@ static bool gregorio_go_to_end_initial(gregorio_character **param_character)
 }
 
 /*
- * 
  * THE big function. Very long, using a lot of long macros, etc. I hope you
  * really want to understand it, 'cause it won't be easy.
  * 
@@ -663,16 +662,10 @@ static bool gregorio_go_to_end_initial(gregorio_character **param_character)
  * Another difficulty is the fact that we must consider characters in verbatim
  * and special character styles like only one block, we can't say the center is 
  * in the middle of a verbatim block.
- * 
- * 29/11/10: there is now the possibility to choose between two centering
- * schemes: - latine is the one used before - english is a new scheme where the 
- * whole syllable (except for forced centering) is centered
- * 
  */
 
 void gregorio_rebuild_characters(gregorio_character **param_character,
-        gregorio_center_determination center_is_determined,
-        gregorio_lyric_centering centering_scheme, bool skip_initial)
+        gregorio_center_determination center_is_determined, bool skip_initial)
 {
     // a det_style, to walk through the list
     det_style *current_style = NULL;
@@ -710,12 +703,6 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
         center_type = ST_CENTER;
     } else {
         center_type = ST_FORCED_CENTER;
-    }
-    // if there is no forced centering, we open the centering before the very
-    // first letter
-    if (centering_scheme == SCHEME_SYLLABLE && center_type == ST_CENTER) {
-        gregorio_insert_style_before(ST_T_BEGIN, ST_CENTER, current_character);
-        center_is_determined = CENTER_FULLY_DETERMINED;
     }
     // we loop until there isn't any character
     while (current_character) {
@@ -916,9 +903,6 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
         }
         gregorio_insert_style_before(ST_T_BEGIN, ST_CENTER, current_character);
     }
-    if (centering_scheme == SCHEME_SYLLABLE && center_type == ST_CENTER) {
-        gregorio_insert_style_after(ST_T_END, ST_CENTER, &current_character);
-    }
     // well.. you're quite brave if you reach this comment.
     gregorio_go_to_first_character(&current_character);
     (*param_character) = current_character;
@@ -1025,7 +1009,7 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
 
                 gregorio_message(_
                         ("Any style applied to the initial will be ignored."),
-                        NULL, WARNING, 0);
+                        NULL, VERBOSITY_WARNING, 0);
             }
             break;
         }
@@ -1042,7 +1026,7 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
 
                 gregorio_message(_
                         ("Any style applied to the initial will be ignored."),
-                        NULL, WARNING, 0);
+                        NULL, VERBOSITY_WARNING, 0);
             }
             gregorio_insert_style_before(ST_T_BEGIN, ST_INITIAL,
                     current_character);

--- a/src/characters.c
+++ b/src/characters.c
@@ -713,7 +713,7 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
     }
     // if there is no forced centering, we open the centering before the very
     // first letter
-    if (centering_scheme == SCHEME_ENGLISH && center_type == ST_CENTER) {
+    if (centering_scheme == SCHEME_SYLLABLE && center_type == ST_CENTER) {
         gregorio_insert_style_before(ST_T_BEGIN, ST_CENTER, current_character);
         center_is_determined = CENTER_FULLY_DETERMINED;
     }
@@ -916,7 +916,7 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
         }
         gregorio_insert_style_before(ST_T_BEGIN, ST_CENTER, current_character);
     }
-    if (centering_scheme == SCHEME_ENGLISH && center_type == ST_CENTER) {
+    if (centering_scheme == SCHEME_SYLLABLE && center_type == ST_CENTER) {
         gregorio_insert_style_after(ST_T_END, ST_CENTER, &current_character);
     }
     // well.. you're quite brave if you reach this comment.

--- a/src/characters.h
+++ b/src/characters.h
@@ -72,8 +72,7 @@ void gregorio_write_initial(gregorio_character *current_character,
 gregorio_character *gregorio_first_text(gregorio_score *score);
 
 void gregorio_rebuild_characters(gregorio_character **param_character,
-        gregorio_center_determination center_is_determined,
-        gregorio_lyric_centering centering_scheme, bool skip_initial);
+        gregorio_center_determination center_is_determined, bool skip_initial);
 
 void gregorio_rebuild_first_syllable(gregorio_character **param_character,
         bool separate_initial);

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -518,9 +518,8 @@ void dump_write_score(FILE *f, gregorio_score *score)
     int annotation_num;
 
     if (!f) {
-        gregorio_message(_
-                         ("call with NULL file"),
-                         "gregoriotex_write_score", ERROR, 0);
+        gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
+                VERBOSITY_ERROR, 0);
         return;
     }
     fprintf(f,

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -65,7 +65,7 @@ static inline void add_bar_as_note(gregorio_bar bar)
 
 static inline void error(void)
 {
-    gregorio_messagef("gabc_notes_determination", ERROR, 0,
+    gregorio_messagef("gabc_notes_determination", VERBOSITY_ERROR, 0,
             _("undefined macro used: m%d"),
             gabc_notes_determination_text[3] - '0');
 }
@@ -99,7 +99,7 @@ static void add_h_episemus(void) {
             size = H_SMALL_RIGHT;
             break;
         default:
-            gregorio_messagef("gabc_notes_determination", ERROR, 0,
+            gregorio_messagef("gabc_notes_determination", VERBOSITY_ERROR, 0,
                     _("unrecognized horizontal episemus modifier: %c"),
                     current);
             break;
@@ -507,7 +507,7 @@ s   {
 .   {        
         snprintf(tempstr, 70, _("unrecognized character: \"%c\""),
                 gabc_notes_determination_text[0]);
-        gregorio_message (tempstr, "det_notes_from_string", ERROR, 0);
+        gregorio_message (tempstr, "det_notes_from_string", VERBOSITY_ERROR, 0);
     }
 
 %%

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -200,7 +200,7 @@ semicolon. */
         char *dirtyvar = malloc(71*sizeof(char));
         snprintf(dirtyvar,70,_("unrecognized character: \"%c\" in definition part"),
                  gabc_score_determination_text[0]);
-        gregorio_message (dirtyvar, "det_score", ERROR, 0);
+        gregorio_message (dirtyvar, "det_score", VERBOSITY_ERROR, 0);
     }
 <score>[^\{\}\(\[\]<%]+ {
         gabc_score_determination_lval.text = strdup(gabc_score_determination_text);

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -489,11 +489,11 @@ static void gregorio_gabc_add_text(char *mbcharacters)
 static void set_centering_scheme(char *sc)
 {
     if (strncmp((const char *) sc, "latine", 6) == 0) {
-        centering_scheme = SCHEME_LATINE;
+        centering_scheme = SCHEME_VOWEL;
         return;
     }
     if (strncmp((const char *) sc, "english", 6) == 0) {
-        centering_scheme = SCHEME_ENGLISH;
+        centering_scheme = SCHEME_SYLLABLE;
         return;
     }
     gregorio_message("centering-scheme unknown value: must be \"latine\" "

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -76,19 +76,19 @@ static gregorio_center_determination center_is_determined;
 // current_key is... the current key... updated by each notes determination
 // (for key changes)
 static int current_key = DEFAULT_KEY;
-static gregorio_lyric_centering centering_scheme;
 
 static inline void check_multiple(char *name, bool exists) {
     if (exists) {
-        gregorio_messagef("det_score", WARNING, 0, _("several %s definitions "
-                "found, only the last will be taken into consideration"), name);
+        gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                _("several %s definitions found, only the last will be taken "
+                "into consideration"), name);
     }
 }
 
 static void gabc_score_determination_error(char *error_str)
 {
     gregorio_message(error_str, (const char *) "gabc_score_determination_parse",
-            ERROR, 0);
+            VERBOSITY_ERROR, 0);
 }
 
 static void gabc_fix_custos(gregorio_score *score_to_check)
@@ -189,7 +189,7 @@ static int check_infos_integrity(gregorio_score *score_to_check)
     if (!score_to_check->name) {
         gregorio_message(_("no name specified, put `name:...;' at the "
                 "beginning of the file, can be dangerous with some output "
-                "formats"), "det_score", WARNING, 0);
+                "formats"), "det_score", VERBOSITY_WARNING, 0);
     }
     return 1;
 }
@@ -216,7 +216,6 @@ static void initialize_variables(void)
     translation_type = TR_NORMAL;
     no_linebreak_area = NLBA_NORMAL;
     euouae = EUOUAE_NORMAL;
-    centering_scheme = SCHEME_DEFAULT;
     center_is_determined = 0;
     for (i = 0; i < 10; i++) {
         macros[i] = NULL;
@@ -283,7 +282,7 @@ static void end_definitions(void)
 
     if (!check_infos_integrity(score)) {
         gregorio_message(_("can't determine valid infos on the score"),
-                "det_score", ERROR, 0);
+                "det_score", VERBOSITY_ERROR, 0);
     }
     if (!number_of_voices) {
         if (voice > MAX_NUMBER_OF_VOICES) {
@@ -298,7 +297,7 @@ static void end_definitions(void)
                     "%d waited, %d assumed", "not enough voice infos found: %d "
                     "found, %d waited, %d assumed", voice), voice,
                     number_of_voices, voice);
-            gregorio_message(error, "det_score", WARNING, 0);
+            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
             score->number_of_voices = voice;
             number_of_voices = voice;
         } else {
@@ -308,7 +307,7 @@ static void end_definitions(void)
                         "infos found: %d found, %d waited, %d assumed",
                         number_of_voices), voice, number_of_voices,
                         number_of_voices);
-                gregorio_message(error, "det_score", WARNING, 0);
+                gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
             }
         }
     }
@@ -369,7 +368,7 @@ static void gregorio_set_translation_center_beginning(
         if (syllable->translation_type == TR_WITH_CENTER_END) {
             gregorio_message("encountering translation centering end but "
                     "cannot find translation centering beginning...",
-                    "set_translation_center_beginning", ERROR, 0);
+                    "set_translation_center_beginning", VERBOSITY_ERROR, 0);
             current_syllable->translation_type = TR_NORMAL;
             return;
         }
@@ -382,13 +381,12 @@ static void gregorio_set_translation_center_beginning(
     // we didn't find any beginning...
     gregorio_message("encountering translation centering end but cannot find "
             "translation centering beginning...",
-            "set_translation_center_beginning", ERROR, 0);
+            "set_translation_center_beginning", VERBOSITY_ERROR, 0);
     current_syllable->translation_type = TR_NORMAL;
 }
 
 static void rebuild_characters(gregorio_character **param_character,
-        gregorio_center_determination center_is_determined,
-        gregorio_lyric_centering centering_scheme)
+        gregorio_center_determination center_is_determined)
 {
     bool has_initial = score->initial_style != NO_INITIAL;
     // we rebuild the first syllable text if it is the first syllable, or if
@@ -401,7 +399,7 @@ static void rebuild_characters(gregorio_character **param_character,
     }
 
     gregorio_rebuild_characters(param_character, center_is_determined,
-                                centering_scheme, has_initial);
+            has_initial);
 }
 
 /*
@@ -446,8 +444,7 @@ static void close_syllable(void)
 // the translation pointer instead of the text pointer
 static void start_translation(unsigned char asked_translation_type)
 {
-    rebuild_characters(&current_character, center_is_determined,
-            centering_scheme);
+    rebuild_characters(&current_character, center_is_determined);
     first_text_character = current_character;
     // the middle letters of the translation have no sense
     center_is_determined = CENTER_FULLY_DETERMINED;
@@ -457,8 +454,7 @@ static void start_translation(unsigned char asked_translation_type)
 
 static void end_translation(void)
 {
-    rebuild_characters(&current_character, center_is_determined,
-            centering_scheme);
+    rebuild_characters(&current_character, center_is_determined);
     first_translation_character = current_character;
 }
 
@@ -488,16 +484,19 @@ static void gregorio_gabc_add_text(char *mbcharacters)
  */
 static void set_centering_scheme(char *sc)
 {
+    gregorio_message("\"centering-scheme\" header is deprecated. Please use "
+            "\\setlyriccentering in TeX instead.", "set_centering_scheme",
+            VERBOSITY_DEPRECATION, 0);
     if (strncmp((const char *) sc, "latine", 6) == 0) {
-        centering_scheme = SCHEME_VOWEL;
+        score->centering = SCHEME_VOWEL;
         return;
     }
     if (strncmp((const char *) sc, "english", 6) == 0) {
-        centering_scheme = SCHEME_SYLLABLE;
+        score->centering = SCHEME_SYLLABLE;
         return;
     }
     gregorio_message("centering-scheme unknown value: must be \"latine\" "
-            "or \"english\"", "set_centering_scheme", WARNING, 0);
+            "or \"english\"", "set_centering_scheme", VERBOSITY_WARNING, 0);
 }
 
 /*
@@ -529,7 +528,7 @@ gregorio_score *gabc_read_score(FILE *f_in)
     gabc_score_determination_in = f_in;
     if (!f_in) {
         gregorio_message(_("can't read stream from argument, returning NULL "
-                "pointer"), "det_score", ERROR, 0);
+                "pointer"), "det_score", VERBOSITY_ERROR, 0);
         return NULL;
     }
     initialize_variables();
@@ -544,7 +543,7 @@ gregorio_score *gabc_read_score(FILE *f_in)
         gregorio_free_score(score);
         score = NULL;
         gregorio_message(_("unable to determine a valid score from file"),
-                "det_score", FATAL_ERROR, 0);
+                "det_score", VERBOSITY_FATAL, 0);
     }
     return score;
 }
@@ -579,7 +578,7 @@ gabc_y_add_notes(char *notes) {
         }
         if (!current_element) {
             gregorio_message(_("current_element is null, this shouldn't "
-                    "happen!"), "gabc_y_add_notes",FATAL_ERROR,0);
+                    "happen!"), "gabc_y_add_notes", VERBOSITY_FATAL, 0);
         }
         if (!current_element->nabc) {
             current_element->nabc = (char **) calloc (nabc_lines,
@@ -627,7 +626,7 @@ number_of_voices_definition:
         if (number_of_voices > MAX_NUMBER_OF_VOICES) {
             snprintf(error, 40, _("can't define %d voices, maximum is %d"),
                      number_of_voices, MAX_NUMBER_OF_VOICES);
-            gregorio_message(error,"det_score",WARNING,0);
+            gregorio_message(error,"det_score", VERBOSITY_WARNING, 0);
         }
         gregorio_set_score_number_of_voices (score, number_of_voices);
     }
@@ -642,7 +641,8 @@ macro_definition:
 name_definition:
     NAME attribute {
         if ($2.text==NULL) {
-            gregorio_message("name can't be empty","det_score", WARNING, 0);
+            gregorio_message("name can't be empty","det_score",
+                    VERBOSITY_WARNING, 0);
         }
         check_multiple("name", score->name);
         gregorio_set_score_name (score, $2.text);
@@ -740,7 +740,7 @@ gabc_version_definition:
         if (strcmp ($2.text, GABC_CURRENT_VERSION) != 0) {
             gregorio_message(_("gabc-version is not the current one "
                     GABC_CURRENT_VERSION " ; there may be problems"),
-                    "det_score", WARNING, 0);
+                    "det_score", VERBOSITY_WARNING, 0);
         }
     }
     ;
@@ -781,7 +781,7 @@ annotation_definition:
             snprintf(error,99,_("too many definitions of annotation found for "
                                 "voice %d, only the first %d will be taken "
                                 "into consideration"), voice, NUM_ANNOTATIONS);
-            gregorio_message(error, "det_score",WARNING,0);
+            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
         }
         gregorio_set_voice_annotation (current_voice_info, $2.text);
     }
@@ -851,7 +851,7 @@ style_definition:
             snprintf(error, 99, _("several definitions of style found for "
                     "voice %d, only the last will be taken into consideration"),
                     voice);
-            gregorio_message(error, "det_score",WARNING,0);
+            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
         }
         gregorio_set_voice_style (current_voice_info, $2.text);
     }
@@ -863,7 +863,7 @@ virgula_position_definition:
             snprintf(error, 105, _("several definitions of virgula position "
                     "found for voice %d, only the last will be taken into "
                     "consideration"), voice);
-            gregorio_message(error, "det_score",WARNING,0);
+            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
         }
         gregorio_set_voice_virgula_position (current_voice_info, $2.text);
     }
@@ -944,7 +944,7 @@ note:
             snprintf(error,105,ngt_("too many voices in note : %d found, %d expected",
                                     "too many voices in note : %d found, %d expected",
                                     number_of_voices), voice+1, number_of_voices);
-            gregorio_message(error, "det_score",ERROR,0);
+            gregorio_message(error, "det_score", VERBOSITY_ERROR, 0);
         }
         if (voice<number_of_voices-1) {
             snprintf(error,105,ngt_("not enough voices in note : %d found, %d "
@@ -952,7 +952,7 @@ note:
                                     "not enough voices in note : %d found, "
                                     "%d expected, completing with empty neume",
                                     voice+1), voice+1, number_of_voices);
-            gregorio_message(error, "det_score",VERBOSE,0);
+            gregorio_message(error, "det_score", VERBOSITY_INFO, 0);
             complete_with_nulls(voice);
         }
         voice=0;
@@ -967,7 +967,7 @@ note:
             snprintf(error,105,ngt_("too many voices in note : %d found, %d expected",
                                     "too many voices in note : %d found, %d expected",
                                     number_of_voices), voice+1, number_of_voices);
-            gregorio_message(error, "det_score",ERROR,0);
+            gregorio_message(error, "det_score", VERBOSITY_ERROR, 0);
         }
         if (voice<number_of_voices-1) {
             snprintf(error,105,ngt_("not enough voices in note : %d found, %d "
@@ -975,7 +975,7 @@ note:
                                     "not enough voices in note : %d found, %d "
                                     "expected, completing with empty neume",
                                     voice+1), voice+1, number_of_voices);
-            gregorio_message(error, "det_score",VERBOSE,0);
+            gregorio_message(error, "det_score", VERBOSITY_INFO, 0);
             complete_with_nulls(voice);
         }
         voice=0;
@@ -992,7 +992,7 @@ note:
             snprintf(error,105,ngt_("too many voices in note : %d found, %d expected",
                                     "too many voices in note : %d found, %d expected",
                                     number_of_voices), voice+1, number_of_voices);
-            gregorio_message(error, "det_score",ERROR,0);
+            gregorio_message(error, "det_score", VERBOSITY_ERROR, 0);
         }
     }
     | NOTES NABC_CUT {
@@ -1000,7 +1000,7 @@ note:
             gregorio_message(_("You used character \"|\" in gabc without "
                                "setting \"nabc-lines\" parameter. Please "
                                "set it in your gabc header."),
-                             "det_score",FATAL_ERROR,0);
+                             "det_score", VERBOSITY_FATAL, 0);
         }
         if (voice<number_of_voices) {
             gabc_y_add_notes($1.text);
@@ -1143,7 +1143,7 @@ above_line_text:
 
 syllable_with_notes:
     text OPENING_BRACKET notes {
-        rebuild_characters (&current_character, center_is_determined, centering_scheme);
+        rebuild_characters (&current_character, center_is_determined);
         first_text_character = current_character;
         close_syllable();
     }

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -58,8 +58,8 @@ static void gabc_write_voice_info(FILE *f, gregorio_voice_info *voice_info)
     int annotation_num;
 
     if (!voice_info) {
-        gregorio_message(_("no voice info"),
-                         "gabc_write_voice_info", WARNING, 0);
+        gregorio_message(_("no voice info"), "gabc_write_voice_info",
+                VERBOSITY_WARNING, 0);
         return;
     }
     for (annotation_num = 0; annotation_num < NUM_ANNOTATIONS; ++annotation_num) {
@@ -265,8 +265,8 @@ static void gabc_write_space(FILE *f, char type)
         // fprintf (f, "/");
         break;
     default:
-        gregorio_message(_("space type is unknown"),
-                         "gabc_write_space", ERROR, 0);
+        gregorio_message(_("space type is unknown"), "gabc_write_space",
+                VERBOSITY_ERROR, 0);
         break;
     }
 }
@@ -314,9 +314,8 @@ static void gabc_write_bar(FILE *f, char type)
         fprintf(f, ";6");
         break;
     default:
-        gregorio_message(_
-                         ("unknown bar type, nothing will be done"),
-                         "gabc_bar_to_str", ERROR, 0);
+        gregorio_message(_("unknown bar type, nothing will be done"),
+                "gabc_bar_to_str", VERBOSITY_ERROR, 0);
         break;
     }
 }
@@ -400,13 +399,13 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
     char shape;
     if (!note) {
         gregorio_message(_("call with NULL argument"),
-                         "gabc_write_gregorio_note", ERROR, 0);
+                "gabc_write_gregorio_note", VERBOSITY_ERROR, 0);
         return;
     }
     if (note->type != GRE_NOTE) {
-        gregorio_message(_
-                         ("call with argument which type is not GRE_NOTE, wrote nothing"),
-                         "gabc_write_gregorio_note", ERROR, 0);
+        gregorio_message(_("call with argument which type is not GRE_NOTE, "
+                    "wrote nothing"), "gabc_write_gregorio_note",
+                VERBOSITY_ERROR, 0);
         return;
     }
     if (glyph_type == G_PES_QUADRATUM) {
@@ -577,7 +576,7 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
 
     if (!glyph) {
         gregorio_message(_("call with NULL argument"),
-                         "gabc_write_gregorio_glyph", ERROR, 0);
+                "gabc_write_gregorio_glyph", VERBOSITY_ERROR, 0);
         return;
     }
     switch (glyph->type) {
@@ -599,8 +598,8 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
         if (glyph->u.misc.unpitched.info.space == SP_ZERO_WIDTH && glyph->next) {
             fprintf(f, "!");
         } else {
-            gregorio_message(_("bad space"),
-                             "gabc_write_gregorio_glyph", ERROR, 0);
+            gregorio_message(_("bad space"), "gabc_write_gregorio_glyph",
+                    VERBOSITY_ERROR, 0);
         }
         break;
     case GRE_MANUAL_CUSTOS:
@@ -622,7 +621,7 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
     default:
 
         gregorio_message(_("call with an argument which type is unknown"),
-                "gabc_write_gregorio_glyph", ERROR, 0);
+                "gabc_write_gregorio_glyph", VERBOSITY_ERROR, 0);
         break;
     }
 }
@@ -641,7 +640,7 @@ static void gabc_write_gregorio_element(FILE *f, gregorio_element *element)
     gregorio_glyph *current_glyph;
     if (!element) {
         gregorio_message(_("call with NULL argument"),
-                         "gabc_write_gregorio_element", ERROR, 0);
+                "gabc_write_gregorio_element", VERBOSITY_ERROR, 0);
         return;
     }
     current_glyph = element->u.first_glyph;
@@ -683,9 +682,8 @@ static void gabc_write_gregorio_element(FILE *f, gregorio_element *element)
         fprintf(f, "z");
         break;
     default:
-        gregorio_message(_
-                         ("call with an argument which type is unknown"),
-                         "gabc_write_gregorio_element", ERROR, 0);
+        gregorio_message(_("call with an argument which type is unknown"),
+                "gabc_write_gregorio_element", VERBOSITY_ERROR, 0);
         break;
     }
 }
@@ -725,8 +723,8 @@ static void gabc_write_gregorio_syllable(FILE *f, gregorio_syllable *syllable,
 {
     int voice = 0;
     if (!syllable) {
-        gregorio_message(_("call with NULL argument"),
-                         "gabc_write_syllable", ERROR, 0);
+        gregorio_message(_("call with NULL argument"), "gabc_write_syllable",
+                VERBOSITY_ERROR, 0);
         return;
     }
     if (syllable->text) {
@@ -783,9 +781,8 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     gregorio_syllable *syllable;
 
     if (!f) {
-        gregorio_message(_
-                         ("call with NULL file"),
-                         "gregoriotex_write_score", ERROR, 0);
+        gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
+                VERBOSITY_ERROR, 0);
         return;
     }
 
@@ -793,7 +790,8 @@ void gabc_write_score(FILE *f, gregorio_score *score)
         gabc_write_str_attribute(f, "name", score->name);
     } else {
         fprintf(f, "name: unknown;\n");
-        gregorio_message(_("name is mandatory"), "gabc_write_score", ERROR, 0);
+        gregorio_message(_("name is mandatory"), "gabc_write_score",
+                VERBOSITY_ERROR, 0);
     }
     gabc_write_str_attribute(f, "gabc-copyright", score->gabc_copyright);
     gabc_write_str_attribute(f, "score-copyright", score->score_copyright);
@@ -831,7 +829,7 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     gabc_write_str_attribute(f, "user-notes", score->user_notes);
     if (score->number_of_voices == 0) {
         gregorio_message(_("gregorio_score seems to be empty"),
-                         "gabc_write_score", ERROR, 0);
+                "gabc_write_score", VERBOSITY_ERROR, 0);
         return;
     }
     if (score->number_of_voices == 1) {

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -360,20 +360,20 @@ int main(int argc, char **argv)
             exit(0);
             break;
         case 'v':
-            if (verb_mode && verb_mode != VERB_WARNINGS) {
+            if (verb_mode && verb_mode != VERBOSITY_WARNING) {
                 fprintf(stderr, "warning: verbose option passed two times\n");
                 break;
             }
-            verb_mode = VERB_VERBOSE;
+            verb_mode = VERBOSITY_INFO;
             break;
         case 'W':
-            if (verb_mode == VERB_WARNINGS) {
+            if (verb_mode == VERBOSITY_WARNING) {
                 fprintf(stderr,
                         "warning: all-warnings option passed two times\n");
                 break;
             }
-            if (verb_mode != VERB_VERBOSE) {
-                verb_mode = VERB_WARNINGS;
+            if (verb_mode != VERBOSITY_INFO) {
+                verb_mode = VERBOSITY_WARNING;
             }
             break;
         case 'L':
@@ -502,7 +502,7 @@ int main(int argc, char **argv)
     }
 
     if (!verb_mode) {
-        verb_mode = VERB_ERRORS;
+        verb_mode = VERBOSITY_DEPRECATION;
     }
 
     gregorio_set_verbosity_mode(verb_mode);

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -146,7 +146,7 @@ static char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
 {
     if (!note) {
         gregorio_message(_("called with NULL pointer"),
-                "gregoriotex_determine_note_glyph_name", ERROR, 0);
+                "gregoriotex_determine_note_glyph_name", VERBOSITY_ERROR, 0);
         return "";
     }
 
@@ -224,8 +224,9 @@ static char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
         *type = AT_STROPHA;
         return "StrophaAucta";
     default:
-        gregorio_messagef("gregoriotex_determine_note_glyph_name", ERROR,
-                0, _("called with unknown shape: %d"), note->u.note.shape);
+        gregorio_messagef("gregoriotex_determine_note_glyph_name",
+                VERBOSITY_ERROR, 0, _("called with unknown shape: %d"),
+                note->u.note.shape);
         return "";
     }
 }
@@ -333,7 +334,7 @@ static inline int compute_ambitus(const gregorio_note *const current_note)
         ambitus = first - second;
     }
     if (ambitus < 1 || ambitus > MAX_AMBITUS) {
-        gregorio_messagef("compute_ambitus", ERROR, 0,
+        gregorio_messagef("compute_ambitus", VERBOSITY_ERROR, 0,
                 _("unsupported ambitus: %d"), ambitus);
         return 0;
     }
@@ -352,19 +353,18 @@ static char *compute_glyph_name(const gregorio_glyph *const glyph,
     int ambitus1, ambitus2, ambitus3;
     if (!glyph) {
         gregorio_message(_("called with NULL pointer"),
-                "compute_glyph_name", ERROR, 0);
+                "compute_glyph_name", VERBOSITY_ERROR, 0);
         return "";
     }
     if (!glyph->u.notes.first_note) {
         gregorio_message(_("called with a glyph that have no note"),
-                "compute_glyph_name", ERROR, 0);
+                "compute_glyph_name", VERBOSITY_ERROR, 0);
         return "";
     }
     current_note = glyph->u.notes.first_note;
     if (!current_note->next) {
         gregorio_message(_("called with a multi-note glyph that has only "
-                        "one note"), "compute_glyph_name", ERROR,
-                0);
+                    "one note"), "compute_glyph_name", VERBOSITY_ERROR, 0);
         return "";
     }
     if (!(ambitus1 = compute_ambitus(current_note))) {
@@ -406,12 +406,12 @@ char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
     char pitch = 0;
     if (!glyph) {
         gregorio_message(_("called with NULL pointer"),
-                "gregoriotex_determine_glyph_name", ERROR, 0);
+                "gregoriotex_determine_glyph_name", VERBOSITY_ERROR, 0);
         return "";
     }
     if (!glyph->u.notes.first_note) {
         gregorio_message(_("called with a glyph that has no note"),
-                "gregorio_tex_determine_glyph_name", ERROR, 0);
+                "gregorio_tex_determine_glyph_name", VERBOSITY_ERROR, 0);
         return "";
     }
     *gtype = T_ONE_NOTE;
@@ -679,8 +679,9 @@ char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         *type = AT_ONE_NOTE;
         break;
     default:
-        gregorio_messagef("gregoriotex_determine_glyph_name", ERROR, 0,
-                _("called with unknown glyph: %d"), glyph->u.notes.glyph_type);
+        gregorio_messagef("gregoriotex_determine_glyph_name", VERBOSITY_ERROR,
+                0, _("called with unknown glyph: %d"),
+                glyph->u.notes.glyph_type);
         break;
     }
     if (shape) {
@@ -810,7 +811,7 @@ static void gregoriotex_getlineinfos(gregorio_syllable *syllable,
     if (line == NULL) {
         gregorio_message(_
                 ("call with NULL pointer"),
-                "gregoriotex_write_score", ERROR, 0);
+                "gregoriotex_write_score", VERBOSITY_ERROR, 0);
         return;
     }
     /*
@@ -1245,8 +1246,8 @@ static char gregoriotex_clef_flat_height(char step, int line)
             offset = 8;
             break;
         default:
-            gregorio_messagef("gregoriotex_clef_flat_height", ERROR, 0,
-                    _("unknown line number: %d"), line);
+            gregorio_messagef("gregoriotex_clef_flat_height", VERBOSITY_ERROR,
+                    0, _("unknown line number: %d"), line);
             break;
         }
         break;
@@ -1265,13 +1266,13 @@ static char gregoriotex_clef_flat_height(char step, int line)
             offset = 5;
             break;
         default:
-            gregorio_messagef("gregoriotex_clef_flat_height", ERROR, 0,
-                    _("unknown line number: %d"), line);
+            gregorio_messagef("gregoriotex_clef_flat_height", VERBOSITY_ERROR,
+                    0, _("unknown line number: %d"), line);
             break;
         }
         break;
     default:
-        gregorio_messagef("gregoriotex_clef_flat_height", ERROR, 0,
+        gregorio_messagef("gregoriotex_clef_flat_height", VERBOSITY_ERROR, 0,
                 _("unknown clef type: %d"), step);
         break;
     }
@@ -1330,7 +1331,7 @@ static void gregoriotex_write_bar(FILE *f, gregorio_bar type,
         fprintf(f, "dominica{6}");
         break;
     default:
-        gregorio_messagef("gregoriotex_write_bar", ERROR, 0,
+        gregorio_messagef("gregoriotex_write_bar", VERBOSITY_ERROR, 0,
                 _("unknown bar type: %d"), type);
         break;
     }
@@ -1692,7 +1693,7 @@ static void gregoriotex_write_additional_line(FILE *f,
     char ambitus = 0;
     if (!current_note) {
         gregorio_message(_("called with no note"),
-                "gregoriotex_write_additional_line", ERROR, 0);
+                "gregoriotex_write_additional_line", VERBOSITY_ERROR, 0);
         return;
     }
     // patch to get a line under the full glyph in the case of dbc (for
@@ -1834,7 +1835,7 @@ static void gregoriotex_write_note(FILE *f, gregorio_note *note,
     if (!note) {
         gregorio_message(_
                 ("called with NULL pointer"),
-                "gregoriotex_write_note", ERROR, 0);
+                "gregoriotex_write_note", VERBOSITY_ERROR, 0);
         return;
     }
     if (note->u.note.shape == S_PUNCTUM
@@ -1957,7 +1958,7 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
     gregorio_element *element;
     if (!syllable) {
         gregorio_message(_("called with a NULL argument"),
-                "gregoriotex_syllable_first_type", ERROR, 0);
+                "gregoriotex_syllable_first_type", VERBOSITY_ERROR, 0);
     }
     element = syllable->elements[0];
     while (element) {
@@ -2301,12 +2302,12 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
     char *leading_shape, *shape;
     if (!glyph) {
         gregorio_message(_("called with NULL pointer"),
-                "gregoriotex_write_glyph", ERROR, 0);
+                "gregoriotex_write_glyph", VERBOSITY_ERROR, 0);
         return;
     }
     if (glyph->type != GRE_GLYPH || !glyph->u.notes.first_note) {
         gregorio_message(_("called with glyph without note"),
-                "gregoriotex_write_glyph", ERROR, 0);
+                "gregoriotex_write_glyph", VERBOSITY_ERROR, 0);
         return;
     }
     next_note_pitch = gregorio_determine_next_pitch(syllable, element, glyph);
@@ -3034,15 +3035,14 @@ void gregoriotex_write_score(FILE *f, gregorio_score *score)
     status->to_modify_note = NULL;
 
     if (!f) {
-        gregorio_message(_
-                ("call with NULL file"), "gregoriotex_write_score", ERROR, 0);
+        gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
+                VERBOSITY_ERROR, 0);
         return;
     }
 
     if (score->number_of_voices != 1) {
-        gregorio_message(_
-                ("gregoriotex only works in monophony (for the moment)"),
-                "gregoriotex_write_score", ERROR, 0);
+        gregorio_message(_("gregoriotex only works in monophony (for the "
+                    "moment)"), "gregoriotex_write_score", VERBOSITY_ERROR, 0);
     }
 
     fprintf(f, "%% File generated by gregorio %s\n", GREGORIO_VERSION);
@@ -3064,6 +3064,17 @@ void gregoriotex_write_score(FILE *f, gregorio_score *score)
     }
 
     fprintf(f, "\\begingregorioscore%%\n");
+    switch (score->centering) {
+    case SCHEME_SYLLABLE:
+        fprintf(f, "\\englishcentering%%\n");
+        break;
+    case SCHEME_VOWEL:
+        fprintf(f, "\\defaultcentering%%\n");
+        break;
+    default:
+        // don't set any centering
+        break;
+    }
     if (score->nabc_lines) {
         fprintf(f, "\\scorenabclines{%d}", (int)score->nabc_lines);
     }

--- a/src/messages.h
+++ b/src/messages.h
@@ -34,22 +34,23 @@
 #define ngt_(str, strtwo, count) str
 #endif
 
+typedef enum gregorio_verbosity {
+    VERBOSITY_INFO = 1,
+    VERBOSITY_WARNING,
+    VERBOSITY_DEPRECATION,
+    VERBOSITY_ERROR,
+    VERBOSITY_FATAL,
+} gregorio_verbosity;
+
 void gregorio_message(const char *string, const char *function_name,
-        char verbosity, int line_number);
-void gregorio_messagef(const char *function_name, char verbosity,
+        gregorio_verbosity verbosity, int line_number);
+void gregorio_messagef(const char *function_name,
+        gregorio_verbosity verbosity,
         int line_number, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 4, 5)));
-void gregorio_set_verbosity_mode(char new_mode);
+void gregorio_set_verbosity_mode(gregorio_verbosity verbosity);
 void gregorio_set_file_name(char *new_name);
 void gregorio_set_error_out(FILE *f);
 int gregorio_get_return_value(void);
-
-#define VERB_VERBOSE 1
-#define VERB_WARNINGS 2
-#define VERB_ERRORS 3
-#define VERBOSE VERB_VERBOSE
-#define WARNING VERB_WARNINGS
-#define ERROR VERB_ERRORS
-#define FATAL_ERROR 4
 
 #endif

--- a/src/struct.c
+++ b/src/struct.c
@@ -52,7 +52,7 @@ static gregorio_note *create_and_link_note(gregorio_note **current_note)
     gregorio_note *note = calloc(1, sizeof(gregorio_note));
     if (!note) {
         gregorio_message(_("error in memory allocation"),
-                         "create_and_link_note", FATAL_ERROR, 0);
+                         "create_and_link_note", VERBOSITY_FATAL, 0);
         return NULL;
     }
 
@@ -258,7 +258,7 @@ void gregorio_change_shape(gregorio_note *note, gregorio_shape shape)
 {
     if (!note || note->type != GRE_NOTE) {
         gregorio_message(_("trying to change the shape of something that is "
-                           "not a note"), "change_shape", ERROR, 0);
+                           "not a note"), "change_shape", VERBOSITY_ERROR, 0);
         return;
     }
     note->u.note.shape = shape;
@@ -297,7 +297,7 @@ void gregorio_add_liquescentia(gregorio_note *note, gregorio_liquescentia liq)
 {
     if (!note || note->type != GRE_NOTE) {
         gregorio_message(_("trying to make a liquescence on something that "
-                           "is not a note"), "add_liquescentia", ERROR, 0);
+                    "is not a note"), "add_liquescentia", VERBOSITY_ERROR, 0);
         return;
     }
     if (is_initio_debilis(liq)) {
@@ -397,7 +397,7 @@ static void gregorio_activate_isolated_h_episemus(gregorio_note *note,
                     "of a note sequence, ignored",
                     "isolated horizontal episemus at the beginning of a note "
                     "sequence, ignored", n), "activate_h_isolated_episemus",
-                WARNING, 0);
+                VERBOSITY_WARNING, 0);
         return;
     }
     if (note->type != GRE_NOTE) {
@@ -405,7 +405,7 @@ static void gregorio_activate_isolated_h_episemus(gregorio_note *note,
                     "that is not a note, ignored",
                     "isolated horizontal episemus after something that is not "
                     "a note, ignored", n), "activate_h_isolated_episemus",
-                WARNING, 0);
+                VERBOSITY_WARNING, 0);
         return;
     }
     for (; n > 0; --n) {
@@ -413,7 +413,7 @@ static void gregorio_activate_isolated_h_episemus(gregorio_note *note,
         if (!note || note->type != GRE_NOTE) {
             gregorio_message(_("found more horizontal episemus than notes "
                         "able to be under"), "activate_h_isolated_episemus",
-                    WARNING, 0);
+                    VERBOSITY_WARNING, 0);
             return;
         }
     }
@@ -426,18 +426,19 @@ void gregorio_add_h_episemus(gregorio_note *note,
 {
     if (!note || (note->type != GRE_NOTE && note->type != GRE_BAR)) {
         gregorio_message(_("trying to add a horizontal episemus on something "
-                           "that is not a note"), "add_h_episemus", ERROR, 0);
+                    "that is not a note"), "add_h_episemus",
+                VERBOSITY_ERROR, 0);
         return;
     }
     if (!nbof_isolated_episemus) {
         gregorio_message(_("NULL argument nbof_isolated_episemus"),
-                           "add_h_episemus", FATAL_ERROR, 0);
+                "add_h_episemus", VERBOSITY_FATAL, 0);
         return;
     }
     if (vposition && *nbof_isolated_episemus) {
         gregorio_message(_("trying to add a forced horizontal episemus on a "
-                           "note which already has an automatic horizontal "
-                           "episemus"), "add_h_episemus", ERROR, 0);
+                    "note which already has an automatic horizontal "
+                    "episemus"), "add_h_episemus", VERBOSITY_ERROR, 0);
         return;
     }
 
@@ -568,7 +569,7 @@ static gregorio_glyph *create_and_link_glyph(gregorio_glyph **current_glyph)
     gregorio_glyph *glyph = calloc(1, sizeof(gregorio_glyph));
     if (!glyph) {
         gregorio_message(_("error in memory allocation"),
-                         "create_and_link_glyph", FATAL_ERROR, 0);
+                         "create_and_link_glyph", VERBOSITY_FATAL, 0);
         return NULL;
     }
 
@@ -687,7 +688,7 @@ static gregorio_element *create_and_link_element(gregorio_element
     gregorio_element *element = calloc(1, sizeof(gregorio_element));
     if (!element) {
         gregorio_message(_("error in memory allocation"),
-                         "create_and_link_element", FATAL_ERROR, 0);
+                         "create_and_link_element", VERBOSITY_FATAL, 0);
         return NULL;
     }
 
@@ -772,7 +773,7 @@ void gregorio_add_character(gregorio_character **current_character,
         (gregorio_character *) calloc(1, sizeof(gregorio_character));
     if (!element) {
         gregorio_message(_("error in memory allocation"),
-                         "gregorio_add_character", FATAL_ERROR, 0);
+                         "gregorio_add_character", VERBOSITY_FATAL, 0);
         return;
     }
     element->is_character = 1;
@@ -823,7 +824,7 @@ void gregorio_begin_style(gregorio_character **current_character,
         (gregorio_character *) calloc(1, sizeof(gregorio_character));
     if (!element) {
         gregorio_message(_("error in memory allocation"),
-                         "add_note", FATAL_ERROR, 0);
+                         "add_note", VERBOSITY_FATAL, 0);
         return;
     }
     element->is_character = 0;
@@ -844,7 +845,7 @@ void gregorio_end_style(gregorio_character **current_character,
         (gregorio_character *) calloc(1, sizeof(gregorio_character));
     if (!element) {
         gregorio_message(_("error in memory allocation"),
-                         "add_note", FATAL_ERROR, 0);
+                         "add_note", VERBOSITY_FATAL, 0);
         return;
     }
     element->is_character = 0;
@@ -870,13 +871,14 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
     gregorio_element **tab;
     int i;
     if (number_of_voices > MAX_NUMBER_OF_VOICES) {
-        gregorio_message(_("too many voices"), "add_syllable", FATAL_ERROR, 0);
+        gregorio_message(_("too many voices"), "add_syllable", VERBOSITY_FATAL,
+                0);
         return;
     }
     next = calloc(1, sizeof(gregorio_syllable));
     if (!next) {
-        gregorio_message(_("error in memory allocation"),
-                         "add_syllable", FATAL_ERROR, 0);
+        gregorio_message(_("error in memory allocation"), "add_syllable",
+                VERBOSITY_FATAL, 0);
         return;
     }
     next->type = GRE_SYLLABLE;
@@ -915,7 +917,7 @@ static void gregorio_free_one_syllable(gregorio_syllable **syllable,
     gregorio_syllable *next;
     if (!syllable || !*syllable) {
         gregorio_message(_("function called with NULL argument"),
-                         "free_one_syllable", WARNING, 0);
+                "free_one_syllable", VERBOSITY_WARNING, 0);
         return;
     }
     for (i = 0; i < number_of_voices; i++) {
@@ -940,7 +942,7 @@ static void gregorio_free_syllables(gregorio_syllable **syllable,
 {
     if (!syllable || !*syllable) {
         gregorio_message(_("function called with NULL argument"),
-                         "free_syllables", WARNING, 0);
+                "free_syllables", VERBOSITY_WARNING, 0);
         return;
     }
     while (*syllable) {
@@ -1014,7 +1016,7 @@ static void gregorio_free_score_infos(gregorio_score *score)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_free_score_infos", WARNING, 0);
+                "gregorio_free_score_infos", VERBOSITY_WARNING, 0);
         return;
     }
     if (score->name) {
@@ -1057,7 +1059,7 @@ void gregorio_free_score(gregorio_score *score)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "free_one_syllable", WARNING, 0);
+                "free_one_syllable", VERBOSITY_WARNING, 0);
         return;
     }
     gregorio_free_syllables(&(score->first_syllable), score->number_of_voices);
@@ -1069,7 +1071,7 @@ void gregorio_set_score_name(gregorio_score *score, char *name)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_name", WARNING, 0);
+                "gregorio_set_score_name", VERBOSITY_WARNING, 0);
         return;
     }
     score->name = name;
@@ -1080,7 +1082,7 @@ void gregorio_set_score_gabc_copyright(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_gabc_copyright", WARNING, 0);
+                "gregorio_set_score_gabc_copyright", VERBOSITY_WARNING, 0);
         return;
     }
     score->gabc_copyright = gabc_copyright;
@@ -1091,7 +1093,7 @@ void gregorio_set_score_score_copyright(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_score_copyright", WARNING, 0);
+                "gregorio_set_score_score_copyright", VERBOSITY_WARNING, 0);
         return;
     }
     score->score_copyright = score_copyright;
@@ -1101,7 +1103,7 @@ void gregorio_set_score_office_part(gregorio_score *score, char *office_part)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_office_part", WARNING, 0);
+                "gregorio_set_score_office_part", VERBOSITY_WARNING, 0);
         return;
     }
     score->office_part = office_part;
@@ -1111,7 +1113,7 @@ void gregorio_set_score_occasion(gregorio_score *score, char *occasion)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_occasion", WARNING, 0);
+                "gregorio_set_score_occasion", VERBOSITY_WARNING, 0);
         return;
     }
     score->occasion = occasion;
@@ -1121,7 +1123,7 @@ void gregorio_set_score_meter(gregorio_score *score, char *meter)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_meter", WARNING, 0);
+                "gregorio_set_score_meter", VERBOSITY_WARNING, 0);
         return;
     }
     score->meter = meter;
@@ -1131,7 +1133,7 @@ void gregorio_set_score_commentary(gregorio_score *score, char *commentary)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_commentary", WARNING, 0);
+                "gregorio_set_score_commentary", VERBOSITY_WARNING, 0);
         return;
     }
     score->commentary = commentary;
@@ -1141,7 +1143,7 @@ void gregorio_set_score_arranger(gregorio_score *score, char *arranger)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_arranger", WARNING, 0);
+                "gregorio_set_score_arranger", VERBOSITY_WARNING, 0);
         return;
     }
     score->arranger = arranger;
@@ -1152,7 +1154,7 @@ void gregorio_set_score_number_of_voices(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_number_of_voices", WARNING, 0);
+                "gregorio_set_score_number_of_voices", VERBOSITY_WARNING, 0);
         return;
     }
     score->number_of_voices = number_of_voices;
@@ -1163,7 +1165,7 @@ void gregorio_set_score_lilypond_preamble(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_lilypond_preamble", WARNING, 0);
+                "gregorio_set_score_lilypond_preamble", VERBOSITY_WARNING, 0);
         return;
     }
     score->lilypond_preamble = lilypond_preamble;
@@ -1174,7 +1176,7 @@ void gregorio_set_score_opustex_preamble(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_opustex_preamble", WARNING, 0);
+                "gregorio_set_score_opustex_preamble", VERBOSITY_WARNING, 0);
         return;
     }
     score->opustex_preamble = opustex_preamble;
@@ -1185,7 +1187,7 @@ void gregorio_set_score_musixtex_preamble(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_musixtex_preamble", WARNING, 0);
+                "gregorio_set_score_musixtex_preamble", VERBOSITY_WARNING, 0);
         return;
     }
     score->musixtex_preamble = musixtex_preamble;
@@ -1195,7 +1197,7 @@ void gregorio_set_score_user_notes(gregorio_score *score, char *user_notes)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_name", WARNING, 0);
+                "gregorio_set_score_name", VERBOSITY_WARNING, 0);
         return;
     }
     score->user_notes = user_notes;
@@ -1225,7 +1227,7 @@ void gregorio_free_voice_infos(gregorio_voice_info *voice_info)
     gregorio_voice_info *next;
     if (!voice_info) {
         gregorio_message(_("function called with NULL argument"),
-                         "free_voice_info", WARNING, 0);
+                "free_voice_info", VERBOSITY_WARNING, 0);
         return;
     }
     while (voice_info) {
@@ -1257,7 +1259,7 @@ void gregorio_set_voice_annotation(gregorio_voice_info *voice_info,
     int annotation_num;
     if (!voice_info) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_voice_annotation", WARNING, 0);
+                "gregorio_set_voice_annotation", VERBOSITY_WARNING, 0);
         return;
     }
     // save the annotation in the first spare place.
@@ -1273,7 +1275,7 @@ void gregorio_set_score_author(gregorio_score *score, char *author)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_author", WARNING, 0);
+                "gregorio_set_score_author", VERBOSITY_WARNING, 0);
         return;
     }
     score->si.author = author;
@@ -1283,7 +1285,7 @@ void gregorio_set_score_date(gregorio_score *score, char *date)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_date", WARNING, 0);
+                "gregorio_set_score_date", VERBOSITY_WARNING, 0);
         return;
     }
     score->si.date = date;
@@ -1293,7 +1295,7 @@ void gregorio_set_score_manuscript(gregorio_score *score, char *manuscript)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_manuscript", WARNING, 0);
+                "gregorio_set_score_manuscript", VERBOSITY_WARNING, 0);
         return;
     }
     score->si.manuscript = manuscript;
@@ -1304,7 +1306,7 @@ void gregorio_set_score_manuscript_reference(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_reference", WARNING, 0);
+                "gregorio_set_score_reference", VERBOSITY_WARNING, 0);
         return;
     }
     score->si.manuscript_reference = manuscript_reference;
@@ -1315,8 +1317,8 @@ void gregorio_set_score_manuscript_storage_place(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_manuscript_storage_place", WARNING,
-                         0);
+                "gregorio_set_score_manuscript_storage_place",
+                VERBOSITY_WARNING, 0);
         return;
     }
     score->si.manuscript_storage_place = manuscript_storage_place;
@@ -1326,7 +1328,7 @@ void gregorio_set_score_book(gregorio_score *score, char *book)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_book", WARNING, 0);
+                "gregorio_set_score_book", VERBOSITY_WARNING, 0);
         return;
     }
     score->si.book = book;
@@ -1336,7 +1338,7 @@ void gregorio_set_score_transcriber(gregorio_score *score, char *transcriber)
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_transcriber", WARNING, 0);
+                "gregorio_set_score_transcriber", VERBOSITY_WARNING, 0);
         return;
     }
     score->si.transcriber = transcriber;
@@ -1347,7 +1349,7 @@ void gregorio_set_score_transcription_date(gregorio_score *score,
 {
     if (!score) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_score_transcription_date", WARNING, 0);
+                "gregorio_set_score_transcription_date", VERBOSITY_WARNING, 0);
         return;
     }
     score->si.transcription_date = transcription_date;
@@ -1357,7 +1359,7 @@ void gregorio_set_voice_style(gregorio_voice_info *voice_info, char *style)
 {
     if (!voice_info) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_voice_style", WARNING, 0);
+                "gregorio_set_voice_style", VERBOSITY_WARNING, 0);
         return;
     }
     voice_info->style = style;
@@ -1368,7 +1370,7 @@ void gregorio_set_voice_virgula_position(gregorio_voice_info *voice_info,
 {
     if (!voice_info) {
         gregorio_message(_("function called with NULL argument"),
-                         "gregorio_set_voice_virgula_position", WARNING, 0);
+                "gregorio_set_voice_virgula_position", VERBOSITY_WARNING, 0);
         return;
     }
     voice_info->virgula_position = virgula_position;
@@ -1404,7 +1406,7 @@ int gregorio_calculate_new_key(char step, int line)
         break;
     default:
         gregorio_message(_("can't calculate key"),
-                         "gregorio_calculate_new_key", ERROR, 0);
+                "gregorio_calculate_new_key", VERBOSITY_ERROR, 0);
         return NO_KEY;
     }
 }
@@ -1455,7 +1457,7 @@ void gregorio_det_step_and_line_from_key(int key, char *step, int *line)
         *step = '?';
         *line = 0;
         gregorio_message(_("can't determine step and line of the key"),
-                         "gregorio_det_step_and_line_from_key", ERROR, 0);
+                "gregorio_det_step_and_line_from_key", VERBOSITY_ERROR, 0);
         return;
     }
 }
@@ -1466,7 +1468,7 @@ static gregorio_glyph *gregorio_first_glyph(gregorio_syllable *syllable)
     gregorio_element *element;
     if (!syllable) {
         gregorio_message(_("called with a NULL argument"),
-                         "gregorio_first_glyph", ERROR, 0);
+                "gregorio_first_glyph", VERBOSITY_ERROR, 0);
     }
     element = syllable->elements[0];
     while (element) {
@@ -1507,7 +1509,7 @@ char gregorio_determine_next_pitch(gregorio_syllable *syllable,
     char temp;
     if (!element || !syllable) {
         gregorio_message(_("called with a NULL argument"),
-                         "gregorio_determine_next_pitch", ERROR, 0);
+                "gregorio_determine_next_pitch", VERBOSITY_ERROR, 0);
         return DUMMY_PITCH;
     }
     // we first explore the next glyphs to find a note, if there is one
@@ -1617,7 +1619,7 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
 
     if (!score || !score->first_syllable || !score->first_voice_info) {
         gregorio_message(_("score is not available"),
-                         "gregorio_fix_initial_keys", WARNING, 0);
+                "gregorio_fix_initial_keys", VERBOSITY_WARNING, 0);
         return;
     }
     error = malloc(100 * sizeof(char));
@@ -1637,7 +1639,8 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
             snprintf(error, 80, _("in voice %d the first element is a key "
                                   "definition, considered as initial key"),
                      i + 1);
-            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSE, 0);
+            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSITY_INFO,
+                    0);
         } else if (element->type == GRE_F_KEY_CHANGE) {
             clef =
                 gregorio_calculate_new_key(F_KEY,
@@ -1648,7 +1651,8 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
             snprintf(error, 80, _("in voice %d the first element is a key "
                                   "definition, considered as initial key"),
                      i + 1);
-            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSE, 0);
+            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSITY_INFO,
+                    0);
         }
         voice_info = voice_info->next_voice_info;
     }
@@ -1675,11 +1679,10 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
     for (i = 0; i < score->number_of_voices; i++) {
         if (voice_info->initial_key == NO_KEY) {
             voice_info->initial_key = default_key;
-            snprintf(error, 75,
-                     _
-                     ("no initial key definition in voice %d, default key definition applied"),
-                     i + 1);
-            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSE, 0);
+            snprintf(error, 75, _("no initial key definition in voice %d, "
+                        "default key definition applied"), i + 1);
+            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSITY_INFO,
+                    0);
         }
         voice_info = voice_info->next_voice_info;
     }

--- a/src/struct.h
+++ b/src/struct.h
@@ -319,8 +319,8 @@ typedef enum gregorio_word_position {
 
 // the centering schemes for gabc:
 typedef enum gregorio_lyric_centering {
-    SCHEME_LATINE = 1,
-    SCHEME_ENGLISH,
+    SCHEME_VOWEL = 1,
+    SCHEME_SYLLABLE,
 } gregorio_lyric_centering;
 
 typedef struct gregorio_extra_info {
@@ -719,7 +719,7 @@ static inline bool is_initio_debilis(char liquescentia)
     return liquescentia >= L_INITIO_DEBILIS;
 }
 
-#define SCHEME_DEFAULT SCHEME_LATINE
+#define SCHEME_DEFAULT SCHEME_VOWEL
 
 #define HEPISEMUS_NONE 0
 #define HEPISEMUS_AUTO -1

--- a/src/struct.h
+++ b/src/struct.h
@@ -319,7 +319,8 @@ typedef enum gregorio_word_position {
 
 // the centering schemes for gabc:
 typedef enum gregorio_lyric_centering {
-    SCHEME_VOWEL = 1,
+    SCHEME_DEFAULT = 0,
+    SCHEME_VOWEL,
     SCHEME_SYLLABLE,
 } gregorio_lyric_centering;
 
@@ -645,6 +646,7 @@ typedef struct gregorio_score {
     // then, as there are some metadata that are voice-specific, we add a
     // pointer to the first voice_info. (see comments below)
     struct gregorio_voice_info *first_voice_info;
+    gregorio_lyric_centering centering;
 } gregorio_score;
 
 /*
@@ -718,8 +720,6 @@ static inline bool is_initio_debilis(char liquescentia)
 {
     return liquescentia >= L_INITIO_DEBILIS;
 }
-
-#define SCHEME_DEFAULT SCHEME_VOWEL
 
 #define HEPISEMUS_NONE 0
 #define HEPISEMUS_AUTO -1

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -44,8 +44,8 @@ static size_t gregorio_mbstowcs(grewchar *dest, char *src, int n)
     unsigned char c;
     size_t res = 0;             // number of bytes we've done so far
     if (!src) {
-        gregorio_message(_("call with a NULL argument"),
-                         "gregorio_mbstowcs", ERROR, 0);
+        gregorio_message(_("call with a NULL argument"), "gregorio_mbstowcs",
+                VERBOSITY_ERROR, 0);
     }
     while (*src && ((int) res <= n || !dest)) {
         c = (unsigned char) (*src);
@@ -71,7 +71,7 @@ static size_t gregorio_mbstowcs(grewchar *dest, char *src, int n)
         } else {
             // printf("%s %d %d\n", src, res, c);
             gregorio_message(_("malformed UTF-8 sequence1"),
-                             "gregorio_mbstowcs", ERROR, 0);
+                    "gregorio_mbstowcs", VERBOSITY_ERROR, 0);
             return -1;
         }
         while (bytes_to_come > 0) {
@@ -83,7 +83,7 @@ static size_t gregorio_mbstowcs(grewchar *dest, char *src, int n)
                 result = (result << 6) | (c & 63);
             } else {
                 gregorio_message(_("malformed UTF-8 sequence2"),
-                                 "gregorio_mbstowcs", ERROR, 0);
+                        "gregorio_mbstowcs", VERBOSITY_ERROR, 0);
                 return -1;
             }
         }

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -805,8 +805,11 @@
 
 % gregorioattr (see its definition in gregorio-syllable) is 0 when we are in a score, and unset when we are not
 
+\newcount\gre@save@englishcentering% DEPRECATED
+
 %macro called at the beginning of a score
 \def\begingregorioscore{%
+  \global\gre@save@englishcentering=\gre@englishcentering\relax % DEPRECATED
   \ifgre@justifylastline%
     \xdef\gre@save@parfillskip{\the\parfillskip}
     \parfillskip=0pt plus 0pt minus 0pt\relax%
@@ -875,6 +878,7 @@
   \ifgre@justifylastline%
     \parfillskip=\gre@save@parfillskip\relax%
   \fi %
+  \global\gre@englishcentering=\gre@save@englishcentering\relax % DEPRECATED
   \relax%
 }%
 


### PR DESCRIPTION
In preparation for language-based centering, I've deprecated `centering-scheme` as discussed in #383.  Currently, this generates `\englishcentering` or `\defaultcentering` (contrary to what is documented) since @rpspringuel in currently in the process of updating the TeX, but we should obviously update this before release.

When/if this is merged, I will continue to use this branch for the language-based centering.

All tests currently pass except for the dump test that uses "english" centering.