### PR TITLE
Fix problem when openout_any = p

### DIFF
--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -311,16 +311,16 @@ end
 
 local function direct_gabc(gabc, header)
   tmpname = os.tmpname()
-  local p = io.popen('gregorio -s -o '..tmpname, 'w')
+  local f = io.open(tmpname, 'w')
+  f:write('name:direct-gabc;\n'..(header or '')..'\n%%\n'..gabc:gsub('\\par ', '\n'))
+  f:close()
+  local p = io.popen('gregorio -S '..tmpname, 'r')
   if p == nil then
-    err("\nSomething went wrong when executing\n    gregorio -s -o "..tmpname..".\n"
+    err("\nSomething went wrong when executing\n    gregorio -S "..tmpname..".\n"
     .."shell-escape mode may not be activated. Try\n\n%s --shell-escape %s.tex\n\nSee the documentation of gregorio or your TeX\ndistribution to automatize it.", tex.formatname, tex.jobname)
   end
-  p:write('name:direct-gabc;\n'..(header or '')..'\n%%%%\n'..gabc:gsub('\\par ', '\n'))
+  tex.print(p:read("*a"):explode('\n'))
   p:close()
-  f = io.open(tmpname)
-  tex.print(f:read("*a"):explode('\n'))
-  f:close()
   os.remove(tmpname)
 end
 


### PR DESCRIPTION
Since Gregorio refuses to write to `/tmp/lua_XXXX` when `openout_any = p`, it wasn't possible any more to use `\gabcsnippet` without `openout_any = a`.
As LuaLaTeX accepts to write to `/tmp/lua_XXXX` event with `openout_any = p`, writing gabc content into the tmpfile, then reading directly from gregorio process makes it possible again.