### PR TITLE
Support for arbitrary number of lines in the annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
   - `highchoralsignshift` is now `choralsignupshift` and its sign is now inverted.
 - `\grecoloredlines` now takes a single argument, a named color, instead of the three components of an RGB color.  As a result, `\redlines` can now use `gregoriocolor`, making the red staff lines consistent with the text, even when the user teaks `gregoriocolor`.  Addresses [#21787 on the old tracker](https://gna.org/bugs/index.php?21787).
 - Style for score elements can now be changed via the `\grechangestyle` command.  This replaces the mixed system of styling commands which could be redefined for some elements and specialized commands for applying styles to others.  See GregorioRef for details.
+- Annotations with more than two lines are now supported.  To build the annotation box use `\greannoataion`.  See GregorioRef for details.
 
 ### Added
 - With thanks to Jakub Jelínek, St. Gallen style adiastematic notation is now handled through [nabc syntax](http://gregoriochant.org/dokuwiki/doku.php/language) (see GregorioNabcRef.pdf for details and [the new example](examples/FactusEst.gabc)). Only one line above the notes is currently handled. This is a preview, backward incompatible change are possible in future releases.
@@ -58,12 +59,14 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `\greabovelinestextstyle`, if you were redefining this command, use `\grechangeformat{abovelinestext}...` instead
 - `\grelowchoralsignstyle`, if you were redefining this command, use `\grechangeformat{lowchoralsign}...` instead
 - `\grehighchoralsignstyle`, if you were redefining this command, use `\grechangeformat{highchoralsign}...` instead
+- `\setaboveinitialseparation`, supplanted by `\grechangedim{annotationseparation}...`
 
 ### Removed
 - GregorioXML and OpusTeX output
 - Support for the font Gregoria.
 - Chironomy markings (gabc `u` and `U`), which were not working correctly in the first place.
 - `\Vbarsmall`, `\greletterbar`, and `\greletteraltbar`, supplanted by the new glyph system, see [UPGRADE.md](upgrade guide).
+- `\GreSetAboveInitialSeparation`, supplanted by `\grechangedim{annotationseparation}...`
 
 ## [3.0.2] - 2015-06-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
   - `highchoralsignshift` is now `choralsignupshift` and its sign is now inverted.
 - `\grecoloredlines` now takes a single argument, a named color, instead of the three components of an RGB color.  As a result, `\redlines` can now use `gregoriocolor`, making the red staff lines consistent with the text, even when the user teaks `gregoriocolor`.  Addresses [#21787 on the old tracker](https://gna.org/bugs/index.php?21787).
 - Style for score elements can now be changed via the `\grechangestyle` command.  This replaces the mixed system of styling commands which could be redefined for some elements and specialized commands for applying styles to others.  See GregorioRef for details.
-- Annotations with more than two lines are now supported.  To build the annotation box use `\greannoataion`.  See GregorioRef for details.
+- Annotations with more than two lines are now supported (originally requested [on the user list](http://www.mail-archive.com/gregorio-users%40gna.org/msg00164.html) when two line annoations were made possible).  To build the annotation box use `\greannoataion`.  See GregorioRef for details.
 
 ### Added
 - With thanks to Jakub Jelínek, St. Gallen style adiastematic notation is now handled through [nabc syntax](http://gregoriochant.org/dokuwiki/doku.php/language) (see GregorioNabcRef.pdf for details and [the new example](examples/FactusEst.gabc)). Only one line above the notes is currently handled. This is a preview, backward incompatible change are possible in future releases.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -74,6 +74,17 @@ Examples: Let's say you previously had the following in your LaTeX document:
 This would have made the text which was wrapped with `<alt></alt>` in your gabc file appear small and italicized in your score.  To update this to the new system you would replace the above line with the following:
     \grechangestyle{abovelinetext}{\small\it}
 
+### Annotations
+
+Support for annotations with an arbitrary number of lines has been added.  To facilite this, the old functions which added annotations to specific lines (either the first or the second) are consolidated into a single function `\greannotation` which builds the annotations line by line.  If you used the old functions for adding annotations, then you should switch out those functions for the new one.  
+
+The distance associated with the annotations has also been renamed (from `aboveinitialseparation` to `annotationseparation`) and added a new one (`annotationraise`).  The first still controls the spacing between the lines of the annoation.  The second controls the position of the annotation relative to the score, and thus replaces the second argument in the old functions.  By default, annotations are positioned so that the baseline of the first line is aligned with the top line of the staff.  Positive values of `annotationraise` will push the annotation up while negative values will push it down.  If you were previously using the second argument to `\gresetfirstlineaboveinitial` to adjust the spacing, you will need to convert this to call:
+
+    \grechangedim{annotationraise}{0.1cm}{1}
+    
+You will need to play with the vaule of the distance a bit to acheive the desired positioning.
+
+As is normal, calls to the deprecated command names will raise a warning but still work.  However there is one caveat: the old functions will always add the annotations to the bottom of the annotation list, regardless of the order in which they are called.  Previously, you could call `\gresetsecondannotation` before `\gresetfirstannotation` and still have the first annotation appear on top.   Which annotation appears on top is now determined by the order in which the functions are called.
     
 
 ## 3.0

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -474,6 +474,17 @@ Macro to adjust the thickness of the staff lines.
 
 Deprecated version: \verb=\gresetstafflinefactor=.
 
+\macroname{\textbackslash greannotation}{[\#1]\{\#2\}}{gregoriotex-main.tex}
+Macro to add annotations (the text which appears above the initial) to a score.  While a single call of the function does not support multiple lines, successive calls to the function will be added to the annotation as a new line below what is already there.
+
+\begin{argtable}
+  \#1 & c & When adding a new line, align the center of the new line with the center of the existing lines\\
+  & l & When adding a new line, align the left side of the new line with the left side of the existing lines\\
+  & r & When adding a new line, align the right side of the new line with the right side of the existing lines\\
+  \#2 & string & the text of the annotation
+\end{argtable}
+
+\textbf{Nota Bene:} The first argument does not affect the alignment of lines already in the annotation, only the way the new line aligns with the existing lines as a whole.
 
 
 
@@ -693,10 +704,15 @@ Space to force the initial width to.  Ignored when 0.
 
 Default: \unit[0]{cm}
 
-\macroname{aboveinitialseparation}{}{gsp-default.tex}
-This space is the one between the bottom of the first annotation line and the top of the second annotation line (above the initial).  
+\macroname{annotationseparation}{}{gsp-default.tex}
+This space is the one between lines in the annotation (text above the initial).  
 
 Default: \unit[0.85]{cm}
+
+\macroname{annotationraise}{}{gsp-default.tex}
+Amount to raise (positive) or lower (negative) the annotation from it's normal position (baseline of the first line aligned with the top line of the staff).
+
+Default: \unit[0]{cm}
 
 \macroname{noclefspace}{}{gsp-default.tex}
 Space at the beginning of the lines if there is no clef.  

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -308,8 +308,9 @@
 
 \def\greinitial#1{%
   % see comments on this function to see what it does
-  \gre@calculate@aboveinitialraise %
-  % we print the initial always at the same place, and the we print the GreAboveinitialfirstbox, centered
+  \gre@debugmsg{annotation}{Time to calculate the true raise.}%
+  \gre@calculate@annotationtrueraise %
+  % we print the initial always at the same place, and then we print the gre@box@annotation, centered
   % first we print the initial
   \gre@dimen@temp@five=-\gre@dimen@textlower %
   % if it is a big initial we print it on the second line 
@@ -323,15 +324,16 @@
       \greinitialformat{\global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth}%
       \endgre@style@initial%
     \fi%
-    \gre@debugmsg{ifdim}{ wd(GreAboveinitialfirstbox) > initialwidth}%
-    \ifdim\wd\GreAboveinitialfirstbox>\gre@dimen@initialwidth\relax%
-      \global\gre@dimen@initialwidth=\wd\GreAboveinitialfirstbox%
+    \gre@debugmsg{ifdim}{ wd(gre@box@annotation) > initialwidth}%
+    \ifdim\wd\gre@box@annotation>\gre@dimen@initialwidth\relax%
+      \global\gre@dimen@initialwidth=\wd\gre@box@annotation%
     \fi%
-    \gre@debugmsg{ifdim}{ wd(GreAboveinitialsecondbox) > initialwidth}%
-    \ifdim\wd\GreAboveinitialsecondbox>\gre@dimen@initialwidth\relax%
-      \global\gre@dimen@initialwidth=\wd\GreAboveinitialsecondbox%
-    \fi%
+    \gre@debugmsg{annotation}{Width check completed.}%
     \setbox\GreInitial=\hbox to \gre@dimen@initialwidth {\hss\raise -\gre@dimen@temp@five\hbox{\gre@style@initial\greinitialformat{#1}\endgre@style@initial}\hss}%
+    \gre@debugmsg{annotation}{Initial set.}%
+    \gre@style@initial%
+    \greinitialformat{\global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift}%
+    \endgre@style@initial%
   \else %
     \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace %
     \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext %
@@ -349,26 +351,17 @@
       \endgre@style@biginitial%
     \fi%
     \gre@debugmsg{ifdim}{ wd(GreAboveinitialfirstbox) > initialwidth}%
-    \ifdim\wd\GreAboveinitialfirstbox>\gre@dimen@initialwidth\relax%
-      \global\gre@dimen@initialwidth=\wd\GreAboveinitialfirstbox%
-    \fi%
-    \gre@debugmsg{ifdim}{ wd(GreAboveinitialsecondbox) > initialwidth}%
-    \ifdim\wd\GreAboveinitialsecondbox>\gre@dimen@initialwidth\relax%
-      \global\gre@dimen@initialwidth=\wd\GreAboveinitialsecondbox%
+    \ifdim\wd\gre@box@annotation>\gre@dimen@initialwidth\relax%
+      \global\gre@dimen@initialwidth=\wd\gre@box@annoation%
     \fi%
     \setbox\GreInitial=\hbox{\vbox to 0pt{\hbox to \gre@dimen@initialwidth {\hss\raise -\gre@dimen@temp@five\hbox{\gre@style@biginitial\grebiginitialformat{#1}\endgre@style@biginitial}\hss}\vss}}%
-  \fi %
-  \ifnum\grebiginitial=0\relax%
-    \gre@style@initial%
-    \greinitialformat{\global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift}%
-    \endgre@style@initial%
-  \else%
     \gre@style@biginitial%
     \grebiginitialformat{\global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift}%
     \endgre@style@biginitial%
-  \fi%
+  \fi %
   \hskip\gre@dimen@temp@four %
   \global\advance\gre@dimen@initialwidth by \gre@dimen@temp@four %
+  \gre@debugmsg{annotation}{Ready to place initial.}%
   \copy\GreInitial%
   \ifnum\grebiginitial=0\relax%
     \gre@style@initial%
@@ -382,32 +375,21 @@
   \hskip\gre@dimen@temp@four %
   \global\advance\gre@dimen@initialwidth by \gre@dimen@temp@four%
   % then we center the first box above the initial, if there is one
-  \gre@debugmsg{ifdim}{ wd(GreAboveinitialfirstbox) = 0pt}%
-  \ifdim\wd\GreAboveinitialfirstbox=0 pt\relax %
+  \gre@debugmsg{annotation}{Time to set the annotation.}%
+  \ifvoid\gre@box@annotation\relax%
+    \gre@debugmsg{annotation}{There is no annotation.}%
   \else %
+    \gre@debugmsg{annotation}{Calculate horizontal position.}%
     \gre@dimen@temp@five=\gre@dimen@initialwidth %
-    \advance\gre@dimen@temp@five by -\wd\GreAboveinitialfirstbox%
+    \advance\gre@dimen@temp@five by -\wd\gre@box@annotation%
     \divide\gre@dimen@temp@five by 2 %
     \gre@skip@temp@four = -\gre@dimen@initialwidth%
     \hskip\gre@skip@temp@four %
     \kern\gre@dimen@temp@five %
-    \raise\gre@dimen@aboveinitialfirstraise\copy\GreAboveinitialfirstbox%
+    \gre@debugmsg{annotation}{And place the annotation.}%
+    \raise\gre@dimen@annotationtrueraise\box\gre@box@annotation%
+    \gre@debugmsg{annotation}{Move to beginning of staff.}%
     \kern\gre@dimen@temp@five %
-    \setbox\GreAboveinitialfirstbox=\hbox{}%
-  \fi %
-  % then we center the second box above the initial, if there is one
-  \gre@debugmsg{ifdim}{ wd(GreAboveinitialsecondbox) = 0pt}%
-  \ifdim\wd\GreAboveinitialsecondbox=0 pt\relax %
-  \else %
-    \gre@dimen@temp@five=\gre@dimen@initialwidth %
-    \advance\gre@dimen@temp@five by -\wd\GreAboveinitialsecondbox %
-    \divide\gre@dimen@temp@five by 2 %
-    \gre@skip@temp@four = -\gre@dimen@initialwidth%
-    \hskip\gre@skip@temp@four %
-    \kern\gre@dimen@temp@five %
-    \raise\gre@dimen@aboveinitialsecondraise\copy\GreAboveinitialsecondbox %
-    \kern\gre@dimen@temp@five %
-    \setbox\GreAboveinitialsecondbox=\hbox{}%
   \fi %
   \relax %
 }%
@@ -419,33 +401,59 @@
   \relax %
 }%
 
-% We set two boxes for the two lines above the initial
 
-\newbox\GreAboveinitialfirstbox%
-\newbox\GreAboveinitialsecondbox%
-% the height difference between the bottom of the first annotation line and the top of the second annotation line (above the initial) is controlled by the \gre@dimen@aboveinitialseparation space, in gregoriotex-spaces.tex
+
+\newbox\gre@box@annotation%
+\newbox\gre@box@annotation@add%
+\newbox\gre@box@annotation@old%
+
+\def\greannotation{\@ifnextchar[{\gre@annotation}{\gre@annotation[c]}}%
+
+\def\gre@annotation[#1]#2{%
+  \ifx l#1\relax%
+    \let\gre@rightfill\hfil%
+    \let\gre@leftfill\relax%
+  \else\ifx r#1\relax%
+    \let\gre@rightfill\relax%
+    \let\gre@leftfill\hfil%
+  \else\ifx c#1\relax%
+    \let\gre@rightfill\hfil%
+    \let\gre@leftfill\hfil%
+  \else%
+    \greerror{Unrecognzied alignment option for \protect\greannotation}%
+  \fi\fi\fi%
+  % first we determine the widest box
+  \grewidthof{#2}%
+  \ifdim\gre@dimen@temp@three < \wd\gre@box@annotation\relax%
+    \gre@dimen@temp@three = \wd\gre@box@annotation\relax%
+  \fi%
+  \setbox\gre@box@annotation@old = \hbox to \gre@dimen@temp@three{\gre@leftfill\copy\gre@box@annotation\gre@rightfill}%
+  \setbox\gre@box@annotation@add = \hbox to \gre@dimen@temp@three{\gre@leftfill#2\gre@rightfill}%
+  \ifvoid\gre@box@annotation%
+    \gre@debugmsg{annotation}{We're on the first line of the annotation.}%
+    \setbox\gre@box@annotation = \hbox to \gre@dimen@temp@three{\vtop spread \gre@dimen@annotationseparation{\vss\noindent\box\gre@box@annotation@add}}%
+  \else%
+    \gre@debugmsg{annotation}{We're not on the first line of the annotation.}%
+    \setbox\gre@box@annotation = \hbox to \gre@dimen@temp@three{\vtop spread \gre@dimen@annotationseparation{\noindent\box\gre@box@annotation@old\vss\noindent\box\gre@box@annotation@add}}%
+  \fi%
+}%
+
 
 \def\gresetfirstlineaboveinitial#1#2{%
-  % we align the top of the box with the top of the line
-  % here the variables are a bit strange... we can calculate the final value of greaboveinitialfirstraise only after the beginning of the score, after the call to this macro. So we just set greaboveinitialfirstraise to the negative value the #2 will add, and then, after the beginning of the score, we'll add gresetaboveinitialraise that will... set greaboveinitialfirstraise.
-  \setbox\GreAboveinitialfirstbox=\hbox{#2}%
-  \global\gre@dimen@aboveinitialfirstraise=-\ht\GreAboveinitialfirstbox %
-  \global\setbox\GreAboveinitialfirstbox=\hbox{#1}%
-  \relax %
+  \gre@warning{\protect\gresetfirstlineaboveinitial\space is deprecated.\MessageBreak Use \protect\greannotation\space instead.}%
+  \greannotation{#1}%
 }%
 
 \def\gresetfirstannotation#1{%
-  \gresetfirstlineaboveinitial{#1}{#1}%
-  \relax %
+  \gre@warning{\protect\gresetfirstannotation\space is deprecated.\MessageBreak Use \protect\greannotation\space instead.}%
+  \greannotation{#1}%
 }%
 
 \let\setfirstannotation\gresetfirstannotation%
 
 \def\gresetsecondannotation#1{%
-  \setbox\GreAboveinitialsecondbox=\hbox{#1}%
-  \global\gre@dimen@aboveinitialsecondraise=-\ht\GreAboveinitialsecondbox %
-  \global\advance\gre@dimen@aboveinitialsecondraise by -\gre@dimen@aboveinitialseparation %
-  \relax %
+  \gre@warning{\protect\gresetsecondannotation\space is deprecated.\MessageBreak Use \protect\greannotation\space instead.}%
+  \greannotation{#1}%
 }%
 
 \let\setsecondannotation\gresetsecondannotation%
@@ -466,7 +474,7 @@
 }%
 
 \def\gregorianmode#1{%
-  \ifhbox \GreAboveinitialfirstbox%
+  \ifhbox \gre@box@annotation%
     \relax%
   \else%
     \ifcase#1%
@@ -854,7 +862,6 @@
   % with some versions of LuaTeX, the \localrightbox and \localleftbox must be set empty in an environment with the good attributes set
   \grelocalleftbox{}%
   \grelocalrightbox{}%
-  \setbox\GreAboveinitialfirstbox=\hbox{}%
   \gre@calculate@additionalspaces{0}{0}%
   \global\gre@dimen@currentabovelinestextheight=0 sp%
   \gre@removetranslationspace %

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -431,6 +431,10 @@
   \setbox\gre@box@annotation@add = \hbox to \gre@dimen@temp@three{\gre@leftfill#2\gre@rightfill}%
   \ifvoid\gre@box@annotation%
     \gre@debugmsg{annotation}{We're on the first line of the annotation.}%
+    % This start point has been fudged manually to get the baseline of the first annotation to align with the top line of the staff.
+    \gre@debugmsg{annnotation}{Initial set point.}%
+    \global\gre@dimen@annotationtrueraise= 0.8em\relax%
+    \global\advance\gre@dimen@annotationtrueraise by -\dp\gre@box@annotation@add%
     \setbox\gre@box@annotation = \hbox to \gre@dimen@temp@three{\vtop spread \gre@dimen@annotationseparation{\vss\noindent\box\gre@box@annotation@add}}%
   \else%
     \gre@debugmsg{annotation}{We're not on the first line of the annotation.}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -782,17 +782,26 @@
 }%
 
 %The distance from the baseline of the line to the baseline of the annotations
-\newdimen\gre@dimen@aboveinitialfirstraise%
-\newdimen\gre@dimen@aboveinitialsecondraise%
+\newdimen\gre@dimen@annotationtrueraise%
 % When text is placed in the annotation boxes these dimensions are initialized with values based on the contents and the user parameters
 %This function sets the true raises of the two lines above the inital (it has to be called just as the boxes are placed in order to make sure that the values are all correct)
-\def\gre@calculate@aboveinitialraise{%
-  \global\advance\gre@dimen@aboveinitialfirstraise by \gre@dimen@staffheight %
-  \global\advance\gre@dimen@aboveinitialfirstraise by \gre@dimen@spacebeneathtext %
-  \global\advance\gre@dimen@aboveinitialfirstraise by \gre@dimen@currenttranslationheight %
-  \global\advance\gre@dimen@aboveinitialfirstraise by \gre@dimen@spacelinestext %
-  \global\advance\gre@dimen@aboveinitialfirstraise by \gre@dimen@additionalbottomspace %
-  \global\advance\gre@dimen@aboveinitialsecondraise by \gre@dimen@aboveinitialfirstraise %
+\def\gre@calculate@annotationtrueraise{%
+  \gre@debugmsg{annotation}{Calculating the raise.}%
+  % This start point has been fudged manually to get the baseline of the first annotation to align with the top line of the staff.
+  \gre@debugmsg{annnotation}{Initial set point.}%
+  \global\gre@dimen@annotationtrueraise= 0.54em\relax%
+  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@staffheight %
+  \gre@debugmsg{annnotation}{Added staff height.}%
+  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@spacebeneathtext %
+  \gre@debugmsg{annnotation}{Added space beneath text.}%
+  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@currenttranslationheight %
+  \gre@debugmsg{annnotation}{Added translation height.}%
+  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@spacelinestext %
+  \gre@debugmsg{annnotation}{Added spacelinestext.}%
+  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@additionalbottomspace %
+  \gre@debugmsg{annnotation}{Added additional bottom space.}%
+  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@annotationraise %
+  \gre@debugmsg{annnotation}{Added user raise.}%
   \relax %
 }%
 
@@ -934,7 +943,8 @@
   \IfStrEq{#1}{beforeinitialshift}{\rubberfalse}{\relax}%
   \IfStrEq{#1}{minimalspaceatlinebeginning}{\rubberfalse}{\relax}%
   \IfStrEq{#1}{manualinitialwidth}{\rubberfalse}{\relax}%
-  \IfStrEq{#1}{aboveinitialseparation}{\rubberfalse}{\relax}%
+  \IfStrEq{#1}{annotationseparation}{\rubberfalse}{\relax}%
+  \IfStrEq{#1}{annotationraise}{\rubberfalse}{\relax}%
   \IfStrEq{#1}{noclefspace}{\rubberfalse}{\relax}%
   \IfStrEq{#1}{clivisalignmentmin}{\rubberfalse}{\relax}%
   \IfStrEq{#1}{abovesignsspace}{\rubberfalse}{\relax}%
@@ -1210,8 +1220,11 @@
   \ifnum\gre@scale@manualinitialwidth=1\relax%
     \gre@changeonedimenfactor{manualinitialwidth}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@aboveinitialseparation=1\relax%
-    \gre@changeonedimenfactor{aboveinitialseparation}{#1}{#2}%
+  \ifnum\gre@scale@annotationseparation=1\relax%
+    \gre@changeonedimenfactor{annotationseparation}{#1}{#2}%
+  \fi%
+  \ifnum\gre@scale@annotationraise=1\relax%
+    \gre@changeonedimenfactor{annotationraise}{#1}{#2}%
   \fi%
   \ifnum\gre@scale@noclefspace=1\relax%
     \gre@changeonedimenfactor{noclefspace}{#1}{#2}%
@@ -1276,18 +1289,14 @@
 
 % To change the spacing between annotations.
 %First argument is distance, second is whether it should scale when \grefactor changes.
-\ifdefined\setaboveinitialseparation%
-  \greerror{\protect\setaboveinitialseparation\space is already defined.  Check for package conflicts.}%
-\else%
-  \def\setaboveinitialseparation#1#2{%
-    \grechangedim{aboveinitialseparation}{#1}{#2}%
-    \relax %
-  }%
-\fi%
+\def\setaboveinitialseparation#1#2{%
+  \gre@warning{\protect\setaboveinitialseparation\space is deprecated.\MessageBreak Use \protect\grechangedim\{annotationseparation\}\space instead.}%
+  \grechangedim{annotationseparation}{#1}{#2}%
+  \relax %
+}%
 
 \def\GreSetAboveInitialSeparation#1{%
-  \gre@warning{\protect\GreSetAboveInitialSeparation\space is deprecated.\MessageBreak Use \protect\setaboveiniitalseparation\space instead.}%
-  \setaboveinitialseparation#1{1}%
+  \greerror{\protect\GreSetAboveInitialSeparation\space is obsolete.\MessageBreak Use \protect\grechangedim\{annotationseparation\}\space instead.}%
 }%
 
 %To change the space after the initial

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -787,9 +787,6 @@
 %This function sets the true raises of the two lines above the inital (it has to be called just as the boxes are placed in order to make sure that the values are all correct)
 \def\gre@calculate@annotationtrueraise{%
   \gre@debugmsg{annotation}{Calculating the raise.}%
-  % This start point has been fudged manually to get the baseline of the first annotation to align with the top line of the staff.
-  \gre@debugmsg{annnotation}{Initial set point.}%
-  \global\gre@dimen@annotationtrueraise= 0.54em\relax%
   \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@staffheight %
   \gre@debugmsg{annnotation}{Added staff height.}%
   \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@spacebeneathtext %

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -164,9 +164,10 @@
 \gresetdim{minimalspaceatlinebeginning}{0.05 cm}{1}%
 % space to force the initial width to.  Ignored when 0.
 \gresetdim{manualinitialwidth}{0 cm}{1}%
-% this space is the one between the bottom of the first anotation line and the top
-% of the second anotation line (above the initial)
-\gresetdim{aboveinitialseparation}{0.05 cm}{1}%
+% Space between lines in the annotation
+\gresetdim{annotationseparation}{0.05cm}{1}%
+% Amount to raise (positive) or lower (negative) the annotations from the default position (base line of top annotation aligned with top line of staff)
+\gresetdim{annotationraise}{0cm}{1}%
 % space at the beginning of the lines if there is no clef
 \gresetdim{noclefspace}{0.1 cm}{1}%
 % space around a clef change


### PR DESCRIPTION
Annotation functions are consolidated into a single function `\greannotation` which can, through multiple calls, build up an annotation with an arbitrary number of lines.
There are now two distances associated with the annotation `annotationseparation` (a renaming of `aboveinitialseparation` for consistency) and `annotationraise`.  The first controls the distance between lines in the annotation, the second raises or lowers the annotation from it's default position (baseline of the first line aligned with the top line of the staff).  This second distance should be more transparent than the old method of measuring the height of a second argument to the annotation functions and more consistent with how other spaces are manipulated.

Three tests fail, all involving the placement of an annotation (as expected, since the new default is slightly higher than the old one).