### PR TITLE
Add package option to make deprecated commands raise an error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `\gresethyphen{force}` forces GregorioTeX to put a hyphen between each syllable in a polysyllabic word.  `\gresethyphen{auto}` restores behavior to normal.
 - Support for custom vowel centering rules.  Put a file called `gregorio-vowels.dat` into your project directory or into a directory accessible from TEXMF and add the header `language: name;` to your gabc file.  The `gregorio-vowels.dat` file describes how vowels are to be located in the *name* language.  See GregorioRef for details.
 - `\gresetlinecolor` takes a named color as an argument.  As a result, the red staff lines can be made consistent with the text, even when the user changes `gregoriocolor` with `\gresetlinecolor{gregoriocolor}`.  Addresses [#21787 on the old tracker](https://gna.org/bugs/index.php?21787).
+- Package option `deprecated=false`. Causes all deprecated commands to raise an error and halt TeX.
 
 ### Deprecated
 - `\GreSetStaffLinesFormat`, supplanted by `\grechangeformat{normalstafflines}...`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,9 +7,11 @@ This file contains instructions to upgrade to a new release of Gregorio.
 
 A naming scheme for GregorioTeX commands has been established and so most commands have had their names changed in order to bring them into line with the new scheme.  Some have also had their syntax changed.  Breifly, user commands all now have a `\gre` prefix (to prevent name colisions with other packages) and groups of commands which altered a single setting have been replaced by a single command which takes an argument specifying the value of the setting.  The notable exception to this are the two main commands: `\gregorioscore` (replaces `\includescore`) and `\gabcsnippet`.  See GregorioRef for the complete list of new command names and their syntax.
 
-Old command names should still work for now, but will raise a deprecation warning.  Exceptions are noted below:
+Old command names should still work for now, but will raise a deprecation warning which indicates the name of the correct command to use. Exceptions are noted below:
 
 - `\grescaledim`: This function now takes two arguments.  The second should be `yes`, `true`, or `on` to acheive the old behavior.
+
+Additionally a new package option has been added. The option `deprecated=false` is helpful if you wish to ensure that your TeX file is compliant with the new naming system. This option causes all deprecated commands to raise an error, halting TeX, thus allowing you to actively find all deprecated commands and update them in your TeX file.
 
 ### Barred letters
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -29,6 +29,10 @@ The optional arguments are:
     gtex has an outdated version, or the gtex file does not exist, %
     THEN Gregorio\TeX\ will compile a new gtex file.\\
   forcecompile & Gregorio\TeX\ will compile all scores from their gabc files.\\
+  \hline
+  deprecated=false & Force all deprecated commands to raise a package error %
+    rather than a warning. This allows the user to ensure that their file is %
+    compliant with the current version of Gregorio\TeX.\\
 \end{tabular}\bigskip
 
 \textbf{Note:} \verb=nevercompile=, \verb=autocompile=, and

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -7,6 +7,32 @@ process the commands listed above.  They should not appear in any user
 document and are listed here for programmer documentation purposes
 only.
 
+\macroname{\textbackslash greerror}{\#1}{gregoriotex.sty}
+Prints an error to the \TeX\ output log.
+
+\begin{argtable}
+  \#1 & string & error message\\
+\end{argtable}
+
+
+\macroname{\textbackslash gre@warning}{\#1}{gregoriotex.sty}
+Prints a warning to the \TeX\ output log.
+
+\begin{argtable}
+  \#1 & string & warning message\\
+\end{argtable}
+
+\macroname{\textbackslash gre@deprecated}{\#1\#2}{gregoriotex.sty}
+Macro that handles deprecated macros. By default, deprecated macros
+are allowed and a warning is printed. If the package option
+\texttt{deprecated=false} is set, then deprecated macros raise a
+package error, halting \TeX.
+
+\begin{argtable}
+  \#1 & string & name of the deprecated macro\\
+  \#2 & string & name of the correct macro to use\\
+\end{argtable}
+
 \macroname{\textbackslash gre@loadgregoriofont}{}{gregoriotex-main.tex}
 Loads the chosen font for the neumes at the correct size.
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -444,19 +444,19 @@
 
 
 \def\gresetfirstlineaboveinitial#1#2{%
-  \gre@warning{\protect\gresetfirstlineaboveinitial\space is deprecated.\MessageBreak Use \protect\greannotation\space instead.}%
+  \gre@deprecated{\protect\gresetfirstlineaboveinitial}{\protect\greannotation}%
   \greannotation{#1}%
 }%
 
 \def\gresetfirstannotation#1{%
-  \gre@warning{\protect\gresetfirstannotation\space is deprecated.\MessageBreak Use \protect\greannotation\space instead.}%
+  \gre@deprecated{\protect\gresetfirstannotation}{\protect\greannotation}%
   \greannotation{#1}%
 }%
 
 \let\setfirstannotation\gresetfirstannotation%
 
 \def\gresetsecondannotation#1{%
-  \gre@warning{\protect\gresetsecondannotation\space is deprecated.\MessageBreak Use \protect\greannotation\space instead.}%
+  \gre@deprecated{\protect\gresetsecondannotation}{\protect\greannotation}%
   \greannotation{#1}%
 }%
 
@@ -471,12 +471,12 @@
 }%
 
 \def\GreScoreReference#1{
-  \gre@warning{\protect\GreScoreReference\space is deprecated.\MessageBreak Use \protect\grescorereference\space instead}%
+  \gre@deprecated{\protect\GreScoreReference}{\protect\grescorereference}%
   \grescorereference{#1}%
 }%
 
 \def\scorereference#1{%
-  \gre@warning{\protect\scorereference\space is deprecated.\MessageBreak Use \protect\grescorereference\space instead}%
+  \gre@deprecated{\protect\scorereference}{\protect\grescorereference}%
   \grescorereference{#1}%
 }%
 
@@ -543,8 +543,8 @@
 }
 
 \def\commentary#1{%
-  \gre@warning{\protect\commentary\space is deprecated.\MessageBreak Use \protect\grecommentary\space instead.}
-  \grecommentary{#1}
+  \gre@deprecated{\protect\commentary}{\protect\grecommentary}%
+  \grecommentary{#1}%
 }%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -626,13 +626,13 @@
 }
 
 \def\greremovelines{%
-  \gre@warning{\protect\greremovelines\space is deprecated.\MessageBreak Use \protect\gresetlines{invisible} instead}
-  \gresetlines{invisible}
+  \gre@deprecated{\protect\greremovelines}{\protect\gresetlines{invisible}}%
+  \gresetlines{invisible}%
 }%
 
 \def\gredonotremovelines{%
-  \gre@warning{\protect\gredonotremovelines\space is deprecated.\MessageBreak Use \protect\gresetlines{visible} instead}
-  \gresetlines{visible}
+  \gre@deprecated{\protect\gredonotremovelines}{\protect\gresetlines{visible}}%
+  \gresetlines{visible}%
 }%
 
 %% macro that draws the stafflines on the first line, it is different from others due to the initial that can take some place, without lines
@@ -798,7 +798,7 @@
 }%
 
 \def\setgretranslationcenteringscheme#1{%
-  \gre@warning{\protect\setgretranslationcenteringscheme\space is deprecated.\MessageBreak Use \protect\gresettranslationcentering\space instead}%
+  \gre@deprecated{\protect\setgretranslationcenteringscheme}{\protect\gresettranslationcentering}%
   \ifnum#1=0\relax%
     \gresettranslationcentering{left}%
   \else%
@@ -820,7 +820,7 @@
 }%
 
 \def\gresetnlbintranslation#1{%
-  \gre@warning{\protect\gresetnlbintranslation\space is deprecated.\MessageBreak Use \protect\gresetbreakintranslation\space instead}%
+  \gre@deprecated{\protect\gresetnlbintranslation}{\protect\gresetbreakintranslation}%
   \ifnum#1=0\relax%
     \gresetbreakintranslation{allow}%
   \else%
@@ -1029,12 +1029,12 @@
 }%
 
 \def\gredisableeolshifts{%
-  \gre@warning{\protect\gredisableeolshifts\space is deprecated.\MessageBreak Use \protect\greseteolshifts{disable}\space instead}%
+  \gre@deprecated{\protect\gredisableeolshifts}{\protect\greseteolshifts{disable}}%
   \gre@eolshiftsenabledfalse%
 }%
 
 \def\greenableeolshifts{%
-  \gre@warning{\protect\greenableeolshifts\space is deprecated.\MessageBreak Use \protect\greseteolshifts{enable}\space instead}%
+  \gre@deprecated{\protect\greenableeolshifts}{\protect\greseteolshifts{enable}}%
   \gre@eolshiftsenabledtrue%
 }%
 
@@ -1056,7 +1056,7 @@
 
 % macro to suppress the custos
 \def\greblockcustos{%
-  \gre@warning{\protect\greblockcustos\space is deprecated.\MessageBreak Use \protect\greseteolcustos{manual}\space instead}%
+  \gre@deprecated{\protect\greblockcustos}{\protect\greseteolcustos{manual}}%
   \greseteolcusots{manual}%
 }%
 
@@ -1305,7 +1305,7 @@
 }%
 
 \def\GreSetStaffLinesFormat#1{%
-  \gre@warning{\protect\GreSetStaffLinesFormat\space is deprecated.\MessageBreak Use \protect\grechangestyle{normalstafflines} instead.}%
+  \gre@deprecated{\protect\GreSetStaffLinesFormat}{\protect\grechangestyle{normalstafflines}}%
   \gre@changestyle{normalstafflines}{#1}[\relax]%
   \relax %
 }%
@@ -1341,7 +1341,7 @@
 }%
 
 \def\setgrefactor#1{%
-  \gre@warning{\protect\setgrefactor\space is deprecated.\MessageBreak Use \protect\grechangestaffsize\space instead.}%
+  \gre@deprecated{\protect\setgrefactor}{\protect\grechangestaffsize}%
   \grechangestaffsize{#1}%
 }%
 
@@ -1370,20 +1370,20 @@
 % User macro to force gregriotex to recompile gabc files. Useful for when there
 % are changes to gregoriotex but the GREGORIOTEX API VERSION is not changed.
 \def\forcecompilegabc{%
-  \gre@warning{\protect\forcecompilegabc\space is deprecated.\MessageBreak Use \protect\gresetcompilegabc{force}\space instead}%
+  \gre@deprecated{\protect\forcecompilegabc}{\protect\gresetcompilegabc{force}}%
   \gresetcompilegabc{force}
 }%
 
 % User macro to let gregoriotex auto recompile gabc files as necessary.
 % Intended to be used in the main tex file to revert the previous macro.
 \def\autocompilegabc{%
-  \gre@warning{\protect\autocompilegabc\space is deprecated.\MessageBreak Use \protect\gresetcompilegabc{auto}\space instead}%
+  \gre@deprecated{\protect\autocompilegabc}{\protect\gresetcompilegabc{auto}}%
   \gresetcompilegabc{auto}
 }%
 
 % User macro to force score inclusion without compilation.
 \def\nevercompilegabc{%
-  \gre@warning{\protect\nevercompilegabc\space is deprecated.\MessageBreak Use \protect\gresetcompilegabc{never}\space instead}%
+  \gre@deprecated{\protect\nevercompilegabc}{\protect\gresetcompilegabc{never}}%
   \gresetcompilegabc{never}
 }
 
@@ -1458,10 +1458,9 @@
 % The main macro used by the user to input scores into the document.
 
 \def\includescore{%
-  \gre@warning{\protect\includescore\space is deprecated.\MessageBreak Use \protect\gregorioscore\space instead}%
+  \gre@deprecated{\protect\includescore}{\protect\gregorioscore}%
   \gregorioscore
 }%
-
 
 \def\gregorioscore{\@ifnextchar[{\gre@gregorioscore@option}%
     {\gre@gregorioscore}%
@@ -1526,12 +1525,12 @@
 }%
 
 \def\GreUseNormalHyphen{%
-  \gre@warning{\protect\GreUseNormalHyphen\space is deprecated.\MessageBreak Use \protect\greseteolhyphen{normal}\space instead.}%
+  \gre@deprecated{\protect\GreUseNormalHyphen}{\protect\greseteolhyphen{normal}}%
   \greseteolhyphen{normal}%
 }%
 
 \def\GreUseZeroHyphen{%
-  \gre@warning{\protect\GreUseZeroHyphen\space is deprecated.\MessageBreak Use \protect\greseteolhyphen{zero}\space instead.}%
+  \gre@deprecated{\protect\GreUseZeroHyphen}{\protect\greseteolhyphen{zero}}%
   \greseteolhyphen{zero}%
 }%
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -48,6 +48,18 @@
     }%
 }%
 
+% Macro to handle deprecated macros.
+% #1 - the deprecated macro
+% #2 - the correct macro to use
+\def\gre@deprecated#1#2{%
+  \ifgre@deprecated%
+    \gre@warning{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+  \else%
+    \greerror{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+  \fi%
+  \relax%
+}%
+
 \def\gre@nothing{}
     
 \AtBeginDocument{\IfStrEq{\gre@debug}{}{}{\typeout{GregorioTeX is in debug mode}\typeout{\gre@debug\space messages will be printed to the log.}}}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -91,12 +91,12 @@
 
 
 \def\greremoveclef{%
-  \gre@warning{\protect\greremoveclef\space is deprecated.\MessageBreak Use \protect\gresetclef{invisible} instead}%
+  \gre@deprecated{\protect\greremoveclef}{\protect\gresetclef{invisible}}%
   \gresetclef{invisible}%
 }%
 
 \def\grenormalclef{%
-  \gre@warning{\protect\grenormalclef\space is deprecated.\MessageBreak Use \protect\gresetclef{visible} instead}%
+  \gre@deprecated{\protect\grenormalclef}{\protect\gresetclef{visible}}%
   \gresetclef{visible}%
 }%
 
@@ -1336,12 +1336,12 @@
 }%
 
 \def\GreHidePCLines{%
-  \gre@warning{\protect\GreHidePCLines\space is deprecated.\MessageBreak Use \protect\gresetlinesbehindpunctumcavum{invisible}\space instead}%
+  \gre@deprecated{\protect\GreHidePCLines}{\protect\gresetlinesbehindpunctumcavum{invisible}}%
   \gre@hidepclinestrue%
 }%
 
 \def\GreDontHidePCLines{%
-  \gre@warning{\protect\GreDontHidePCLines\space is deprecated.\MessageBreak Use \protect\gresetlinesbehindpunctumcavum{visible}\space instead}%
+  \gre@deprecated{\protect\GreDontHidePCLines}{\protect\gresetlinesbehindpunctumcavum{visible}}%
   \gre@hidepclinesfalse%
 }%
 
@@ -1361,12 +1361,12 @@
 }%
 
 \def\GreHideAltLines{%
-  \gre@warning{\protect\GreHideAltLines\space is deprecated.\MessageBreak Use \protect\gresetlinesbehindalteration{invisible}\space instead.}%
+  \gre@deprecated{\protect\GreHideAltLines}{\protect\gresetlinesbehindalteration{invisible}}%
   \gre@hidealtlinestrue%
 }%
 
 \def\GreDontHideAltLines{%
-  \gre@warning{\protect\GreDontHideAltLines\space is deprecated.\MessageBreak Use \protect\gresetlinesbehindalteration{visible}\space instead.}%
+  \gre@deprecated{\protect\GreDontHideAltLines}{\protect\gresetlinesbehindalteration{visible}}%
   \gre@hidealtlinesfalse%
 }%
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -203,7 +203,7 @@
 }%
 
 \def\setstafflinethickness{%
-  \gre@warning{\protect\setstafflinethickness\space is deprecated.\MessageBreak Use \protect\grechangestafflinethickness\space instead.}%
+  \gre@deprecated{\protect\setstafflinethickness}{\protect\grechangestafflinethickness}%
   \grechangestafflinethickness%
 }%
 
@@ -879,7 +879,7 @@
 }%
 
 \def\gresetdim{%
-  \gre@warning{\protect\gresetdim\space is deprecated.\MessageBreak Use \protect\grecreatedim\space instead}%
+  \gre@deprecated{\protect\gresetdim}{\protect\grecreatedim}%
   \grecreatedim%
 }%
 
@@ -916,7 +916,7 @@
 }
 
 \def\grenoscaledim#1{%
-  \gre@warning{\protect\grenoscaledim\space is deprecated.\MessageBreak Use \protect\grescaledim{...}{no} instead.}%
+  \gre@deprecated{\protect\grenoscaledim}{\protect\grescaledim{...}{no}}%
   \expandafter\gdef\csname gre@scale@#1\endcsname{0}%
 }%
 
@@ -925,7 +925,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \def\GreLoadSpaceConf#1{%
-  \gre@warning{\protect\GreLoadSpaceConf\space is deprecated.\MessageBreak Use \protect\greloadspaceconf\space instead.}%
+  \gre@deprecated{\protect\GreLoadSpaceConf}{\protect\greloadspaceconf}%
   \greloadspaceconf{#1}%
 }%
 
@@ -1305,7 +1305,7 @@
 % To change the spacing between annotations.
 %First argument is distance, second is whether it should scale when \grefactor changes.
 \def\setaboveinitialseparation#1#2{%
-  \gre@warning{\protect\setaboveinitialseparation\space is deprecated.\MessageBreak Use \protect\grechangedim\{annotationseparation\}\space instead.}%
+  \gre@deprecated{\protect\setaboveinitialseparation}{\protect\grechangedim\{annotationseparation\}}%
   \grechangedim{annotationseparation}{#1}{#2}%
   \relax %
 }%
@@ -1326,7 +1326,7 @@
 \fi%
 
 \def\GreSetSpaceAfterInitial#1{%
-  \gre@warning{\protect\GreSetSpaceAfterInitial\space is deprecated.\MessageBreak Use \protect\setspaceafteriniital\space instead.}%
+  \gre@deprecated{\protect\GreSetSpaceAfterInitial}{\protect\setspaceafteriniital}%
   \setspaceafterinitial#1{1}%
 }%
 
@@ -1342,7 +1342,7 @@
 \fi%
 
 \def\GreSetSpaceBeforeInitial#1{%
-  \gre@warning{\protect\GreSetSpaceBeforeInitial\space is deprecated.\MessageBreak Use \protect\setspacebeforeiniital\space instead.}%
+  \gre@deprecated{\protect\GreSetSpaceBeforeInitial}{\protect\setspacebeforeiniital}%
   \setspacebeforeinitial#1{1}%
 }%
 

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -407,12 +407,12 @@
 \gre@vowelcenteringtrue
 
 \def\englishcentering{%
-  \gre@warning{\protect\englishcentering\space is deprecated.\MessageBreak Use \protect\gresetlyriccentering{syllable} instead}%
+  \gre@deprecated{\protect\englishcentering}{\protect\gresetlyriccentering{syllable}}%
   \gresetlyriccentering{syllable}%
 }%
 
 \def\defaultcentering{%
-  \gre@warning{\protect\defaultcentering\space is deprecated.\MessageBreak Use \protect\gresetlyriccentering{vowel} instead}%
+  \gre@deprecated{\protect\defaultcentering}{\protect\gresetlyriccentering{vowel} }%
   \gresetlyriccentering{vowel}%
 }%
 

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -32,6 +32,18 @@
 \def\gre@warning#1{\PackageWarning{GregorioTeX}{#1}}%
 \def\gre@bug#1{\PackageError{GregorioTeX}{#1 !! This is a bug in Gregorio.  Please report it at https://github.com/gregorio-project/gregorio/issues}{}}%
 
+% Macro to handle deprecated macros.
+% #1 - the deprecated macro
+% #2 - the correct macro to use
+\def\gre@deprecated#1#2{%
+  \ifgre@deprecated%
+    \gre@warning{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+  \else%
+    \greerror{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+  \fi%
+  \relax%
+}%
+
 \SetupKeyvalOptions{prefix=gre@}
 \DeclareStringOption{debug}[all]
 
@@ -45,6 +57,14 @@
 \DeclareVoidOption{autocompile}{\gresetcompilegabc{auto}}
 
 \ExecuteOptions{nevercompile}
+
+% This option allows the user to transform all deprecation messages
+% into errors.  Allowing one to determine if the TeX file is compliant
+% with future versions of gregoriotex. To enable, use gregoriotex with
+% this option: deprecated=false
+\DeclareBoolOption[true]{deprecated}
+
+
 \ProcessKeyvalOptions*
 
 % we hide lines only under LaTeX

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -32,18 +32,6 @@
 \def\gre@warning#1{\PackageWarning{GregorioTeX}{#1}}%
 \def\gre@bug#1{\PackageError{GregorioTeX}{#1 !! This is a bug in Gregorio.  Please report it at https://github.com/gregorio-project/gregorio/issues}{}}%
 
-% Macro to handle deprecated macros.
-% #1 - the deprecated macro
-% #2 - the correct macro to use
-\def\gre@deprecated#1#2{%
-  \ifgre@deprecated%
-    \gre@warning{#1\space is deprecated.\MessageBreak Use #2\space instead}%
-  \else%
-    \greerror{#1\space is deprecated.\MessageBreak Use #2\space instead}%
-  \fi%
-  \relax%
-}%
-
 \SetupKeyvalOptions{prefix=gre@}
 \DeclareStringOption{debug}[all]
 
@@ -63,7 +51,6 @@
 % with future versions of gregoriotex. To enable, use gregoriotex with
 % this option: deprecated=false
 \DeclareBoolOption[true]{deprecated}
-
 
 \ProcessKeyvalOptions*
 

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -109,12 +109,12 @@
 
 
 \def\grecoloredlines#1{%
-  \gre@warning{\protect\greredlines\space is deprecated.\MessageBreak Use \protect\gresetlinecolor\space instead.}%
+  \gre@deprecated{\protect\greredlines}{\protect\gresetlinecolor}%
   \relax %
 }
 
 \def\greredlines{%
-  \gre@warning{\protect\greredlines\space is deprecated.\MessageBreak Use \protect\gresetlinecolor{gregoriocolor}\space instead.}%
+  \gre@deprecated{\protect\greredlines}{\protect\gresetlinecolor{gregoriocolor}}%
   \gresetlinecolor{gregoriocolor}%
   \relax %
 }
@@ -122,7 +122,7 @@
 \let\redlines\greredlines
 
 \def\grenormallines{%
-  \gre@warning{\protect\grenormallines\space is deprecated.\MessageBreak Use \protect\gresetlinecolor{black}\space instead.}%
+  \gre@deprecated{\protect\grenormallines}{\protect\gresetlinecolor{black}}%
   \gresetlinecolor{black}%
   \relax %
 }


### PR DESCRIPTION
Added a new package option `deprecated=false` that makes deprecated macro raise an error instead of a warning.

Ready for review.