### PR TITLE
Make a new formatting style for `\gre@writemode`.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -68,8 +68,9 @@ Changing the styling of text elements of the score (the initial, translations, e
 - `additionalstafflines`: the short lines behind notes above or below the staff.  This style defaults to inheriting changes to `normalstafflines`.
 - `lowchoralsign`: low choral signs
 - `highchoralsign`: high choral signs
+- `modeline`: the mode annotation above the initial if the content of the mode header is rendered.
 
-    The second argument, also required, is the code necessary to turn on the styling.  The third argument, optional and enclosed in square braces (`[` and `]`), is the code necessary to turn off the styling (e.g. if the code to turn on the styling contains a `\begin{environment}` then the code to turn it off must have the matching `\end{environment}`.  The third argument is optional because not all styling commands have explicit off switches.
+The second argument, also required, is the code necessary to turn on the styling.  The third argument, optional and enclosed in square braces (`[` and `]`), is the code necessary to turn off the styling (e.g. if the code to turn on the styling contains a `\begin{environment}` then the code to turn it off must have the matching `\end{environment}`.  The third argument is optional because not all styling commands have explicit off switches.
 
 While the old way of changing the styles is still supported, you should switch to this new method to future proof your scores.
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -420,7 +420,8 @@ Different elements of an include score have different styles applied.  These ele
   \texttt{lowchoralsign} & low choral signs & none\\
   \texttt{highchoralsign} & high choral signs & none\\
   \texttt{firstsyllableinitial} & the first letter of the first syllable of a score which is not the score initial & none\\
-  \texttt{firstsyllable} & the balance of the first syllable of the score & none
+  \texttt{firstsyllable} & the balance of the first syllable of the score & none\\
+  \texttt{modeline} & the rendered annotation from the \texttt{mode: ;} header in the gabc file & \textsc{\textbf{Bold Small Capitals}}\\
 \end{tabular}
 
 \textit{Special:} By default, \texttt{additionalstafflines} inherits its properties from \texttt{normalstafflines}.  To decouple these environments, you must manually change \texttt{additionalstafflines} using \texttt{\textbackslash grechangestyle}.

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -486,7 +486,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \def\gre@writemode#1{%
-  \greannotation{\GreSmallCaps{\GreBold{#1}}}%
+  \greannotation{\gre@style@modeline #1\endgre@style@modeline}%
   \relax %
 }%
 

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -177,6 +177,10 @@
   {\begingroup}%
   {\endgroup}%
 
+\newenvironment{gre@style@modeline}%
+  {\begingroup\begin{scshape}\begin{bfseries}}%
+  {\end{bfseries}\end{scshape}\endgroup}%
+
 \def\gre@changestyle#1#2[#3]{%
   \renewenvironment{gre@style@#1}{\begingroup#2}{#3\endgroup}%
 }%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -213,6 +213,14 @@
 }%
 \def\endgre@style@firstsyllable{\endgroup}%
 
+\def\gre@style@modeline{%
+  \begingroup%
+  \bf%
+  \sc%
+  \relax%
+}%
+\def\endgre@style@modeline{\endgroup}%
+
 \def\gre@changestyle#1#2[#3]{%
   \gdef\csname gre@style@#1\endcsname{\begingroup#2}%
   \gdef\csname endgre@style@#1\endcsname{#3\endgroup}%


### PR DESCRIPTION
Adds the new style environment `modeline`.
Addresses #487