### PR TITLE
Fixes for TexLive integration

### DIFF
--- a/install-gtex.sh
+++ b/install-gtex.sh
@@ -62,7 +62,7 @@ TTFFILES=(gregorio.ttf greciliae.ttf parmesan.ttf gregorio-op.ttf
           greciliae-op.ttf parmesan-op.ttf greextra.ttf gregall.ttf
           gresgmodern.ttf)
 DOCFILES=(fonts/README.md)
-FONTSRCFILES=(Makefile gregorio-base.sfd parmesan-base.sfd greciliae-base.sfd
+FONTSRCFILES=(gregorio-base.sfd parmesan-base.sfd greciliae-base.sfd
               greextra.sfd squarize.py convertsfdtottf.py gregall.sfd
               gresgmodern.sfd)
 

--- a/src/characters.c
+++ b/src/characters.c
@@ -63,7 +63,8 @@ static inline void rtrim(char *buf)
 static bool read_vowel_rules(const char *const lang) {
     const char *language = lang;
     rulefile_parse_status status = RFPS_NOT_FOUND;
-    char **filenames, *filename, *description;
+    char **filenames, *filename;
+    const char *description;
 
 #ifdef USE_KPSE
     filenames = kpse_find_file_generic(VOWEL_FILE, kpse_tex_format, true, true);

--- a/src/characters.c
+++ b/src/characters.c
@@ -60,8 +60,8 @@ static inline void rtrim(char *buf)
 }
 #endif
 
-static bool read_vowel_rules(const char *const lang) {
-    const char *language = lang;
+static bool read_vowel_rules(char *const lang) {
+    char *language = lang;
     rulefile_parse_status status = RFPS_NOT_FOUND;
     char **filenames, *filename;
     const char *description;
@@ -155,13 +155,13 @@ static bool read_vowel_rules(const char *const lang) {
     }
     free(filenames);
     if (language != lang) {
-        free((void *)language);
+        free(language);
     }
 
     return status == RFPS_FOUND;
 }
 
-void gregorio_set_centering_language(const char *const language)
+void gregorio_set_centering_language(char *const language)
 {
     if (!read_vowel_rules(language)) {
         if (strcmp(language, "Latin") != 0) {

--- a/src/characters.h
+++ b/src/characters.h
@@ -69,7 +69,7 @@ void gregorio_write_initial(gregorio_character *current_character,
         void (*end) (FILE *, grestyle_style),
         void (*printspchar) (FILE *, grewchar *));
 
-void gregorio_set_centering_language(const char *language);
+void gregorio_set_centering_language(char *language);
 
 gregorio_character *gregorio_first_text(gregorio_score *score);
 

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -24,6 +24,7 @@
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"
+#include "plugins.h"
 
 static const char *unknown(int value) {
     static char buf[20];

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -60,7 +60,7 @@ static inline void lex_add_note(int i, gregorio_shape shape, char signs,
 {
     nbof_isolated_episemus = 0;
     gregorio_add_note(&current_note,
-            pitch_letter_to_height(tolower(gabc_notes_determination_text[i])),
+            pitch_letter_to_height(tolower((unsigned char)gabc_notes_determination_text[i])),
             shape, signs, liquescentia, NULL, &notes_lloc);
 }
 

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -46,7 +46,7 @@ static inline char pitch_letter_to_height(const char pitch) {
     return pitch - 'a' + LOWEST_PITCH;
 }
 
-gregorio_shape punctum(const char pitch)
+static gregorio_shape punctum(const char pitch)
 {
     if (pitch < 'a') {
         return S_PUNCTUM_INCLINATUM;

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -36,7 +36,7 @@
 #include "messages.h"
 #include "characters.h"
 #include "sha1.h"
-
+#include "plugins.h"
 #include "gabc.h"
 
 #define YYLLOC_DEFAULT(Current, Rhs, N) \
@@ -96,7 +96,7 @@ static int current_key = DEFAULT_KEY;
 static bool got_language = false;
 static struct sha1_ctx digester;
 
-static inline void check_multiple(char *name, bool exists) {
+static inline void check_multiple(const char *name, bool exists) {
     if (exists) {
         gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
                 _("several %s definitions found, only the last will be taken "
@@ -104,7 +104,7 @@ static inline void check_multiple(char *name, bool exists) {
     }
 }
 
-static void gabc_score_determination_error(char *error_str)
+static void gabc_score_determination_error(const char *error_str)
 {
     gregorio_message(error_str, (const char *) "gabc_score_determination_parse",
             VERBOSITY_ERROR, 0);
@@ -584,7 +584,7 @@ gregorio_score *gabc_read_score(FILE *f_in)
 unsigned char nabc_state = 0;
 size_t nabc_lines = 0;
 
-void gabc_y_add_notes(char *notes, YYLTYPE loc) {
+static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
     gregorio_element *new_elements;
     gregorio_element *last_element;
     if (nabc_state == 0) {

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -29,6 +29,7 @@
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"
+#include "plugins.h"
 
 #include "gabc.h"
 
@@ -331,7 +332,7 @@ static void gabc_write_bar_signs(FILE *f, char type)
     }
 }
 
-static void gabc_hepisemus(FILE *f, char *prefix, bool connect,
+static void gabc_hepisemus(FILE *f, const char *prefix, bool connect,
         grehepisemus_size size)
 {
     fprintf(f, "_%s", prefix);
@@ -354,7 +355,7 @@ static void gabc_hepisemus(FILE *f, char *prefix, bool connect,
     }
 }
 
-static char *vepisemus_position(gregorio_note *note)
+static const char *vepisemus_position(gregorio_note *note)
 {
     if (!note->v_episemus_height) {
         return "";
@@ -365,7 +366,7 @@ static char *vepisemus_position(gregorio_note *note)
     return "1";
 }
 
-static char *mora_vposition(gregorio_note *note)
+static const char *mora_vposition(gregorio_note *note)
 {
     switch (note->mora_vposition) {
     case VPOS_AUTO:

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -412,27 +412,27 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         fprintf(f, "%c", pitch_letter(note->u.note.pitch));
         break;
     case S_PUNCTUM_INCLINATUM:
-        fprintf(f, "%c", toupper(pitch_letter(note->u.note.pitch)));
+        fprintf(f, "%c", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         break;
     case S_PUNCTUM_INCLINATUM_DEMINUTUS:
         if (note->next) {
-            fprintf(f, "%c~", toupper(pitch_letter(note->u.note.pitch)));
+            fprintf(f, "%c~", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         } else {
-            fprintf(f, "%c", toupper(pitch_letter(note->u.note.pitch)));
+            fprintf(f, "%c", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         }
         break;
     case S_PUNCTUM_INCLINATUM_AUCTUS:
         if (note->next) {
-            fprintf(f, "%c<", toupper(pitch_letter(note->u.note.pitch)));
+            fprintf(f, "%c<", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         } else {
-            fprintf(f, "%c", toupper(pitch_letter(note->u.note.pitch)));
+            fprintf(f, "%c", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         }
         break;
     case S_PUNCTUM_CAVUM_INCLINATUM:
-        fprintf(f, "%cr", toupper(pitch_letter(note->u.note.pitch)));
+        fprintf(f, "%cr", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         break;
     case S_PUNCTUM_CAVUM_INCLINATUM_AUCTUS:
-        fprintf(f, "%cr<", toupper(pitch_letter(note->u.note.pitch)));
+        fprintf(f, "%cr<", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         break;
     case S_VIRGA:
         fprintf(f, "%cv", pitch_letter(note->u.note.pitch));

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -132,7 +132,7 @@ static char *get_base_filename(char *fbasename)
 }
 
 // function that adds the good extension to a basename (without extension)
-static char *get_output_filename(char *fbasename, char *extension)
+static char *get_output_filename(char *fbasename, const char *extension)
 {
     char *output_filename = NULL;
     output_filename =
@@ -276,9 +276,6 @@ int main(int argc, char **argv)
         "Copyright (C) 2006-2015 Gregorio project authors (see CONTRIBUTORS.md)";
     int c;
 
-    #ifdef USE_KPSE
-        kpse_set_program_name("gregorio", "gregorio");
-    #endif
     char *input_file_name = NULL;
     char *output_file_name = NULL;
     char *output_basename = NULL;
@@ -309,6 +306,9 @@ int main(int argc, char **argv)
     };
     gregorio_score *score = NULL;
 
+    #ifdef USE_KPSE
+        kpse_set_program_name("gregorio", "gregorio");
+    #endif
     if (argc == 1) {
         print_usage(argv[0]);
         exit(0);

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -21,7 +21,11 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#ifdef USE_KPSE
+#include <kpathsea/kpathsea.h>
+#else
 #include <getopt.h>
+#endif
 #include <libgen.h>             /* for basename */
 #include <string.h>             /* for strcmp */
 #include <locale.h>
@@ -32,9 +36,6 @@
 #include "characters.h"
 #include "gabc/gabc.h"
 #include "vowel/vowel.h"
-#ifdef USE_KPSE
-    #include <kpathsea/kpathsea.h>
-#endif
 
 #ifndef MODULE_PATH_ENV
 #define MODULE_PATH_ENV        "MODULE_PATH"

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2674,6 +2674,7 @@ static inline bool next_is_bar(const gregorio_syllable *syllable,
     }
 
     assert(false); // should never reach here
+    return false; // avoid gcc 5.1 warning
 }
 
 static inline void write_syllable_point_and_click(FILE *const f,

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -32,6 +32,7 @@
 #include "unicode.h"
 #include "messages.h"
 #include "characters.h"
+#include "plugins.h"
 
 #include "gregoriotex.h"
 
@@ -59,7 +60,7 @@ typedef struct gregoriotex_status {
 #define UNDETERMINED_HEIGHT -127
 
 #define MAX_AMBITUS 5
-static char *tex_ambitus[] = {
+static const char *tex_ambitus[] = {
     NULL, "One", "Two", "Three", "Four", "Five"
 };
 
@@ -165,10 +166,11 @@ static inline bool is_shortqueue(const signed char pitch,
 static grestyle_style gregoriotex_ignore_style = ST_NO_STYLE;
 static grestyle_style gregoriotex_next_ignore_style = ST_NO_STYLE;
 
-static char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
+static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
         gregorio_glyph *glyph, gregorio_element *element, gtex_alignment *type)
 {
-    static char buf[128], *name;
+    static char buf[128];
+    const char *name;
 
     if (!note) {
         gregorio_message(_("called with NULL pointer"),
@@ -288,7 +290,7 @@ static char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
  * They also are and must be the same as in squarize.py.
  */
 
-static char *gregoriotex_determine_liquescentia(gtex_glyph_liquescentia type,
+static const char *gregoriotex_determine_liquescentia(gtex_glyph_liquescentia type,
         gregorio_liquescentia liquescentia)
 {
     switch (liquescentia) {
@@ -381,12 +383,12 @@ static inline int compute_ambitus(const gregorio_note *const current_note)
     return ambitus;
 }
 
-static char *compute_glyph_name(const gregorio_glyph *const glyph,
-        char *const shape, const gtex_glyph_liquescentia ltype)
+static const char *compute_glyph_name(const gregorio_glyph *const glyph,
+        const char *const shape, const gtex_glyph_liquescentia ltype)
 {
     static char buf[BUFSIZE];
 
-    char *liquescentia = gregoriotex_determine_liquescentia(ltype,
+    const char *liquescentia = gregoriotex_determine_liquescentia(ltype,
             glyph->u.notes.liquescentia);
     gregorio_note *current_note;
     // then we start making our formula
@@ -437,11 +439,11 @@ static char *compute_glyph_name(const gregorio_glyph *const glyph,
 // calculates the type, used for determining the position of signs. Type is
 // very basic, it is only the global dimensions : torculus, one_note, etc.
 
-char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
+const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         const gregorio_element *const element, gtex_alignment *const  type,
         gtex_type *const gtype)
 {
-    char *shape = NULL;
+    const char *shape = NULL;
     gtex_glyph_liquescentia ltype;
     char pitch = 0;
     if (!glyph) {
@@ -742,7 +744,7 @@ char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
  * now part of the score info.  But we keep it here in case it may
  * be needed in future.
  */
-void gregoriotex_write_voice_info(FILE *f, gregorio_voice_info *voice_info)
+static void gregoriotex_write_voice_info(FILE *f, gregorio_voice_info *voice_info)
 {
     if (!f || !voice_info) {
         return;
@@ -1730,7 +1732,7 @@ static void gregoriotex_write_note(FILE *f, gregorio_note *note,
 {
     unsigned int initial_shape = note->u.note.shape;
     char temp;
-    char *shape;
+    const char *shape;
     // type in the sense of GregorioTeX alignment type
     gtex_alignment type = AT_ONE_NOTE;
     if (!note) {
@@ -2222,7 +2224,7 @@ static char *determine_leading_shape(gregorio_glyph *glyph)
 {
     static char buf[BUFSIZE];
     int ambitus = compute_ambitus(glyph->u.notes.first_note);
-    char *head, *head_liquescence;
+    const char *head, *head_liquescence;
 
     switch (glyph->u.notes.first_note->u.note.shape) {
     case S_QUILISMA:
@@ -2269,7 +2271,7 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
     gtex_type gtype = 0;
     char next_note_pitch = 0;
     gregorio_note *current_note;
-    char *leading_shape, *shape;
+    const char *leading_shape, *shape;
     if (!glyph) {
         gregorio_message(_("called with NULL pointer"),
                 "gregoriotex_write_glyph", VERBOSITY_ERROR, 0);
@@ -2592,7 +2594,7 @@ static void gregoriotex_print_change_line_clef(FILE *f,
     }
 }
 
-static void handle_final_bar(FILE *f, char *type, gregorio_syllable *syllable)
+static void handle_final_bar(FILE *f, const char *type, gregorio_syllable *syllable)
 {
     fprintf(f, "\\GreFinal%s{%%\n", type);
     // first element will be the bar, which we just handled, so skip it

--- a/src/gregoriotex/gregoriotex.h
+++ b/src/gregoriotex/gregoriotex.h
@@ -153,7 +153,7 @@ static inline bool is_between_lines(const char pitch)
 
 bool gtex_is_h_episemus_above_shown(const gregorio_note *const note);
 bool gtex_is_h_episemus_below_shown(const gregorio_note *const note);
-char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
+const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         const gregorio_element *const element, gtex_alignment *const  type,
         gtex_type *const gtype);
 void gregoriotex_compute_positioning(const gregorio_element *element);

--- a/src/messages.c
+++ b/src/messages.c
@@ -50,10 +50,12 @@ void gregorio_set_verbosity_mode(const gregorio_verbosity verbosity)
     verbosity_mode = verbosity;
 }
 
-void gregorio_set_debug_messages(bool debug)
+#if 0 /* unused */
+static void gregorio_set_debug_messages(bool debug)
 {
     debug_messages = debug;
 }
+#endif
 
 static const char *verbosity_to_str(const gregorio_verbosity verbosity)
 {

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -138,7 +138,7 @@ gregorio_character *gregorio_build_char_list_from_buf(const char *const buf)
 // the function to compare a grewchar * and a buf. Returns 1 if different, 0
 // if not.
 
-unsigned char gregorio_wcsbufcmp(grewchar *wstr, char *buf)
+unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf)
 {
     int i = 0;
     size_t len;

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -32,7 +32,7 @@ typedef uint32_t grewchar;
 
 void gregorio_print_unichar(FILE *f, grewchar to_print);
 void gregorio_print_unistring(FILE *f, grewchar *first_char);
-unsigned char gregorio_wcsbufcmp(grewchar *wstr, char *buf);
+unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf);
 grewchar *gregorio_build_grewchar_string_from_buf(const char *buf);
 
 static inline size_t gregorio_wcstrlen(const grewchar *wstr)

--- a/src/vowel/vowel-rules.y
+++ b/src/vowel/vowel-rules.y
@@ -46,7 +46,7 @@
 //int gregorio_vowel_rulefile_debug=1;
 
 static void gregorio_vowel_rulefile_error(const char *const filename,
-        const char **const language, rulefile_parse_status *const status,
+        char **const language, rulefile_parse_status *const status,
         const char *const error_str)
 {
     IGNORE(language);
@@ -56,7 +56,7 @@ static void gregorio_vowel_rulefile_error(const char *const filename,
 }
 
 // this returns false until the language *after* the desired language
-static inline bool match_language(const char **language,
+static inline bool match_language(char **language,
         rulefile_parse_status *status, char *const name)
 {
     if (*status == RFPS_FOUND) {
@@ -72,22 +72,22 @@ static inline bool match_language(const char **language,
     return false;
 }
 
-static inline void alias(const char **const language,
-        rulefile_parse_status *const status, const char *const name,
-        const char *const target)
+static inline void alias(char **const language,
+        rulefile_parse_status *const status, char *const name,
+        char *const target)
 {
     if (strcmp(*language, name) == 0) {
         gregorio_messagef("alias", VERBOSITY_INFO, 0, _("Aliasing %s to %s"),
                 name, target);
         if (*status == RFPS_ALIASED) {
-            free((void *)*language);
+            free(*language);
         }
         *language = target;
         *status = RFPS_ALIASED;
     } else {
-        free((void *)target);
+        free(target);
     }
-    free((void *)name);
+    free(name);
 }
 
 static inline void add(const rulefile_parse_status *const status,
@@ -107,7 +107,7 @@ static inline void add(const rulefile_parse_status *const status,
 
 %name-prefix "gregorio_vowel_rulefile_"
 %parse-param { const char *const filename }
-%parse-param { const char **language }
+%parse-param { char **language }
 %parse-param { rulefile_parse_status *const status }
 
 %token LANGUAGE VOWEL PREFIX SUFFIX SECONDARY ALIAS SEMICOLON TO

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -246,7 +246,7 @@ void gregorio_vowel_tables_init(void)
 }
 
 void gregorio_vowel_tables_load(const char *const filename,
-        const char **const language, rulefile_parse_status *status)
+        char **const language, rulefile_parse_status *status)
 {
 #ifdef USE_KPSE
     if (!kpse_in_name_ok(filename)) {

--- a/src/vowel/vowel.h
+++ b/src/vowel/vowel.h
@@ -30,11 +30,11 @@ typedef enum rulefile_parse_status {
     RFPS_ALIASED,
 } rulefile_parse_status;
 
-int gregorio_vowel_rulefile_parse(const char *filename, const char **language,
+int gregorio_vowel_rulefile_parse(const char *filename, char **language,
         rulefile_parse_status *status);
 int gregorio_vowel_rulefile_lex_destroy(void);
 void gregorio_vowel_tables_init(void);
-void gregorio_vowel_tables_load(const char *filename, const char **language,
+void gregorio_vowel_tables_load(const char *filename, char **language,
         rulefile_parse_status *status);
 void gregorio_vowel_tables_free(void);
 void gregorio_vowel_table_add(const char *vowels);


### PR DESCRIPTION
Addresses some of the items in #551:

I applied patches 1, 2, 4, and 5 from Peter Breitenlohner.  Some hunks were left out and all of patch 3 was left out for (flex/bison-generated) files not checked into git.  These changes should pass once flex 2.5.39 is used to generate these files for the distribution archive.

I also took Peter's advice and removed the `const` modifier from pointers which are freed to remove the warnings about casting away const.  Note that Peter is wrong about language never being changed, so the `free` in `character.c` is, in fact, necessary.

Finally, I implemented @eroux's suggestion to not install the Makefile into the TDS.

Tests pass.  This is ready for review and merge.