### PR TITLE
Fix for unknown type name ‘rulefile_parse_status’.

### DIFF
--- a/src/vowel/vowel-rules.l
+++ b/src/vowel/vowel-rules.l
@@ -25,6 +25,8 @@
 #include "struct.h"
 #include "messages.h"
 
+#include "vowel.h"
+
 #include "vowel-rules.h"
 #include "vowel-rules-y.h"
 


### PR DESCRIPTION
Possible fix for #505.

@jperon Please try out this fix for #505 and merge it if it works for you.  I don't get that error, so maybe it's a differing version of bison.