### PR TITLE
Prevented a line break before a bar immediately after a no-line-break area.

### DIFF
--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -177,8 +177,15 @@ Macro to typeset a dominican bar.
   \#2 & code    & Macros which may happen before the skip but after the divisio dominica (typically \verb=\grevepisemus=).\\
 \end{argtable}
 
-\macroname{\textbackslash GreEndEUOUAE}{}{gregoriotex-main.tex}
+\macroname{\textbackslash GreEndEUOUAE}{\#1}{gregoriotex-main.tex}
 Macro to mark the end of a EUOUAE block.
+
+\begin{argtable}
+  \#1 & 0 & ending element\\
+      & 1 & ending syllable\\
+      & 2 & ending score\\
+      & 3 & before bar
+\end{argtable}
 
 \macroname{\textbackslash GreEndOfElement}{\#1\#2}{gregoriotex-main.tex}
 Macro to end elements.
@@ -197,10 +204,11 @@ Macro to end a no line break area.
 
 \begin{argtable}
   \#1 & 0 & ending element\\
-  & 1 & ending syllable\\
-  & 2 & ending score\\
+      & 1 & ending syllable\\
+      & 2 & ending score\\
+      & 3 & before bar\\
   \#2 & 0 & ??\\ %I can’t tell what this flag is for
-  & else & ??
+      & else & ??
 \end{argtable}
 
 \macroname{\textbackslash GreEndOfGlyph}{\#1}{gregoriotex-main.tex}

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1253,12 +1253,14 @@
       \xdef\greendafterbaraltpenalty{\greendafterbaraltpenaltysave}%
       \xdef\greendofelementpenalty{\greendofelementpenaltysave}%
       \xdef\grehyphenpenalty{\grehyphenpenaltysave}%
-      \ifcase #1\relax %
+      \ifcase #1\relax % 0
         \grepenalty{\greendofelementpenalty}%
-      \or %
+      \or % 1
         \grepenalty{\greendofsyllablepenalty}%
-      \or %
-    % end of score, no penalty needs to be added
+      \or % 2
+        % end of score, no penalty needs to be added
+      \or % 3
+        % before bar, no penalty should to be added
       \fi %
     \fi %
   \fi %
@@ -1287,9 +1289,9 @@
   \gre@in@euouaetrue %
 }
 
-\def\GreEndEUOUAE{%
+\def\GreEndEUOUAE#1{%
   \ifgre@euouae@implies@nlba %
-    \GreEndNLBArea{0}{0}%
+    \GreEndNLBArea{#1}{0}%
   \fi %
   \gre@in@euouaefalse %
 }

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1300,6 +1300,7 @@
   \grehskip\gre@skip@temp@four %
   \grenobreak %
   \GreBarSyllable{}{}{}{1}{}{}{0}{\GreLastOfLine}{%
+    \grenobreak %
     \GreDivisioFinalis{}%
     #1%
   }%
@@ -1311,6 +1312,7 @@
   \grelocalrightbox{}%
   \grelocalleftbox{}%
     \GreBarSyllable{}{}{}{1}{}{}{0}{}{%
+    \grenobreak %
     \GreDivisioMaior{}%
     #1%
   }%

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -200,7 +200,11 @@ end
 local function dump_nodes(head)
   local n, m
   for n in traverse(head) do
-    log("node %s [%d] {%d}", node.type(n.id), n.subtype, has_attribute(n, glyph_id_attr))
+    if node.type(n.id) == 'penalty' then
+      log("%s=%d {%d}", node.type(n.id), n.penalty, has_attribute(n, glyph_id_attr))
+    else
+      log("node %s [%d] {%d}", node.type(n.id), n.subtype, has_attribute(n, glyph_id_attr))
+    end
     if n.id == hlist then
       for m in traverse(n.head) do
         if node.type(m.id) == 'penalty' then


### PR DESCRIPTION
Fixes #396.