### PR TITLE
Rewording TeX not found error message

### DIFF
--- a/macosx/Gregorio.pkgproj
+++ b/macosx/Gregorio.pkgproj
@@ -812,7 +812,7 @@
 							<key>LANGUAGE</key>
 							<string>English</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Gregorio requires TeX in order to work.  If you do not have a TeX distribution installed, you can get one from https://www.tug.org/texlive/.
+							<string>Gregorio requires TeX in order to work.  If you do not have a TeX distribution installed, you can get one from https://www.tug.org/mactex/.
 
 If you have a TeX distribution installed in a non-standard location, then either place a symlink to kpsewhich in /usr/texbin/ and try again with this installer or build Gregorio from source.</string>
 							<key>VALUE</key>


### PR DESCRIPTION
Since this is the Mac installer, it's probably better for the website link to point directly to MacTeX, rather than the generic TeXLive page.