### PR TITLE
Develop

### DIFF
--- a/.gregorio-version
+++ b/.gregorio-version
@@ -1,4 +1,4 @@
-3.0.2
+3.0.3
 
 *** Do not modify this file. ***
 Use VersionManager.py to change the version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `\GreSetAboveInitialSeparation`, supplanted by `\grechangedim{annotationseparation}...`
 - `\gresetstafflinefactor`, supplanted by `\grechangestafflinethickness`
 
-## [Unreleased][unreleased]
+## [3.0.3] - 2015-07-01
 ### Fixed
 - Horizontal episemae on salicus figures now render correctly (See [#511](https://github.com/gregorio-project/gregorio/issues/511)).
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,8 +16,8 @@ dnl
 dnl You should have received a copy of the GNU General Public License
 dnl along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
-AC_INIT([gregorio],[3.0.2],[gregorio-devel@gna.org])
-FILENAME_VERSION="3_0_2"
+AC_INIT([gregorio],[3.0.3],[gregorio-devel@gna.org])
+FILENAME_VERSION="3_0_3"
 AC_SUBST(FILENAME_VERSION)
 MK=""
 AC_SUBST(MK)

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -108,7 +108,7 @@
 
     \vspace{1cm}
 
-    \large Version \textbf{3.0.2}, 01 June 2015 %% PARSE_VERSION_DATE
+    \large Version \textbf{3.0.3}, 01/07/15 %% PARSE_VERSION_DATE
 
     \vspace{1.5cm}
   \end{center}

--- a/macosx/Gregorio.pkgproj
+++ b/macosx/Gregorio.pkgproj
@@ -547,7 +547,7 @@
 				<key>OVERWRITE_PERMISSIONS</key>
 				<false/>
 				<key>VERSION</key>
-				<string>3.0.2</string><!--GREGORIO_VERSION-->
+				<string>3.0.3</string><!--GREGORIO_VERSION-->
 			</dict>
 			<key>UUID</key>
 			<string>74692645-8112-42EB-8FFC-2CBE2CEDE9FB</string>

--- a/tex/gregoriotex-chars.tex
+++ b/tex/gregoriotex-chars.tex
@@ -17,7 +17,7 @@
 % You should have received a copy of the GNU General Public License
 % along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
-\gre@declarefileversion{gregoriotex-chars.tex}{3.0.2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-chars.tex}{3.0.3}% GREGORIO_VERSION
 
 % bars
 \def\gre@char@divisiomaior{\GreCPDivisioMaior}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -22,7 +22,7 @@
 
 \def\grebarbracewidth{.58879}%
 
-\gre@declarefileversion{gregoriotex-signs.tex}{3.0.2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-signs.tex}{3.0.3}% GREGORIO_VERSION
 
 \def\greusestylecommon{%
   \ifnum\greusestylefont=0\relax %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -19,7 +19,7 @@
 
 % this file contains definitions of spaces
 
-\gre@declarefileversion{gregoriotex-spaces.tex}{3.0.2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-spaces.tex}{3.0.3}% GREGORIO_VERSION
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% macros for tuning penalties

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -19,7 +19,7 @@
 
 % this file contains definitions of the glyphs and the syllables
 
-\gre@declarefileversion{gregoriotex-syllable.tex}{3.0.2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-syllable.tex}{3.0.3}% GREGORIO_VERSION
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% macros for the typesetting of the different glyphs

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -22,7 +22,7 @@
 \ifcsname gregoriotex@symbols@loaded\endcsname\endinput\fi%
 \def\gregoriotex@symbols@loaded{}%
 
-\gre@declarefileversion{gregoriotex-symbols.tex}{3.0.2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-symbols.tex}{3.0.3}% GREGORIO_VERSION
 
 \RequireLuaModule{gregoriotex}%
 

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -24,13 +24,13 @@ local hpack, traverse, traverse_id, has_attribute, count, remove, insert_after, 
 gregoriotex = gregoriotex or {}
 local gregoriotex = gregoriotex
 
-local internalversion = '3.0.2' -- GREGORIO_VERSION (comment used by VersionManager.py)
+local internalversion = '3.0.3' -- GREGORIO_VERSION (comment used by VersionManager.py)
 
 local err, warn, info, log = luatexbase.provides_module({
     name               = "gregoriotex",
-    version            = '3.0.2', -- GREGORIO_VERSION
+    version            = '3.0.3', -- GREGORIO_VERSION
     greinternalversion = internalversion,
-    date               = "2015/06/01", -- GREGORIO_DATE_LTX
+    date               = "2015/07/01", -- GREGORIO_DATE_LTX
     description        = "GregorioTeX module.",
     author             = "The Gregorio Project (see CONTRIBUTORS.md)",
     copyright          = "2008-2015 - The Gregorio Project",

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -19,8 +19,8 @@
 
 \NeedsTeXFormat{LaTeX2e}%
 \ProvidesPackage{gregoriotex}%
-    [2015/06/01 v3.0.2 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
-\RequirePackage{xcolor}%
+    [2015/07/01 v3.0.3 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
+\RequirePackage{xcolor}
 \RequirePackage{kvoptions}%
 \RequirePackage{ifluatex}%
 \RequirePackage{graphicx}% for \resizebox

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -19,6 +19,11 @@
 
 % this file contains definitions for lines, initial, fonts, etc.
 
+
+% This file needs to be marked with the version number.  For now I've done this with the following comment, but we should check to see if PlainTeX has something similar to the version declaration of LaTeX and use that if it does.
+% 		[2015/07/01 v3.0.3 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
+
+
 \edef\greoldcatcode{\the\catcode`@}
 \catcode`\@=11
 

--- a/windows/gregorio-resources.rc
+++ b/windows/gregorio-resources.rc
@@ -9,12 +9,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Gregorio project"
       VALUE "FileDescription", "Gregorio"
-      VALUE "FileVersion", "3.0.2"
+      VALUE "FileVersion", "3.0.3"
       VALUE "InternalName", "gregorio"
       VALUE "LegalCopyright", "See COPYING in the installation directory."
       VALUE "OriginalFilename", "gregorio.exe"
       VALUE "ProductName", "Gregorio"
-      VALUE "ProductVersion", "3.0.2"
+      VALUE "ProductVersion", "3.0.3"
     END
   END
 

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=gregorio
-AppVersion=3.0.2
+AppVersion=3.0.3
 DefaultDirName={pf}\gregorio
 DefaultGroupName=gregorio
 SetupIconFile=gregorio.ico
@@ -53,7 +53,7 @@ Source: "../README.md"; DestDir: "{app}";
 Source: "../CONTRIBUTORS.md"; DestDir: "{app}";
 Source: "../UPGRADE.md"; DestDir: "{app}";
 ; PARSE_VERSION_FILE_NEXTLINE
-Source: "../doc/GregorioRef-3_0_2.pdf"; DestDir: "{app}";
+Source: "../doc/GregorioRef-3_0_3.pdf"; DestDir: "{app}";
 Source: "../COPYING.md"; DestDir: "{app}";
 Source: "../contrib/900_gregorio.xml"; DestDir: "{app}\contrib";
 Source: "../contrib/system-setup.bat"; DestDir: "{app}";


### PR DESCRIPTION
This is a version number update for the new release.

Since the patch implemented in the release is already in develop (in a different form), the only visible changes should be to the version number.

Please note that I've added a comment to `gregoriotex.tex` which states the version number (said file is already on the list of `VersionManager.py` because it didn't have anything declaring the version.  I'm not sure if a comment is the best way to do this but it's all I have time to do right now.