### PR TITLE
Moved calls to \GreSet(Fixed)NextFormat before \GreSyllable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The dot in a space directly above a punctum in a descending neume is now placed slightly higher in the space (see [#386](https://github.com/gregorio-project/gregorio/issues/386) and [Gna! bug 21737](https://gna.org/bugs/?21737)).
 - Choral signs are now positioned correctly around porrectus and torculus resupinus (see [#387](https://github.com/gregorio-project/gregorio/issues/387) and [Gna! bug 22025](https://gna.org/bugs/?22025)).
 - Gregorio will now try harder to select an appropriate pitch for an automatic custos (`z0`) on a clef change (see [#446](https://github.com/gregorio-project/gregorio/issues/446)).  If results are not satisfactory, use a manual custos (`+`) to select a pitch manually.
+- The centering of styled text under notes is now correct (See [#509](https://github.com/gregorio-project/gregorio/issues/509)).
 
 ### Changed
 - A new, more systematic naming scheme has been created for GregorioTeX macros.  The naming scheme should reduce the chances of naming conflicts with other packages and make it easier to identify what a particular macro is for and how to use it.  Most user functions have been renamed in order to bring them into line with this scheme.  Please see GregorioRef for a complete list of the new function names.  In general, old names will still work, but they will raise a deprecation warning and will be dropped from GregorioTeX in a future relase.

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -36,8 +36,6 @@
 
 #define BUFSIZE 128
 
-enum syllable { THIS_SYL, NEXT_SYL };
-
 #define MAX_AMBITUS 5
 static char *tex_ambitus[] = {
     NULL, "One", "Two", "Three", "Four", "Five"
@@ -140,6 +138,7 @@ static inline bool is_shortqueue(const char pitch,
 
 static gregoriotex_status *status = NULL;
 static grestyle_style gregoriotex_ignore_style = ST_NO_STYLE;
+static grestyle_style gregoriotex_next_ignore_style = ST_NO_STYLE;
 
 static char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
         gregorio_glyph *glyph, gregorio_element *element, gtex_alignment * type)
@@ -2539,33 +2538,44 @@ static void gregoriotex_write_element(FILE *f, gregorio_syllable *syllable,
     }
 }
 
+static void write_fixed_text_styles(FILE *f, gregorio_character *syllable_text,
+        gregorio_character *next_syllable_text)
+{
+    if (syllable_text) {
+        gregoriotex_ignore_style = gregoriotex_fix_style(syllable_text);
+        if (gregoriotex_ignore_style) {
+            fprintf(f, "\\GreSetFixedTextFormat{%d}",
+                    gregoriotex_internal_style_to_gregoriotex
+                    (gregoriotex_ignore_style));
+        }
+    }
+    if (next_syllable_text) {
+        gregoriotex_next_ignore_style = gregoriotex_fix_style(
+                next_syllable_text);
+        if (gregoriotex_next_ignore_style) {
+            fprintf(f, "\\GreSetFixedNextTextFormat{%d}",
+                    gregoriotex_internal_style_to_gregoriotex
+                    (gregoriotex_next_ignore_style));
+        }
+    }
+}
+
 static void gregoriotex_write_text(FILE *f, gregorio_character *text,
-        bool * first_syllable, int next_syl)
+        bool *first_syllable)
 {
     if (text == NULL) {
         fprintf(f, "{}{}{}");
         return;
     }
     fprintf(f, "{");
-    gregoriotex_ignore_style = gregoriotex_fix_style(text);
-    if (gregoriotex_ignore_style != 0) {
-        if (next_syl) {
-            fprintf(f, "\\GreSetFixedNextTextFormat{%d}",
-                    gregoriotex_internal_style_to_gregoriotex
-                    (gregoriotex_ignore_style));
-        } else {
-            fprintf(f, "\\GreSetFixedTextFormat{%d}",
-                    gregoriotex_internal_style_to_gregoriotex
-                    (gregoriotex_ignore_style));
-        }
-    }
     gregorio_write_text(first_syllable && *first_syllable, text, f,
             (&gtex_write_verb), (&gtex_print_char), (&gtex_write_begin),
             (&gtex_write_end), (&gtex_write_special_char));
     if (first_syllable) {
         *first_syllable = false;
     }
-    gregoriotex_ignore_style = 0;
+    gregoriotex_ignore_style = gregoriotex_next_ignore_style;
+    gregoriotex_next_ignore_style = ST_NO_STYLE;
     fprintf(f, "}");
 }
 
@@ -2741,6 +2751,8 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                 return;
             }
         }
+        write_fixed_text_styles(f, syllable->text,
+                syllable->next_syllable? syllable->next_syllable->text : NULL);
         if ((syllable->elements)[0]->type == GRE_BAR) {
             if (!syllable->next_syllable && !syllable->text
                     && (syllable->elements)[0]->u.misc.unpitched.info.bar ==
@@ -2760,9 +2772,11 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
             fprintf(f, "\\GreSyllable");
         }
     } else {
+        write_fixed_text_styles(f, syllable->text,
+                syllable->next_syllable? syllable->next_syllable->text : NULL);
         fprintf(f, "\\GreSyllable");
     }
-    gregoriotex_write_text(f, syllable->text, first_syllable, THIS_SYL);
+    gregoriotex_write_text(f, syllable->text, first_syllable);
     if (syllable->position == WORD_END
             || syllable->position == WORD_ONE_SYLLABLE || !syllable->text
             || !syllable->next_syllable
@@ -2774,8 +2788,7 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
     }
     if (syllable->next_syllable) {
         fprintf(f, "{\\GreSetNextSyllable");
-        gregoriotex_write_text(f, syllable->next_syllable->text, NULL,
-                NEXT_SYL);
+        gregoriotex_write_text(f, syllable->next_syllable->text, NULL);
         fprintf(f, "}{}{%d}{",
                 gregoriotex_syllable_first_type(syllable->next_syllable));
     } else {


### PR DESCRIPTION
Fixes #509.

This breaks a couple of tests:
- gabc-gtex/bugs/fix-135.tex - because the calls were moved; expected
- gabc-output/glyphs/styles.gabc - illustrates the issue at hand, though not as dramatically; expected

This is ready for review and merge should it be found satisfactory.