### PR TITLE
Added the ability to alias language rule sets to multiple names.

### DIFF
--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -131,6 +131,15 @@ The keywords are:
 
 \begin{description}
 
+\item[alias]
+
+The \texttt{alias} keyword indicates that a given name is an alias for a
+given language.  The \texttt{alias} keyword must be followed by the name
+of the alias (enclosed in square brackets), the \texttt{to} keyword, the
+name of the target language (enclosed in square brackets), and a
+semicolon.  Since gregorio reads the vowel files sequentially, aliases
+should precede the language they are aliasing, for best performance.
+
 \item[language]
 
 The \texttt{language} keyword indicates that the rules which follow are
@@ -166,6 +175,8 @@ English and \emph{y} in Spanish.
 By way of example, here is a vowel file that works for English:
 
 \begin{lstlisting}
+alias [english] to [English];
+
 language [English];
 
 vowel aàáAÀÁ;

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -665,6 +665,7 @@ language_definition:
     LANGUAGE attribute {
         check_multiple("language", got_language);
         gregorio_set_centering_language($2.text);
+        free($2.text);
         got_language = true;
     }
     ;

--- a/src/vowel/vowel-rules.l
+++ b/src/vowel/vowel-rules.l
@@ -72,7 +72,9 @@ static inline void invalid(void)
 <INITIAL>vowel                  { BEGIN(chars); return VOWEL; }
 <INITIAL>prefix                 { BEGIN(chars); return PREFIX; }
 <INITIAL>suffix                 { BEGIN(chars); return SUFFIX; }
+<INITIAL>alias                  { BEGIN(lang); return ALIAS; }
 <*>;                            { BEGIN(INITIAL); return SEMICOLON; }
+<lang>to                        { return TO; }
 <lang>"["                       { BEGIN(langname); }
 <langname>[^\]]+                { save_lval(); return NAME; }
 <langname>"]"                   { BEGIN(lang); }

--- a/src/vowel/vowel.h
+++ b/src/vowel/vowel.h
@@ -24,11 +24,17 @@
 #include <stdbool.h>
 #include "unicode.h"
 
-int gregorio_vowel_rulefile_parse(const char *filename, const char *language,
-        bool *found);
+typedef enum rulefile_parse_status {
+    RFPS_NOT_FOUND = 0,
+    RFPS_FOUND,
+    RFPS_ALIASED,
+} rulefile_parse_status;
+
+int gregorio_vowel_rulefile_parse(const char *filename, const char **language,
+        rulefile_parse_status *status);
 void gregorio_vowel_tables_init(void);
-bool gregorio_vowel_tables_load(FILE *f, const char *filename,
-        const char *language);
+void gregorio_vowel_tables_load(const char *filename, const char **language,
+        rulefile_parse_status *status);
 void gregorio_vowel_tables_free(void);
 void gregorio_vowel_table_add(const char *vowels);
 void gregorio_prefix_table_add(const char *prefix);

--- a/tex/gregorio-vowels.dat
+++ b/tex/gregorio-vowels.dat
@@ -19,6 +19,13 @@
 # Comments begin with a hash symbol and end at the end of the line.  These two
 # lines are comments.
 
+# The "alias" keyword indicates that a name is an alias for a given language.
+# The "alias" keyword must be followed by the name of the alias in square
+# brackets, the "to" keyword, the name of the target language in square
+# brackets, and a semicolon.  For best performance, aliases should precede the
+# language they are aliasing.
+alias [english] to [English];
+
 # The "language" keyword indicates that the rules which follow are for the
 # specified language.  It must be followed by the language name enclosed in
 # square brackets and a semicolon.  The language specified applies until the


### PR DESCRIPTION
The syntax is `alias [name] to [language];`.  Hopefully I documented this clearly.

Ready for review.  This also fixes a memory leak in vowel parsing.