### PR TITLE
Make `writemode` use the new `\greannotation`.

### DIFF
--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -254,6 +254,14 @@ argument.
   \#2 & string & Relative or absolute path to the score.\\
 \end{argtable}
 
+\macroname{\textbackslash gre@writemode}{\#1}{gregoriotex-main.tex}
+Macro that writes its argument with \verb=\greannotation=. The
+argument typically is given to this macro by \verb=\Gremode= in the
+gtex file.
+
+\begin{argtable}
+  \#1 & string & Text to place above the initial of a score.\\
+\end{argtable}
 
 \subsection{Distances}
 All of the distances listed in \nameref{distances} have two internals

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -256,7 +256,7 @@ argument.
 
 \macroname{\textbackslash gre@writemode}{\#1}{gregoriotex-main.tex}
 Macro that writes its argument with \verb=\greannotation=. The
-argument typically is given to this macro by \verb=\Gremode= in the
+argument typically is given to this macro by \verb=\GreMode= in the
 gtex file.
 
 \begin{argtable}

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -472,8 +472,8 @@
 %% macros for the typesetting the things above the initial
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\def\writemode#1{%
-  \gresetfirstlineaboveinitial{\sc{\bf{#1}}}{\sc{\bf{#1}}}%
+\def\gre@writemode#1{%
+  \greannotation{\sc{\bf{#1}}}%
   \relax %
 }%
 
@@ -483,21 +483,21 @@
   \else%
     \ifcase#1%
     \or%
-      \writemode{I}%
+      \gre@writemode{I}%
     \or%
-      \writemode{II}%
+      \gre@writemode{II}%
     \or%
-      \writemode{III}%
+      \gre@writemode{III}%
     \or%
-      \writemode{IV}%
+      \gre@writemode{IV}%
     \or%
-      \writemode{V}%
+      \gre@writemode{V}%
     \or%
-      \writemode{VI}%
+      \gre@writemode{VI}%
     \or%
-      \writemode{VII}%
+      \gre@writemode{VII}%
     \or%
-      \writemode{VIII}%
+      \gre@writemode{VIII}%
     \fi%
   \fi%
   \relax%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -473,7 +473,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \def\gre@writemode#1{%
-  \greannotation{\sc{\bf{#1}}}%
+  \greannotation{\gresmallcaps{\greboldfont{#1}}}%
   \relax %
 }%
 

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -168,9 +168,3 @@
 \def\gre@changestyle#1#2[#3]{%
   \renewenvironment{gre@style@#1}{\begingroup#2}{#3\endgroup}%
 }%
-
-% keep this here, but \writemode may be deprecated at some point
-\def\writemode#1{%
-  \gresetfirstlineaboveinitial{\textsc{\textbf{#1}}}{\textsc{\textbf{#1}}}%
-  \relax %
-}


### PR DESCRIPTION
Removed the conflicting macro definition from `gregoriotex.sty`

Renamed `writemode` to conform with the new naming scheme.

Added `gre@writemode` to `GregorioRef`