### PR TITLE
Fixed self-intersection and wrong-direction errors.

### DIFF
--- a/fonts/greciliae-base.sfd
+++ b/fonts/greciliae-base.sfd
@@ -19,7 +19,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1176402534
-ModificationTime: 1437872559
+ModificationTime: 1438737067
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
@@ -86,6 +86,7 @@ SplineSet
  0 121.6 l 2
  0 153.667 26.4502 168.7 82.3496 168.7 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumInclinatum
@@ -103,6 +104,7 @@ SplineSet
  104.332 -59.373 l 1
  -0.0927734 60.3877 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Stropha.caeciliae
@@ -124,6 +126,7 @@ SplineSet
  0 72.25 l 5
  75.8545 185.372 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Quilisma
@@ -151,6 +154,7 @@ SplineSet
  51.1006 19.2363 51.9479 -42.5551 33 -45 c 0
  17.5 -47 0 -16 0 0 c 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: OriscusReversus
@@ -172,6 +176,7 @@ SplineSet
  168 -23.0293 157.816 3.65039 128.2 3.65039 c 4
  99.4707 3.65039 66.3203 -30.1504 39.7998 -30.1504 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Oriscus
@@ -193,6 +198,7 @@ SplineSet
  -0.200195 160.06 15.4004 172.15 38.7998 172.15 c 4
  61.2793 172.15 106.118 139.65 127.2 139.65 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Flat
@@ -219,6 +225,7 @@ SplineSet
  45.9746 126.55 l 1
  45.9746 179.05 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: queue
@@ -237,6 +244,7 @@ SplineSet
  3.5752 -164.267 0.0751953 -157.333 0.0751953 -145.2 c 2
  0 -5 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumInclinatumDeminutus
@@ -254,6 +262,7 @@ SplineSet
  -0.3125 71.8936 l 1
  60.0762 174.205 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioMaior
@@ -293,6 +302,7 @@ SplineSet
  87.1504 551.21 49.4326 560.818 16.9502 566.55 c 4
  1.34961 568.283 -6.4502 577.817 -6.4502 595.15 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CClef
@@ -319,6 +329,7 @@ SplineSet
  166.2 9.59961 l 6
  166.2 -23 138 -40 107.7 -39.5996 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: Virga
@@ -341,6 +352,7 @@ SplineSet
  166.4 -227.3 l 2
  166.4 -239.433 162.5 -246.367 154.7 -248.1 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversa
@@ -363,6 +375,7 @@ SplineSet
  17.7998 -204.3 l 6
  17.7998 -249.54 16.5 -251.1 11.2998 -251.1 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioMinima
@@ -381,6 +394,7 @@ SplineSet
  19 364.431 l 21
  6.04395 364.565 2.43457 367.609 0 371.128 c 13
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioMinor
@@ -421,6 +435,7 @@ SplineSet
  18.7998 -328.5 l 2
  18.7998 -373.74 17.5 -375.3 12.2998 -375.3 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: pesdeminutus
@@ -435,14 +450,15 @@ SplineSet
 166 0 m 1
  139.165 -55.9062 46.9414 -57.252 35.9141 -57.252 c 2
  34.9004 -57.25 l 2
- 11.5 -57.25 0 -47.7324 0 -25.1992 c 6
- 0 149 l 5
+ 11.5 -57.25 0 -47.7324 0 -25.1992 c 2
+ 0 149 l 1
  6.93359 136.867 21.0332 132.551 42.7002 132.551 c 0
  65.8945 132.551 120.304 137.428 148.004 170.001 c 1
- 148 201.667 148 161.333 148.007 193.993 c 1
- 182 194 131.667 194.333 166 194.001 c 1
+ 148.007 193.993 l 1
+ 166 194.001 l 1
  166 0 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusd1
@@ -464,6 +480,7 @@ SplineSet
  152.126 -19.2393 69.7139 -7.40039 42.7012 -7.40039 c 0
  21.0342 -7.40039 6.93359 -13.9004 0 -26.9004 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusa1
@@ -486,6 +503,7 @@ SplineSet
  70.9697 137 152.649 146.594 166 200 c 5
  166 3.7002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: mdeminutus
@@ -510,6 +528,7 @@ SplineSet
  73.5 186.5 124.375 168.858 154.375 158.375 c 1
  156.938 157.5 167.999 154.004 168 147.341 c 9
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Natural
@@ -545,6 +564,7 @@ SplineSet
  86.4004 18.5 l 5
  86.4004 128.9 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: FClef
@@ -581,6 +601,7 @@ SplineSet
  141.7 -38.7998 l 2
  141.7 -54.4004 139.1 -62.6328 133.9 -63.5 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: CustosDownLong
@@ -601,6 +622,7 @@ SplineSet
  59.3672 -370.101 57.2002 -363.168 57.2002 -349.301 c 2
  57.2002 -15.2002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosDownShort
@@ -622,6 +644,7 @@ SplineSet
  59.2822 -265.974 57.2002 -259.383 57.2002 -246.2 c 6
  57.2002 -25.2002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosUpLong
@@ -644,6 +667,7 @@ SplineSet
  74.8291 494.439 74.1533 488.312 72.7979 480.999 c 1
  72.7979 -49.4014 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosUpShort
@@ -665,6 +689,7 @@ SplineSet
  70.1982 398.232 72.7979 387.399 72.7979 366.6 c 6
  72.7979 -49.4004 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineBR
@@ -686,6 +711,7 @@ SplineSet
  0 120.267 l 6
  0 152.334 27.75 168.367 83.6504 168.367 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineBL
@@ -707,6 +733,7 @@ SplineSet
  -0 120.267 l 6
  -0 152.334 26.4502 168.367 82.3496 168.367 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineTL
@@ -728,6 +755,7 @@ SplineSet
  18.5 161.5 18 171.705 18 158 c 5
  26 162 52.8395 167.7 82.3496 167.7 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineTR
@@ -749,6 +777,7 @@ SplineSet
  0 119.6 l 6
  0 151.667 27.75 167.7 83.6504 167.7 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineBLBR
@@ -772,6 +801,7 @@ SplineSet
  -0 120.267 l 6
  -0 152.334 26.4502 168.367 82.3496 168.367 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: base6
@@ -795,6 +825,7 @@ SplineSet
  18 167 18 169.5 18 153.906 c 1
  31.8512 163.102 53.7142 167.7 83.6504 167.7 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: line2
@@ -812,6 +843,7 @@ SplineSet
  18 -12 l 29
  0 -12 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: line3
@@ -829,6 +861,7 @@ SplineSet
  18 -12 l 25
  0 -12 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: line4
@@ -846,6 +879,7 @@ SplineSet
  18 -12 l 25
  0 -12 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: line5
@@ -863,6 +897,7 @@ SplineSet
  18 -12 l 25
  0 -12 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: VirgaLineBR
@@ -887,6 +922,7 @@ SplineSet
  18.2002 -205.3 l 6
  18.2002 -250.54 16.9004 -252.1 11.7002 -252.1 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: rvsbase
@@ -911,6 +947,7 @@ SplineSet
  166 -231.3 l 2
  166 -243.433 162.1 -250.367 154.3 -252.1 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vlbase
@@ -935,6 +972,7 @@ SplineSet
  18.2002 -332 l 2
  18.2002 -377.24 16.9004 -378.8 11.7002 -378.8 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: QuilismaLineTR
@@ -963,6 +1001,7 @@ SplineSet
  51.1006 19.2363 51.9479 -42.5551 33 -45 c 4
  17.5 -47 0 -16 0 0 c 6
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: OriscusLineTR
@@ -986,6 +1025,7 @@ SplineSet
  0 132.609 27 137 41 137 c 0
  70 137 106.318 112.2 127.4 112.2 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: pbase
@@ -1012,6 +1052,7 @@ SplineSet
  166 -30.3105 157.757 -31.5137 128.375 -31.5137 c 0
  115.999 -31.5137 99.9414 -31.2998 79.2998 -31.2998 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: idebilis
@@ -1033,6 +1074,7 @@ SplineSet
  83 20.3008 l 6
  83 5.48047 71.2393 -4.39941 53.2998 -4.39941 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: deminutus
@@ -1054,6 +1096,7 @@ SplineSet
  83 9.30078 l 6
  83 -5.51953 71.2393 -15.3994 53.2998 -15.3994 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: rdeminutus
@@ -1075,6 +1118,7 @@ SplineSet
  0 94 l 2
  0 119.286 23.5117 143.399 53.2998 143.399 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumAuctusLineBL
@@ -1097,6 +1141,7 @@ SplineSet
  47.0723 186.502 140.456 185.508 166.399 129.3 c 1
  166.399 -65.7002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusa2
@@ -1119,6 +1164,7 @@ SplineSet
  70.9697 147 153.049 157.293 166.4 210.699 c 1
  166.4 14.3994 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectus1
@@ -1141,6 +1187,7 @@ SplineSet
  447 -183 l 2
  447 -195.133 436.65 -201.313 415.85 -201.2 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectus2
@@ -1164,6 +1211,7 @@ SplineSet
  547 -131.1 l 1
  547 -354.1 l 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectus3
@@ -1188,6 +1236,7 @@ SplineSet
  628 -551 622 -559 611 -559 c 0
  608 -559 603 -558 598 -556 c 0
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: porrectus4
@@ -1212,6 +1261,7 @@ SplineSet
  704 -700.495 693.133 -713.3 683.601 -713.3 c 0
  679.268 -713.3 673.486 -713.071 668 -709.399 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectus5
@@ -1236,6 +1286,7 @@ SplineSet
  849 -838.495 838.133 -851.3 828.601 -851.3 c 0
  824.268 -851.3 819.067 -850 813 -847.399 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexus1
@@ -1258,6 +1309,7 @@ SplineSet
  503 -183 l 6
  503.019 -195.133 492.65 -201.2 471.85 -201.2 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexus2
@@ -1280,6 +1332,7 @@ SplineSet
  139.94 -11.6719 354.969 -174.639 540.9 -201.8 c 5
  540.9 -201.8 611.667 -215 610.001 -195.499 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexus3
@@ -1304,6 +1357,7 @@ SplineSet
  628 -536.698 622.268 -544.5 611 -544.5 c 4
  607.533 -544.5 603.2 -543.633 598 -541.9 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexus4
@@ -1327,6 +1381,7 @@ SplineSet
  392.664 -392.583 450 -462 538.9 -533.199 c 0
  561.555 -551.343 587.25 -555 609.75 -557 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexus5
@@ -1348,6 +1403,7 @@ SplineSet
  931 -843.229 930.646 -842.992 928.76 -842.591 c 1
  351 -717 54 -249 0 -34 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PesQuilismaOneNothing
@@ -1380,6 +1436,7 @@ SplineSet
  51.1006 16.2363 51.9482 -45.5547 33 -48 c 4
  17.5 -50 0 -19 0 -3 c 6
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: StrophaAucta.caeciliae
@@ -1401,6 +1458,7 @@ SplineSet
  0 72.25 l 1
  75.8545 185.372 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumInclinatumAuctus.caeciliae
@@ -1423,6 +1481,7 @@ SplineSet
  64.7744 -66.8652 62.9893 -66.6143 62.9893 -65.7539 c 0
  62.9893 -65.0098 64.3223 -63.8135 67.6621 -61.9316 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaLongqueue
@@ -1445,6 +1504,7 @@ SplineSet
  166.4 -352.5 l 2
  166.4 -363.767 162.5 -370.7 154.7 -373.3 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: AuctumMora
@@ -1462,6 +1522,7 @@ SplineSet
  53.5186 119.25 71.25 104.121 71.25 83.5 c 4
  71.25 62.8447 53.5273 47.75 35.5 47.75 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VEpisemus
@@ -1481,6 +1542,7 @@ SplineSet
  7.0127 -18.2061 3.29395 -16.0811 0 -11.8311 c 9
  0 84.9375 l 21
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumDeminutus
@@ -1500,6 +1562,7 @@ SplineSet
  -0.30957 91.3467 l 2
  -0.30957 107.483 13 115.551 41.1289 115.551 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: hepisemus_base
@@ -1517,6 +1580,7 @@ SplineSet
  1 64 l 25
  0 64 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: CustosUpMedium
@@ -1538,6 +1602,7 @@ SplineSet
  70.1982 430.232 72.7979 419.399 72.7979 398.6 c 6
  72.7979 -49.4004 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosDownMedium
@@ -1559,6 +1624,7 @@ SplineSet
  59.2822 -285.974 57.2002 -279.383 57.2002 -266.2 c 6
  57.2002 -25.2002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Accentus
@@ -1579,6 +1645,7 @@ SplineSet
  73.1992 79.4004 l 6
  78.7998 89.8008 86 95 94.7998 95 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: AccentusReversus
@@ -1590,15 +1657,16 @@ LayerCount: 2
 Fore
 SplineSet
 -88.6006 95 m 0
- -96.6006 95 -105 92.6006 -113.801 87.8008 c 128
- -122.601 83 -127 75.8008 -127 66.2002 c 128
- -127 56.6006 -123.801 49.4004 -117.4 44.6006 c 2
- 0.199219 -55 l 1
- 2.59961 -55.7998 4.19922 -56.1992 5 -56.1992 c 256
- 5.7998 -56.1992 6.19922 -54.5996 6.19922 -51.3994 c 1
- -67 79.4004 l 2
- -72.6006 89.8008 -79.8008 95 -88.6006 95 c 0
+ -79.8008 95 -72.6006 89.8008 -67 79.4004 c 2
+ 6.19922 -51.3994 l 1
+ 6.19922 -54.5996 5.7998 -56.1992 5 -56.1992 c 256
+ 4.19922 -56.1992 2.59961 -55.7998 0.199219 -55 c 1
+ -117.4 44.6006 l 2
+ -123.801 49.4004 -127 56.6006 -127 66.2002 c 128
+ -127 75.8008 -122.601 83 -113.801 87.8008 c 128
+ -105 92.6006 -96.6006 95 -88.6006 95 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: SemicirculusReversus
@@ -1688,6 +1756,7 @@ SplineSet
  166.2 9.59961 l 6
  166.2 -23 138 -40 107.7 -39.5996 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: FClefChange
@@ -1724,6 +1793,7 @@ SplineSet
  141.499 -35.3496 l 2
  141.499 -50.9502 138.898 -59.1826 133.699 -60.0498 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VEpisemus.circumflexus
@@ -1774,6 +1844,7 @@ SplineSet
  -0.200195 121.6 l 2
  -0.200195 153.667 26.4502 169.7 82.3496 169.7 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: LineaPunctum
@@ -1807,6 +1878,7 @@ SplineSet
  50 120 l 2
  50 152.067 76.4502 168.101 132.35 168.101 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: LineaPunctumCavum
@@ -1847,6 +1919,7 @@ SplineSet
  262.952 157.744 265.827 151.13 265.827 145.43 c 2
  265.92 -34.2568 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumSmall
@@ -1867,6 +1940,7 @@ SplineSet
  155 -48.8008 l 5
  137 -48.8008 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: hepisemusright
@@ -1884,6 +1958,7 @@ SplineSet
  2 96 l 25
  0 64 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: mpdeminutus
@@ -1908,6 +1983,7 @@ SplineSet
  150 183.003 160.98 183.003 168 183.003 c 29
  168 -0.336914 l 17
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumAscendens
@@ -1928,6 +2004,7 @@ SplineSet
  70.9697 149.801 152.649 160.094 166 213.5 c 5
  166 17.2002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumDescendens
@@ -1947,6 +2024,7 @@ SplineSet
  0 150.5 l 6
  0 168 36 174 48 174 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: mnbdeminutus
@@ -1970,6 +2048,7 @@ SplineSet
  92.3412 -9.39673 32.25 -3.25 19 -3.5 c 0
  12.7287 -3.61833 1.54545 -13.9091 0 -19.002 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: mnbpdeminutus
@@ -1992,6 +2071,7 @@ SplineSet
  -2.00488 -35.2031 0.000976562 -20.999 0.000976562 -20.999 c 1
  0 140.005 l 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexusnb1
@@ -2012,6 +2092,7 @@ SplineSet
  289.005 -22.5283 356.667 -33.2002 415.417 -32.4004 c 0
  450.947 -31.917 488.682 -31.3135 503 -26 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexusnb2
@@ -2032,6 +2113,7 @@ SplineSet
  139.94 -11.6719 354.969 -161.639 540.9 -188.8 c 5
  554.667 -190.333 613.672 -187.735 627.986 -173.686 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexusnb3
@@ -2054,6 +2136,7 @@ SplineSet
  440 -308.4 542.25 -353.5 561.7 -356.9 c 5
  607.5 -366 622.667 -353 627.986 -344.338 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexusnb4
@@ -2075,26 +2158,28 @@ SplineSet
  392.664 -363.583 450 -433 538.9 -504.199 c 4
  561.555 -522.343 605.333 -525.667 627.986 -521.016 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexusnb5
 Encoding: 92 -1 90
 Width: 931
 VWidth: 2048
-Flags: HW
+Flags: HWO
 HStem: -409 15 -94 15 221 15 536 15
 LayerCount: 2
 Fore
 SplineSet
-931 -676.5 m 5
- 931 -816 l 6
- 931 -818.229 930.646 -817.992 928.76 -817.591 c 5
+931 -676.5 m 1
+ 931 -816 l 2
+ 931 -818.229 930.646 -817.992 928.76 -817.591 c 1
  351 -692 54 -249 0 -34 c 1
  0 183 l 2
  0 187.739 5.35547 186.627 7 182.75 c 0
- 122.5 -89.5 359.5 -560.5 886 -680.5 c 5
- 908 -685 931.649 -684.668 931 -676.5 c 5
+ 122.5 -89.5 359.5 -560.5 886 -680.5 c 1
+ 908 -685 931 -684.35 931 -676.5 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: p2base
@@ -2121,6 +2206,7 @@ SplineSet
  166 -4.31055 136.757 -12.5137 107.375 -12.5137 c 0
  94.999 -12.5137 94.9414 -12.2998 74.2998 -12.2998 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PesOneNothing
@@ -2151,6 +2237,7 @@ SplineSet
  166 -25.3105 157.757 -26.5137 128.375 -26.5137 c 4
  115.999 -26.5137 99.9414 -26.2998 79.2998 -26.2998 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: rvlbase
@@ -2175,6 +2262,7 @@ SplineSet
  166 -352.3 l 6
  166 -364.433 162.1 -371.367 154.3 -373.1 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: msdeminutus
@@ -2200,6 +2288,7 @@ SplineSet
  43.625 138.858 96.5 151 150 151 c 5
  150 177 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: mademinutus
@@ -2225,6 +2314,7 @@ SplineSet
  92.3412 -9.39673 32.25 -3.25 19 -3.5 c 0
  12.7287 -3.61833 1.5 -7 0 -9.00195 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumCavum.caeciliae
@@ -2249,6 +2339,7 @@ SplineSet
  -0.200195 121.6 l 2
  -0.200195 153.667 26.4502 169.7 82.3496 169.7 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: LineaPunctumCavum.caeciliae
@@ -2287,23 +2378,25 @@ SplineSet
  18.3662 162.667 25.2412 156.053 25.2412 150.353 c 2
  25.334 -29.334 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumHole.caeciliae
 Encoding: 101 -1 98
 Width: 166
 VWidth: 2612
-Flags: W
+Flags: HW
 HStem: -409 15 -94 15 221 15 536 15
 LayerCount: 2
 Fore
 SplineSet
-82.8701 135.51 m 4
- 48.7617 135.51 18.5195 107.482 18.5195 69.0156 c 4
- 18.5195 30.6182 48.7578 1.08984 82.8701 1.08984 c 4
- 123.196 1.08984 150.08 33.3008 150.08 69.0156 c 4
- 150.08 105.565 123.108 135.51 82.8701 135.51 c 4
+82.8701 135.51 m 0
+ 123.108 135.51 150.08 105.565 150.08 69.0156 c 0
+ 150.08 33.3008 123.196 1.08984 82.8701 1.08984 c 0
+ 48.7578 1.08984 18.5195 30.6182 18.5195 69.0156 c 0
+ 18.5195 107.482 48.7617 135.51 82.8701 135.51 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: LineaPunctumCavumHole.caeciliae
@@ -2321,6 +2414,7 @@ SplineSet
  99.7578 1.68945 69.5195 31.2178 69.5195 69.6152 c 4
  69.5195 108.081 99.7617 136.11 133.87 136.11 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumHole
@@ -2340,6 +2434,7 @@ SplineSet
  18.6152 114.963 l 2
  18.5986 134.042 49.3525 142.987 82.6133 142.987 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: LineaPunctumCavumHole
@@ -2359,6 +2454,7 @@ SplineSet
  74.6152 113.963 l 6
  74.6006 133.042 101.353 141.987 134.613 141.987 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: NaturalHole
@@ -2370,11 +2466,12 @@ LayerCount: 2
 Fore
 SplineSet
 19.6201 1.64062 m 5
- 19.6201 83.4795 20.0596 124.399 20.9404 124.399 c 6
+ 20.9404 124.399 l 6
  89.5801 134.96 l 5
- 89.5801 13.5195 l 5
+ 89.5801 13.5195 l 1
  19.6201 1.64062 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: FlatHole
@@ -2394,6 +2491,7 @@ SplineSet
  152.315 16.166 143.735 7.58594 126.575 7.58594 c 0
  91.3008 7.58594 15.0352 73.3662 15.0352 73.3662 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: odbase
@@ -2417,6 +2515,7 @@ SplineSet
  144.224 -3.0293 137.585 -0.349609 128.2 -0.349609 c 0
  99.4707 -0.349609 69.3203 -30.1504 42.7998 -30.1504 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioDominican
@@ -2434,6 +2533,7 @@ SplineSet
  18 -94 l 25
  0 -94 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioDominicanAlt
@@ -2451,6 +2551,7 @@ SplineSet
  18 -241 l 17
  11.6489 -241.01 3.25 -240.75 0 -237 c 9
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Sharp
@@ -2513,6 +2614,7 @@ SplineSet
  118 73 l 5
  129 58.7002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: SharpHole
@@ -2530,6 +2632,7 @@ SplineSet
  141.1 73 l 1
  129 57.2705 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Linea
@@ -2557,6 +2660,7 @@ SplineSet
  176.867 -6.09961 48.5 -6.09961 19 -7.7998 c 1
  19 -54.8037 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: RoundBrace
@@ -2582,6 +2686,7 @@ SplineSet
  18.5613 695 l 2
  11.032 695 -1.91563 695.081 -1.91563 703.473 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CurlyBrace
@@ -2609,6 +2714,7 @@ SplineSet
  610.8 698 550.6 710.6 503 748.4 c 1
  455.4 710.6 395.2 698 333.6 698 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: BarBrace
@@ -2634,6 +2740,7 @@ SplineSet
  12.9932 682 l 2
  8.25 682 0.0927734 682.081 0.0927734 690.474 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusDeminutus.caeciliae
@@ -2645,17 +2752,18 @@ HStem: -409 15 -94 15 221 15 536 15
 LayerCount: 2
 Fore
 SplineSet
-116.5 -61.5 m 5
- 116.5 -61.5 168 -43 168 37 c 1
- 168 128 l 2
- 168 166.609 151.6 179.15 128.2 179.15 c 0
- 97.5713 179.15 70.1924 146.65 39.7998 146.65 c 0
- 8.59961 146.65 0 174.771 0 197 c 1
- 0 20.5 l 2
- 0 -6.01953 8.59961 -30.1504 39.7998 -30.1504 c 0
- 66.3203 -30.1504 99.4707 3.65039 128.2 3.65039 c 1
- 145.949 3.65039 116.5 -61.5 116.5 -61.5 c 5
+116.5 -61.5 m 1
+ 116.5 -61.5 145.949 3.65039 128.2 3.65039 c 1
+ 99.4707 3.65039 66.3203 -30.1504 39.7998 -30.1504 c 0
+ 8.59961 -30.1504 0 -6.01953 0 20.5 c 2
+ 0 197 l 1
+ 0 174.771 8.59961 146.65 39.7998 146.65 c 0
+ 70.1924 146.65 97.5713 179.15 128.2 179.15 c 0
+ 151.6 179.15 168 166.609 168 128 c 2
+ 168 37 l 1
+ 168 -43 116.5 -61.5 116.5 -61.5 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: obase4
@@ -2680,6 +2788,7 @@ SplineSet
  -0 160 15 172 39 172 c 0
  61 172 106 140 127 140 c 0xc0
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: SalicusOriscus
@@ -2706,6 +2815,7 @@ SplineSet
  0 133 27 137 41 137 c 0
  70 137 106 112 127 112 c 0
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: VirgaReversaDescendens
@@ -2729,6 +2839,7 @@ SplineSet
  47.0723 186.5 140.456 185.508 166.399 129.3 c 5
  166.399 -65.7002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens
@@ -2752,6 +2863,7 @@ SplineSet
  47.0723 186.5 140.456 185.508 166.399 129.3 c 1
  166.399 -65.7002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: vbase2
@@ -2776,6 +2888,7 @@ SplineSet
  18.2002 -307 l 2
  18.2002 -352.24 16.9004 -353.8 11.7002 -353.8 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase3
@@ -2800,6 +2913,7 @@ SplineSet
  18.2002 -464 l 6
  18.2002 -509.24 16.9004 -510.8 11.7002 -510.8 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase4
@@ -2824,6 +2938,7 @@ SplineSet
  18.2002 -622 l 2
  18.2002 -667.24 16.9004 -668.8 11.7002 -668.8 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase5
@@ -2848,6 +2963,7 @@ SplineSet
  18.2002 -779 l 6
  18.2002 -824.24 16.9004 -825.8 11.7002 -825.8 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase1
@@ -2860,16 +2976,17 @@ LayerCount: 2
 Fore
 SplineSet
 11.2998 -193.1 m 1
- 16.5 -193.1 17.7998 -191.54 17.7998 -146.3 c 2
- 17.7998 -31.4004 l 1
- 34.2666 -16.667 55.9326 -9.2998 82.7998 -9.2998 c 0
- 121.8 -9.2998 148.667 -17.9668 166 -35.2998 c 1
- 166 122 l 2
- 166 154.067 139.35 170.1 83.4502 170.1 c 0
- 27.5498 170.1 0 154.067 0 122 c 2
- 0 -172.3 l 2
- 0 -184.433 3.5 -191.367 11.2998 -193.1 c 1
+ 3.5 -191.367 0 -184.433 0 -172.3 c 2
+ 0 122 l 2
+ 0 154.067 27.5498 170.1 83.4502 170.1 c 0
+ 139.35 170.1 166 154.067 166 122 c 2
+ 166 -35.2998 l 1
+ 148.667 -17.9668 121.8 -9.2998 82.7998 -9.2998 c 0
+ 55.9326 -9.2998 34.2666 -16.667 17.7998 -31.4004 c 1
+ 17.7998 -146.3 l 2
+ 17.7998 -191.54 16.5 -193.1 11.2998 -193.1 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusScapusLongqueue
@@ -2894,6 +3011,7 @@ SplineSet
  4.5 -372.7 0.0146484 -365.935 0 -354.668 c 1
  0 -196.667 -0 -35.335 -0 122.666 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: OriscusScapus
@@ -2918,6 +3036,7 @@ SplineSet
  3.5 -249.367 0.00683594 -242.433 0 -230.3 c 2
  -0.200195 121.45 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: osbase1
@@ -2942,6 +3061,7 @@ SplineSet
  3.5 -191.367 0.0078125 -184.433 0 -172.3 c 2
  -0.200195 121.45 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: osbase2
@@ -2968,6 +3088,7 @@ SplineSet
  3.90039 -352.067 0 -345.133 0 -333 c 2
  0 121 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: osbase3
@@ -2994,6 +3115,7 @@ SplineSet
  30.2247 -3.34961 23.2744 -5.56738 17.834 -9.34668 c 1
  18.2002 -464 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: osbase4
@@ -3020,6 +3142,7 @@ SplineSet
  30.2247 -3.34961 23.2744 -5.56738 17.834 -9.34668 c 1
  18.2002 -622 l 6
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: osbase5
@@ -3046,6 +3169,7 @@ SplineSet
  30.2247 -3.34961 23.2744 -5.56738 17.834 -9.34668 c 1
  18.2002 -779 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: oslbase
@@ -3072,6 +3196,7 @@ SplineSet
  30.2247 -3.34961 23.2744 -5.56738 17.834 -9.34668 c 1
  18.2002 -332 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: StrophaAucta
@@ -3094,6 +3219,7 @@ SplineSet
  74.0265 -134.051 70.859 -135.9 69 -134 c 0
  67.8376 -132.812 68.9399 -130.683 70 -129 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: Stropha
@@ -3118,6 +3244,7 @@ SplineSet
  67 -67 65 -67 65 -66 c 0
  65 -65 68.1093 -63.644 70 -62 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: hepisemusleft
@@ -3135,6 +3262,7 @@ SplineSet
  1 64 l 25
  -2 64 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: porrectusam11
@@ -3157,6 +3285,7 @@ SplineSet
  503 -183 l 6
  503 -195.133 492.65 -201.2 471.85 -201.2 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusam12
@@ -3179,6 +3308,7 @@ SplineSet
  628 -131.1 l 1
  628 -354.1 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusam13
@@ -3203,6 +3333,7 @@ SplineSet
  678 -527 668 -539 657 -539 c 0
  654 -539 649.183 -537.462 644 -536 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusam14
@@ -3227,6 +3358,7 @@ SplineSet
  721 -695.495 718.133 -722.3 708.601 -722.3 c 0
  704.268 -722.3 696.933 -720.292 691 -717.399 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusam15
@@ -3251,6 +3383,7 @@ SplineSet
  933 -820.495 930.133 -847.3 920.601 -847.3 c 0
  916.268 -847.3 909.298 -844.373 903 -842.399 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: RoundBraceDown
@@ -3262,20 +3395,21 @@ HStem: 1984 15 1669 15 1354 15 1039 15
 LayerCount: 2
 Fore
 SplineSet
--1.91602 246.527 m 4
- -1.91602 244.75 -1.33496 242.6 0 240 c 4
- 19 203 177.993 55 471 55 c 4
- 759.007 55 918 203 937 240 c 4
- 938.335 242.6 938.916 244.75 938.916 246.527 c 4
- 938.916 254.919 925.968 255 918.439 255 c 6
- 918 255 l 6
- 909 255 907.881 246.701 899 237 c 4
- 780 107 552 86 471 86 c 4
- 385 86 157 107 38 237 c 4
- 29.1191 246.701 28 255 19 255 c 6
- 18.5615 255 l 6
- 11.0322 255 -1.91602 254.919 -1.91602 246.527 c 4
+-1.91602 246.527 m 0
+ -1.91602 254.919 11.0322 255 18.5615 255 c 2
+ 19 255 l 2
+ 28 255 29.1191 246.701 38 237 c 0
+ 157 107 385 86 471 86 c 0
+ 552 86 780 107 899 237 c 0
+ 907.881 246.701 909 255 918 255 c 2
+ 918.439 255 l 2
+ 925.968 255 938.916 254.919 938.916 246.527 c 0
+ 938.916 244.75 938.335 242.6 937 240 c 0
+ 918 203 759.007 55 471 55 c 0
+ 177.993 55 19 203 0 240 c 0
+ -1.33496 242.6 -1.91602 244.75 -1.91602 246.527 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusDeminutus
@@ -3301,6 +3435,7 @@ SplineSet
  168 37 l 2
  168 -54 89 -65 89 -65 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumInclinatumAuctus
@@ -3311,16 +3446,17 @@ Flags: HW
 LayerCount: 2
 Fore
 SplineSet
-65.2959 -71.8662 m 4
- 65.6895 -72.8594 80.9023 -69.0273 94.0605 -59 c 0
- 109.061 -46 118.393 -31.7139 130.061 -15 c 0
- 164.717 35.876 185.213 78.624 185.213 78.624 c 1
+65.2959 -71.8662 m 0
+ 65.0352 -71.207 66.9351 -71.0073 71 -67 c 1
+ 71 -67 88 -49 79 -24 c 1
+ 56.0605 22 -0.0927734 63.9004 -0.0927734 63.9004 c 1
  79.9277 199.834 l 1
- -0.0927734 63.9004 l 1
- -0.673628 64.4493 56.0605 22 79 -24 c 1
- 88 -49 71 -67 71 -67 c 0
- 66.9351 -71.0073 65.0352 -71.207 65.2959 -71.8662 c 4
+ 185.213 78.624 l 1
+ 185.213 78.624 164.717 35.876 130.061 -15 c 0
+ 118.393 -31.7139 109.061 -46 94.0605 -59 c 1
+ 80.9023 -69.0273 65.6895 -72.8594 65.2959 -71.8662 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaAscendens_op
@@ -3347,6 +3483,7 @@ SplineSet
  162.101 301.067 166.001 294.133 166.001 282 c 2
  166 0 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueueAscendens_op
@@ -3373,6 +3510,7 @@ SplineSet
  11.5 -57.25 0 -47.7324 0 -25.1992 c 2
  0 484.668 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens_op
@@ -3401,6 +3539,7 @@ SplineSet
  156.938 157.5 167.999 154.004 168 147.341 c 9
  167.994 -152.336 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaDescendens_op
@@ -3428,6 +3567,7 @@ SplineSet
  156.938 157.5 167.999 154.004 168 147.341 c 9
  168 -152 l 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaAscendens
@@ -3452,6 +3592,7 @@ SplineSet
  4.5 -248.7 0 -241.935 0 -230.668 c 2
  0 154 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueueAscendens
@@ -3476,6 +3617,7 @@ SplineSet
  35.1006 -40 l 2
  28.4574 -40 22.7572 -39.0919 18 -37.2754 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumAscendens_op
@@ -3499,6 +3641,7 @@ SplineSet
  162.101 301.067 166.001 294.133 166.001 282 c 6
  166 17.2002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumDescendens_op
@@ -3521,6 +3664,7 @@ SplineSet
  73.3184 174 140 177 166 126.5 c 1
  166 -152 l 6
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: auctusd1_op
@@ -3545,6 +3689,7 @@ SplineSet
  21.0342 -7.40039 6.93359 -13.9004 0 -26.9004 c 1
  0 200 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusa1_op
@@ -3570,6 +3715,7 @@ SplineSet
  162.101 301.067 166.001 294.133 166.001 282 c 2
  166 3.7002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusa2_op
@@ -3595,6 +3741,7 @@ SplineSet
  64.5688 147 118.423 153.134 148 180.5 c 1
  148.175 256 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumAuctusLineBL_op
@@ -3620,6 +3767,7 @@ SplineSet
  149.1 -172.8 147.8 -171.24 147.8 -126 c 2
  147.812 -35.4977 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: pesdeminutus_op
@@ -3645,6 +3793,7 @@ SplineSet
  17.5 209.3 18 207.74 18 162.5 c 2
  18 135.495 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatum
@@ -3667,6 +3816,7 @@ SplineSet
  104.332 -59.373 l 1
  -0.0927734 60.3877 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatumAuctus
@@ -3677,22 +3827,22 @@ Flags: HW
 LayerCount: 2
 Fore
 SplineSet
-98.9121 -16.332 m 5
- 109.413 -7.23242 110.644 -3.00488 118.811 8.69531 c 0
- 143.07 44.3086 157.417 74.2324 157.417 74.2324 c 1
+98.9121 -16.332 m 1
+ 120.033 1.97049 157.417 74.2324 157.417 74.2324 c 1
  83.7178 159.079 l 1
  29.5576 67.7969 l 1
- 41.0579 61.2967 91.5579 6.79673 98.9121 -16.332 c 5
+ 41.0579 61.2967 91.5579 6.79673 98.9121 -16.332 c 1
 65.2959 -71.8662 m 0
- 65.0352 -71.207 66.9351 -71.0073 71 -67 c 0
+ 65.0352 -71.207 66.9351 -71.0073 71 -67 c 1
  71 -67 88 -49 79 -24 c 1
- 56.0605 22 -0.673628 64.4493 -0.0927734 63.9004 c 1
+ 56.0605 22 -0.0927734 63.9004 -0.0927734 63.9004 c 1
  79.9277 199.834 l 1
  185.213 78.624 l 1
  185.213 78.624 164.717 35.876 130.061 -15 c 0
- 118.393 -31.7139 109.061 -46 94.0605 -59 c 0
+ 118.393 -31.7139 109.061 -46 94.0605 -59 c 1
  80.9023 -69.0273 65.6895 -72.8594 65.2959 -71.8662 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumCavumInclinatumAuctusHole
@@ -3710,6 +3860,7 @@ SplineSet
  157.417 74.2324 143.07 44.3086 118.811 8.69531 c 0
  110.644 -3.00488 109.413 -7.23242 98.9121 -16.332 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatumHole
@@ -3727,6 +3878,7 @@ SplineSet
  100.801 -21.0186 l 1
  27.7031 62.8135 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 EndChars
 EndSplineFont

--- a/fonts/gregorio-base.sfd
+++ b/fonts/gregorio-base.sfd
@@ -19,7 +19,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1176402534
-ModificationTime: 1437850433
+ModificationTime: 1438738099
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
@@ -90,6 +90,7 @@ SplineSet
  69.3857 -17.626 12.6895 45.1592 0.0732422 75.707 c 5
  5.4834 99.8564 57.748 176.531 71.6055 191.61 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Stropha
@@ -259,6 +260,7 @@ SplineSet
  36.3867 30.9961 6.96094 61.3809 0.123047 76.4248 c 5
  2.40625 88.5879 27.1846 127.812 33.8447 135.59 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioMaior
@@ -289,13 +291,13 @@ LayerCount: 2
 Fore
 SplineSet
 152 553.333 m 1
- 152 586.678 122.5 613.998 75 612.998 c 1
- 49 612.998 17 597.998 17 572.998 c 1
- 17 510.498 124.5 530.998 120 561.998 c 1
- 152.5 495.998 46 458 0 418.998 c 5
- 67 439 152 497.678 152 553.333 c 1
+ 152 497.678 67 439 0 418.998 c 1
+ 46 458 152.5 495.998 120 561.998 c 1
+ 124.5 530.998 17 510.498 17 572.998 c 1
+ 17 597.998 49 612.998 75 612.998 c 1
+ 122.5 613.998 152 586.678 152 553.333 c 1
 EndSplineSet
-Validated: 41
+Validated: 524321
 EndChar
 
 StartChar: CClef
@@ -307,21 +309,21 @@ HStem: -409 15 -94 15 221 15 536 15
 LayerCount: 2
 Fore
 SplineSet
-0 380.5 m 9
- 0 74.5 l 17
- 0 51.167 25 12.5 63.333 10.6699 c 0
- 105.336 8.66463 140 19.667 140 27.9941 c 9
- 140 27.9941 141.667 167.667 138.334 173 c 1
- 98.334 163.657 63.374 168.845 55.667 170.665 c 0
- 22.499 178.502 22 224.161 22 224.161 c 10
- 22 236.667 l 18
- 23 236.667 18.8457 279.427 55.333 289.834 c 0
- 62.333 291.831 99.334 294.679 138.334 286.333 c 1
- 141.667 296.667 140 378.667 140 424.5 c 1
- 131.333 431.333 101.415 447.478 60 440 c 0
- 24 433.5 0 400.667 0 380.5 c 9
+0 380.5 m 17
+ 0 400.667 24 433.5 60 440 c 0
+ 101.415 447.478 131.333 431.333 140 424.5 c 1
+ 140 378.667 141.667 296.667 138.334 286.333 c 1
+ 99.334 294.679 62.333 291.831 55.333 289.834 c 0
+ 18.8457 279.427 23 236.667 22 236.667 c 10
+ 22 224.161 l 18
+ 22 224.161 23.4234 181.705 55.667 170.665 c 0
+ 63.0418 168.14 98.334 163.657 138.334 173 c 1
+ 141.667 167.667 140 27.9941 140 27.9941 c 17
+ 140 19.667 105.336 8.66463 63.333 10.6699 c 0
+ 25 12.5 0 51.167 0 74.5 c 9
+ 0 380.5 l 17
 EndSplineSet
-Validated: 41
+Validated: 524321
 EndChar
 
 StartChar: Virga
@@ -518,6 +520,7 @@ SplineSet
  11 149.666 16.1506 155.337 37.999 154.664 c 4
  92 153 156.02 134.329 186 100.001 c 13
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: Natural
@@ -529,21 +532,21 @@ HStem: -409 15 -94 15 221 15 536 15
 LayerCount: 2
 Fore
 SplineSet
-0 382 m 9
- 0 -53 l 17
- 51 -47 116 -45 170 0 c 1
- 170 13 169 19 169 59 c 5
- 111 12 70 12 22 5 c 13
- 22 79 l 21
- 68 113 106.103 115.761 179 126 c 13
- 179 -244 l 17
- 186.675 -242.17 195.761 -243.79 201 -236 c 9
- 201 185 l 17
- 117 177 81 177 22 140 c 9
- 22 393 l 17
- 14.6667 390.185 7.33334 390.885 0 382 c 9
+0 382 m 17
+ 7.33334 390.885 14.6667 390.185 22 393 c 9
+ 22 140 l 17
+ 81 177 117 177 201 185 c 9
+ 201 -236 l 17
+ 195.761 -243.79 186.675 -242.17 179 -244 c 9
+ 179 126 l 17
+ 106.103 115.761 68 113 22 79 c 9
+ 22 5 l 17
+ 70 12 111 12 169 59 c 1
+ 169 19 170 13 170 0 c 1
+ 116 -45 51 -47 0 -53 c 9
+ 0 382 l 17
 EndSplineSet
-Validated: 9
+Validated: 524289
 EndChar
 
 StartChar: FClef
@@ -565,21 +568,21 @@ SplineSet
  151.999 133.666 152 -54.666 152 -58 c 1
  133.333 -57.999 129.995 -53.626 129.995 -53.626 c 25
  129.995 131.999 l 1
-181 389.006 m 9
- 181 52.5059 l 17
- 181 29.1729 209 6.21973 244.333 5.17578 c 0
- 269.289 4.4375 321 14.1729 321 22.5 c 9
- 321 22.5 322.667 162.173 319.334 167.506 c 1
- 279.334 158.163 244.374 163.351 236.667 165.171 c 0
- 203.499 173.008 203 218.667 203 218.667 c 10
- 203 231.173 l 18
- 204 231.173 199.846 273.933 236.333 284.34 c 0
- 243.333 286.337 280.334 289.185 319.334 280.839 c 1
- 322.667 291.173 321 373.173 321 419.006 c 1
- 312.333 425.839 283 437.173 241 434.506 c 0
- 215.718 432.9 181 409.173 181 389.006 c 9
+181 389.006 m 17
+ 181 409.173 215.718 432.9 241 434.506 c 0
+ 283 437.173 312.333 425.839 321 419.006 c 1
+ 321 373.173 322.667 291.173 319.334 280.839 c 1
+ 280.334 289.185 243.333 286.337 236.333 284.34 c 0
+ 199.846 273.933 204 231.173 203 231.173 c 10
+ 203 218.667 l 18
+ 203 218.667 203.499 173.008 236.667 165.171 c 0
+ 244.374 163.351 279.334 158.163 319.334 167.506 c 1
+ 322.667 162.173 321 22.5 321 22.5 c 17
+ 321 14.1729 269.289 4.4375 244.333 5.17578 c 0
+ 209 6.21973 181 29.1729 181 52.5059 c 9
+ 181 389.006 l 17
 EndSplineSet
-Validated: 41
+Validated: 524321
 EndChar
 
 StartChar: CustosDownLong
@@ -631,15 +634,15 @@ HStem: 854.5 15 539.5 15 224.5 15 -90.5 15
 LayerCount: 2
 Fore
 SplineSet
-63 478.5 m 5
- 63 140 l 5
- 59 129.5 25 160.5 3 170.5 c 5
- 0 160.5 0.279297 20.5 0 10.5 c 5
- -0.329102 -8.0752 78 -52.5 85 -36 c 5
- 85 466.5 l 6
- 85 471.5 63 478.5 63 478.5 c 5
+63 478.5 m 1
+ 63 478.5 85 471.5 85 466.5 c 2
+ 85 -36 l 1
+ 78 -52.5 -0.329102 -8.0752 0 10.5 c 1
+ 0.279297 20.5 0 160.5 3 170.5 c 1
+ 25 160.5 59 129.5 63 140 c 1
+ 63 478.5 l 1
 EndSplineSet
-Validated: 41
+Validated: 524321
 EndChar
 
 StartChar: CustosUpShort
@@ -651,15 +654,15 @@ HStem: 957.5 15 642.5 15 327.5 15 12.5 15
 LayerCount: 2
 Fore
 SplineSet
-63 370.5 m 5
- 63 147 l 5
- 59 136.5 25 167.5 3 177.5 c 5
- 0 167.5 0.279297 27.5 0 17.5 c 5
- -0.329102 -1.0752 78 -45.5 85 -29 c 5
- 85 358.5 l 6
- 84.9746 367.485 63 370.5 63 370.5 c 5
+63 370.5 m 1
+ 63 370.5 84.9746 367.485 85 358.5 c 2
+ 85 -29 l 1
+ 78 -45.5 -0.329102 -1.0752 0 17.5 c 1
+ 0.279297 27.5 0 167.5 3 177.5 c 1
+ 25 167.5 59 136.5 63 147 c 1
+ 63 370.5 l 1
 EndSplineSet
-Validated: 41
+Validated: 524321
 EndChar
 
 StartChar: PunctumLineBR
@@ -961,6 +964,7 @@ SplineSet
  -6.39941 90.001 l 1
  -8.11914 105.713 -14.7559 152.207 0.155273 154.667 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: OriscusLineTR
@@ -1418,6 +1422,7 @@ SplineSet
  39.6904 17.0068 8.97949 52.1523 -0.414062 72.8213 c 5
  4.15039 97.1445 53.707 175.597 67.0293 191.15 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaLongqueue
@@ -1457,6 +1462,7 @@ SplineSet
  53.5186 119.25 71.25 104.121 71.25 83.5 c 4
  71.25 62.8447 53.5273 47.75 35.5 47.75 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VEpisemus
@@ -1476,6 +1482,7 @@ SplineSet
  8.25 -28.125 3.875 -25.625 0 -20.625 c 9
  0 96.75 l 17
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumDeminutus
@@ -1513,6 +1520,7 @@ SplineSet
  1 64 l 25
  0 64 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: PesOneNothing
@@ -1557,6 +1565,7 @@ SplineSet
  25 160.5 59 129.5 63 140 c 1
  63 412.5 l 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: CustosDownMedium
@@ -1748,6 +1757,7 @@ SplineSet
  209 6.21973 181 29.1729 181 52.5059 c 9
  181 389.006 l 17
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VEpisemus.circumflexus
@@ -1894,6 +1904,7 @@ SplineSet
  108 158 135 150 154 142 c 13
  154 -26 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: hepisemusright
@@ -1911,6 +1922,7 @@ SplineSet
  2 96 l 25
  0 64 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: mpdeminutus
@@ -1934,6 +1946,7 @@ SplineSet
  164 164 l 1
  186 164 l 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumDescendens
@@ -1956,6 +1969,7 @@ SplineSet
  41.0605 5.05566 15 0.648438 0 -10.0078 c 1
  0 146.342 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumAscendens
@@ -1978,6 +1992,7 @@ SplineSet
  50.0889 -13.0303 12 -14 0 -10 c 5
  0 151.673 l 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: mnbdeminutus
@@ -1999,6 +2014,7 @@ SplineSet
  11 149.666 16.1506 155.337 37.999 154.664 c 0
  92 153 156.02 134.329 186 100.001 c 9
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: mnbpdeminutus
@@ -2020,6 +2036,7 @@ SplineSet
  16.1504 -63.6719 11 -58.001 0 -53.001 c 1
  0 148.165 l 21
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: porrectusflexusnb1
@@ -2040,6 +2057,7 @@ SplineSet
  143.49 48.2977 204 -2.125 318 -6 c 5
  334.25 -3.75 336.5 -0.5 340 3.25 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb2
@@ -2060,6 +2078,7 @@ SplineSet
  98 9 278 -148.625 406 -154 c 5
  422.75 -154.25 424.75 -152.5 428 -149 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb3
@@ -2080,6 +2099,7 @@ SplineSet
  96 -16 328 -271 564 -315.5 c 5
  582 -317.75 584.25 -310.25 586 -306.5 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb4
@@ -2100,6 +2120,7 @@ SplineSet
  109 -52 374 -395 648 -440.5 c 5
  661.75 -442.75 668 -437.75 670 -434 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb5
@@ -2120,6 +2141,7 @@ SplineSet
  122.5 -117.5 382.5 -511 909 -631 c 5
  919 -633.333 929 -626.667 931 -620.326 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: p2base
@@ -2140,6 +2162,7 @@ SplineSet
  120.543 136.112 134 142.5 141.992 148.668 c 0
  164 148.674 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: rvlbase
@@ -2163,6 +2186,7 @@ SplineSet
  145.333 -362.667 141.996 -354.293 141.996 -354.293 c 25
  141.996 -26.668 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: msdeminutus
@@ -2186,6 +2210,7 @@ SplineSet
  6 -93 13 -93 0 -93 c 1
  0 148.165 l 17
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: mademinutus
@@ -2209,6 +2234,7 @@ SplineSet
  26.1074 155.219 31.5831 154.862 37.999 154.664 c 0
  92 153 156.02 134.329 186 100.001 c 9
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumCavumHole
@@ -2228,6 +2254,7 @@ SplineSet
  130.95 23.7246 100.656 26.4746 83.0996 26.4746 c 4
  65.5439 26.4746 34.1504 25.9248 19.8496 16.5752 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: LineaPunctumCavumHole
@@ -2247,6 +2274,7 @@ SplineSet
  182.291 24.2246 151.997 26.9746 134.441 26.9746 c 4
  116.885 26.9746 85.4912 26.4248 71.1904 17.0752 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: FlatHole
@@ -2264,6 +2292,7 @@ SplineSet
  85.6631 -2.22461 44.9619 14.084 18.9873 52.375 c 9
  18.9785 97.5264 l 17
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: NaturalHole
@@ -2281,6 +2310,7 @@ SplineSet
  18.0752 79.6748 l 17
  66.375 115.375 182.925 129.025 182.925 129.025 c 9
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: odbase
@@ -2308,6 +2338,7 @@ SplineSet
  -0.300029 17.3307 -0.20241 18.3267 0 19.3301 c 9
  0 191 l 17
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioDominican
@@ -2325,6 +2356,7 @@ SplineSet
  22 -94 l 29
  0 -94 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: DivisioDominicanAlt
@@ -2342,6 +2374,7 @@ SplineSet
  22 -246 l 29
  0 -246 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: Sharp
@@ -2404,6 +2437,7 @@ SplineSet
  118 73 l 5
  129 58.7002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: SharpHole
@@ -2421,6 +2455,7 @@ SplineSet
  141.1 73 l 5
  129 57.2705 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Linea
@@ -2448,6 +2483,7 @@ SplineSet
  176.867 -6.09961 48.5 -6.09961 19 -7.7998 c 1
  19 -54.8037 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: RoundBrace
@@ -2473,6 +2509,7 @@ SplineSet
  18.5613 695 l 2
  11.032 695 -1.91563 695.081 -1.91563 703.473 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CurlyBrace
@@ -2500,6 +2537,7 @@ SplineSet
  610.8 698 550.6 710.6 503 748.4 c 1
  455.4 710.6 395.2 698 333.6 698 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: BarBrace
@@ -2525,6 +2563,7 @@ SplineSet
  12.9932 682 l 2
  8.25 682 0.0927734 682.081 0.0927734 690.474 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusDeminutus
@@ -2553,6 +2592,7 @@ SplineSet
  -0.300029 17.3307 -0.20241 18.3267 0 19.3301 c 9
  0 191 l 17
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: obase4
@@ -2580,6 +2620,7 @@ SplineSet
  0 130 l 1
  12 144 31 160 52 160 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: SalicusOriscus
@@ -2606,6 +2647,7 @@ SplineSet
  164 22 l 2
  164 6.09481 145.261 -6.68724 125.721 -6.68724 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaDescendens
@@ -2628,6 +2670,7 @@ SplineSet
  22 -212.293 18.667 -220.667 0 -220.668 c 1
  0 146.001 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens
@@ -2650,6 +2693,7 @@ SplineSet
  22 -356.293 18.667 -364.667 0 -364.668 c 5
  0 146.001 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase2
@@ -2673,6 +2717,7 @@ SplineSet
  114 8 103.563 9.49736 81.999 9.33301 c 0
  51.331 8.66695 22.0039 0 22.0039 -26.668 c 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase3
@@ -2696,6 +2741,7 @@ SplineSet
  114 8 103.563 9.49736 81.999 9.33301 c 0
  51.331 8.66695 22.0039 0 22.0039 -26.668 c 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase4
@@ -2719,6 +2765,7 @@ SplineSet
  114 8 103.563 9.49736 81.999 9.33301 c 0
  51.331 8.66695 22.0039 0 22.0039 -26.668 c 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase5
@@ -2742,6 +2789,7 @@ SplineSet
  114 8 103.563 9.49736 81.999 9.33301 c 0
  51.331 8.66695 22.0039 0 22.0039 -26.668 c 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase1
@@ -2763,6 +2811,7 @@ SplineSet
  149 0.65625 116.999 9.33301 81.999 9.33301 c 0
  51.333 8.66699 22.0039 -4 22.0039 -26.668 c 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusScapusLongqueue
@@ -2790,6 +2839,7 @@ SplineSet
  22 -356 19 -365 0 -365 c 1
  0 130 l 17
 EndSplineSet
+Validated: 33
 EndChar
 
 StartChar: OriscusScapus
@@ -2818,6 +2868,7 @@ SplineSet
  22.0039 -212.293 18.667 -220.667 0 -220.668 c 1
  0 -41.25 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase1
@@ -2845,6 +2896,7 @@ SplineSet
  22 -160 19 -169 0 -169 c 5
  0 130 l 21
 EndSplineSet
+Validated: 33
 EndChar
 
 StartChar: osbase2
@@ -2873,6 +2925,7 @@ SplineSet
  153.375 -19.875 164 -20 142 -20 c 1
  142 -3.91719 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase3
@@ -2901,6 +2954,7 @@ SplineSet
  22.0039 -483.293 18.667 -491.667 0 -491.668 c 5
  0 129.75 l 21
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase4
@@ -2929,6 +2983,7 @@ SplineSet
  22.0039 -640.293 18.667 -648.667 0 -648.668 c 5
  0 129.75 l 21
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase5
@@ -2957,6 +3012,7 @@ SplineSet
  22.0039 -790.293 18.667 -798.667 0 -798.668 c 1
  0 129.75 l 17
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: oslbase
@@ -2985,6 +3041,7 @@ SplineSet
  21.998 -356.617 18.667 -364.991 0 -364.992 c 5
  0 129.75 l 21
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: hepisemusleft
@@ -3002,31 +3059,33 @@ SplineSet
  1 64 l 25
  -2 64 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: RoundBraceDown
 Encoding: 130 -1 128
 Width: 937
 VWidth: 2048
-Flags: W
+Flags: HW
 HStem: 1984 15 1669 15 1354 15 1039 15
 LayerCount: 2
 Fore
 SplineSet
--1.91602 246.527 m 4
- -1.91602 244.75 -1.33496 242.6 0 240 c 4
- 19 203 177.993 55 471 55 c 4
- 759.007 55 918 203 937 240 c 4
- 938.335 242.6 938.916 244.75 938.916 246.527 c 4
- 938.916 254.919 925.968 255 918.439 255 c 6
- 918 255 l 6
- 909 255 907.881 246.701 899 237 c 4
- 780 107 552 86 471 86 c 4
- 385 86 157 107 38 237 c 4
- 29.1191 246.701 28 255 19 255 c 6
- 18.5615 255 l 6
- 11.0322 255 -1.91602 254.919 -1.91602 246.527 c 4
+-1.91602 246.527 m 0
+ -1.91602 254.919 11.0322 255 18.5615 255 c 2
+ 19 255 l 2
+ 28 255 29.1191 246.701 38 237 c 0
+ 157 107 385 86 471 86 c 0
+ 552 86 780 107 899 237 c 0
+ 907.881 246.701 909 255 918 255 c 2
+ 918.439 255 l 2
+ 925.968 255 938.916 254.919 938.916 246.527 c 0
+ 938.916 244.75 938.335 242.6 937 240 c 0
+ 918 203 759.007 55 471 55 c 0
+ 177.993 55 19 203 0 240 c 0
+ -1.33496 242.6 -1.91602 244.75 -1.91602 246.527 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaAscendens_op
@@ -3050,6 +3109,7 @@ SplineSet
  23.5 81.5 37.3945 80.6611 46 81.665 c 0
  106 88.665 164 99 164 131.664 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaLongqueueAscendens_op
@@ -3073,6 +3133,7 @@ SplineSet
  163.996 268.29 l 29
  163.996 268.29 167.333 276.664 186 276.665 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaDescendens_op
@@ -3096,6 +3157,7 @@ SplineSet
  167.333 -199.999 163.996 -191.625 163.996 -191.625 c 29
  164 -61.999 l 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens_op
@@ -3119,6 +3181,7 @@ SplineSet
  167.333 -199.999 163.996 -191.625 163.996 -191.625 c 29
  164 -61.999 l 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaAscendens
@@ -3143,6 +3206,7 @@ SplineSet
  22 -212.293 l 1
  22 -212.293 18.667 -220.667 0 -220.668 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaLongqueueAscendens
@@ -3167,6 +3231,7 @@ SplineSet
  22 -356.293 l 1
  22 -356.293 18.667 -364.667 0 -364.668 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumDescendens_op
@@ -3191,6 +3256,7 @@ SplineSet
  145.333 -199.999 141.996 -191.625 141.996 -191.625 c 29
  141.998 -38.6875 l 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumAscendens_op
@@ -3215,6 +3281,7 @@ SplineSet
  82.7738 139.043 117.585 160.223 133 177 c 0
  135.781 180.026 138.878 185.212 142.027 191.562 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: auctusd1_op
@@ -3240,6 +3307,7 @@ SplineSet
  151.56 112.633 160.316 71.7822 164 60.0078 c 9
  164.007 -200 l 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: auctusa1_op
@@ -3265,6 +3333,7 @@ SplineSet
  141.996 268.29 l 25
  141.996 268.29 145.333 276.664 164 276.665 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: auctusa2_op
@@ -3290,6 +3359,7 @@ SplineSet
  82.8027 137.995 117.585 160.223 133 177 c 0
  135.79 180.036 138.899 185.246 142.058 191.625 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumAuctusLineBL_op
@@ -3315,6 +3385,7 @@ SplineSet
  145.34 -199.999 142.003 -191.625 142.003 -191.625 c 25
  142.02 -38.7273 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: pesdeminutus_op
@@ -3340,6 +3411,7 @@ SplineSet
  86.0557 -40.8721 43.333 -40.8418 28.667 -34.1758 c 0
  22.418 -31.3359 3.33301 -19.5098 0 -10.1777 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumCavumInclinatum
@@ -3362,6 +3434,7 @@ SplineSet
  69.3857 -17.626 12.6895 45.1592 0.0732422 75.707 c 1
  5.4834 99.8564 57.748 176.531 71.6055 191.61 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatumAuctus
@@ -3389,6 +3462,7 @@ SplineSet
  39.6904 17.0068 8.97949 52.1523 -0.414062 72.8213 c 1
  4.15039 97.1445 53.707 175.597 67.0293 191.15 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatumHole
@@ -3406,6 +3480,7 @@ SplineSet
  73.1035 11.4561 33.416 55.4062 24.585 76.7891 c 1
  28.3721 93.6943 64.957 147.366 74.6572 157.922 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatumAuctusHole
@@ -3423,6 +3498,7 @@ SplineSet
  81.0039 145.403 122.651 98.9473 134.969 86.6738 c 1
  122.467 59.2998 109.128 31.168 86.4688 4.17383 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 EndChars
 EndSplineFont

--- a/fonts/parmesan-base.sfd
+++ b/fonts/parmesan-base.sfd
@@ -19,7 +19,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1176402534
-ModificationTime: 1437850829
+ModificationTime: 1438738212
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
@@ -75,6 +75,7 @@ SplineSet
  134.445 -21.7686 118.485 -5.80859 79.7246 -5.80859 c 0
  44.3848 -5.80859 23.8652 -21.7686 17.0254 -21.7686 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumInclinatum
@@ -99,6 +100,7 @@ SplineSet
  93.666 -54.9922 88.958 -53.0371 86.3652 -48.6465 c 6
  3.43652 58.6895 l 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Stropha
@@ -129,6 +131,7 @@ SplineSet
  10.2607 86.6016 4.56055 88.8809 0 90.0215 c 1
  68.4004 192.621 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Quilisma
@@ -164,6 +167,7 @@ SplineSet
  94.6201 -17.4658 93.4805 -16.3262 92.3398 -16.3262 c 1
  57 11.0342 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusReversus
@@ -186,6 +190,7 @@ SplineSet
  190.86 83.3135 192 55.9541 192 37.7139 c 0
  192 19.4736 188.58 -42.0859 177.181 -42.0859 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Oriscus
@@ -208,6 +213,7 @@ SplineSet
  100.333 -40.9463 82.0938 -7.88574 51.3135 -7.88574 c 0
  17.1133 -7.88574 23.9531 -42.0859 14.833 -42.0859 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Flat
@@ -237,6 +243,7 @@ SplineSet
  0 281 l 2
  0 287.84 1.14062 312.92 7.98047 312.92 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: queue
@@ -254,6 +261,7 @@ SplineSet
  22 -157.5 l 17
  17.5928 -163.278 8.15723 -163.709 0 -165.5 c 9
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumInclinatumDeminutus
@@ -279,6 +287,7 @@ SplineSet
  58.3066 -17.085 53.5645 -15.2109 49.7607 -10.9668 c 6
  3.21289 50.1885 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioMaior
@@ -296,6 +305,7 @@ SplineSet
  0 -409.002 l 29
  0 550.999 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Virgula
@@ -314,6 +324,7 @@ SplineSet
  17 597.998 49 612.998 75 612.998 c 1
  122.5 613.998 152.337 586.678 152.337 553.333 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: CClef
@@ -342,6 +353,7 @@ SplineSet
  143 342.26 140.221 275.046 132.241 275.046 c 0
  127.681 275.046 114.001 291.006 86.6406 291.006 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: Virga
@@ -363,6 +375,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 6
  160.992 -224.002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversa
@@ -384,6 +397,7 @@ SplineSet
  22.125 -220.875 l 1
  18.5 -223.375 0.0078125 -224.002 0.0078125 -224.002 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioMinima
@@ -402,6 +416,7 @@ SplineSet
  19 352.431 l 17
  6.04348 352.565 2.43478 355.609 0 359.128 c 9
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioMinor
@@ -419,6 +434,7 @@ SplineSet
  19 -293.375 l 21
  14.875 -293.5 5 -293.375 0 -296.375 c 13
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueue
@@ -440,6 +456,7 @@ SplineSet
  22.5 -352.5 l 1
  18.875 -355 0.382812 -355.627 0.382812 -355.627 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: pesdeminutus
@@ -460,6 +477,7 @@ SplineSet
  118.485 148.037 130.5 162.729 139 163.729 c 4
  140.905 163.952 161 163.729 161 163.729 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusd1
@@ -482,6 +500,7 @@ SplineSet
  127.676 -31.9609 111.716 4.51953 79.7959 4.51953 c 4
  42.1758 4.51953 22.7959 -4.60059 17.0967 -4.60059 c 4x40
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusa1
@@ -505,6 +524,7 @@ SplineSet
  111.72 133.569 127.68 170.05 127.68 206.529 c 4
  127.68 214.51 134.521 222.49 143.64 222.49 c 4x40
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: mdeminutus
@@ -525,6 +545,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 6
  161 -21.5 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Natural
@@ -557,6 +578,7 @@ SplineSet
  113.637 73.5176 l 1
  113.637 119.118 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: FClef
@@ -597,6 +619,7 @@ SplineSet
  99.1797 186.72 74.0996 189 62.7002 189 c 0
  33.0596 189 10.2598 175.32 10.2598 175.32 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: CustosDownLong
@@ -619,6 +642,7 @@ SplineSet
  76.6904 196.34 l 5
  76.6904 -320.08 l 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosDownShort
@@ -641,6 +665,7 @@ SplineSet
  76.6904 189.59 l 5
  76.6904 -184.33 l 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosUpLong
@@ -663,6 +688,7 @@ SplineSet
  53.8896 -49.3398 l 2
  32.2305 -49.3398 18.5498 -27.6797 0.30957 -17.4199 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosUpShort
@@ -685,6 +711,7 @@ SplineSet
  53.8896 -45.5898 l 6
  32.2305 -45.5898 18.5498 -23.9297 0.30957 -13.6699 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineBR
@@ -705,6 +732,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 6
  161 -21.5 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineBL
@@ -725,6 +753,7 @@ SplineSet
  42.5146 -5.80859 32.5 -13.5 22 -21.5 c 0
  20.4743 -22.6624 0 -21.5 0 -21.5 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineTL
@@ -746,6 +775,7 @@ SplineSet
  134.445 -21.7686 118.485 -5.80859 79.7246 -5.80859 c 0
  44.3848 -5.80859 23.8652 -21.7686 17.0254 -21.7686 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineTR
@@ -767,6 +797,7 @@ SplineSet
  161 -4.66504 l 5
  160.615 -13.7842 153.135 -21.7686 143.975 -21.7686 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumLineBLBR
@@ -787,6 +818,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 2
  161 -21.5 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: base6
@@ -809,6 +841,7 @@ SplineSet
  134.445 -21.7686 118.485 -5.80859 79.7246 -5.80859 c 0
  44.3848 -5.80859 23.8652 -21.7686 17.0254 -21.7686 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: line2
@@ -826,6 +859,7 @@ SplineSet
  22 -11.5 l 25
  0 -11.5 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: line3
@@ -843,6 +877,7 @@ SplineSet
  22 -11.5 l 25
  0 -11.5 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: line4
@@ -860,6 +895,7 @@ SplineSet
  22 -11.5 l 25
  0 -11.5 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: line5
@@ -877,6 +913,7 @@ SplineSet
  22 -11.5 l 25
  0 -11.5 l 25
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaLineBR
@@ -899,6 +936,7 @@ SplineSet
  22.125 -220.875 l 1
  18.5 -223.375 0.0078125 -224.002 0.0078125 -224.002 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: rvsbase
@@ -921,6 +959,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 2
  160.992 -224.002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: vlbase
@@ -943,6 +982,7 @@ SplineSet
  22.1172 -359.873 l 1
  18.4922 -362.373 0 -363 0 -363 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: QuilismaLineTR
@@ -978,6 +1018,7 @@ SplineSet
  94.6201 -17.4658 93.4805 -16.3262 92.3398 -16.3262 c 1
  57 11.0342 l 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: OriscusLineTR
@@ -1001,6 +1042,7 @@ SplineSet
  100.333 -40.9463 82.0938 -7.88574 51.3135 -7.88574 c 0
  17.1133 -7.88574 23.9531 -42.0859 14.833 -42.0859 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: pbase
@@ -1021,6 +1063,7 @@ SplineSet
  118.485 148.037 130.5 162.729 139 163.729 c 4
  140.905 163.952 161 163.729 161 163.729 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: idebilis
@@ -1044,6 +1087,7 @@ SplineSet
  97 13.9805 l 6
  97 4.86035 88.9199 -3.12012 79.7998 -3.12012 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: deminutus
@@ -1066,6 +1110,7 @@ SplineSet
  28.5 129.12 30.7803 120 49.0205 120 c 0
  67.2598 120 69.2537 123.2 75 128.8 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: rdeminutus
@@ -1088,6 +1133,7 @@ SplineSet
  79 -21.8242 94.0127 -21.5742 75 -21.4424 c 1
  75 13.5 75 -11 75 22 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumAuctusLineBL
@@ -1111,6 +1157,7 @@ SplineSet
  112 -9.31934 98 22.6807 70 22.6807 c 0
  37 22.6807 34.6667 19.3333 22 14.8174 c 1x40
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: auctusa2
@@ -1134,6 +1181,7 @@ SplineSet
  111.72 129.09 127.68 165.571 127.68 202.05 c 0
  127.68 210.031 134.521 218.011 143.64 218.011 c 0x40
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectus1
@@ -1155,6 +1203,7 @@ SplineSet
  490 -191.229 489.69 -190.612 487.76 -190.591 c 0
  254 -188 136.5 -110 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectus2
@@ -1176,6 +1225,7 @@ SplineSet
  575 -359.229 574.68 -358.787 572.76 -358.591 c 4
  322.5 -333 154.5 -201 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectus3
@@ -1197,6 +1247,7 @@ SplineSet
  650 -481.229 649.661 -480.926 647.76 -480.591 c 0
  202 -402 116 -240 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectus4
@@ -1218,6 +1269,7 @@ SplineSet
  740 -681.229 739.615 -681.119 737.76 -680.591 c 0
  270 -547.5 75 -217.5 0 -25 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectus5
@@ -1239,6 +1291,7 @@ SplineSet
  931 -843.229 930.646 -842.992 928.76 -842.591 c 0
  315 -712 70 -240 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexus1
@@ -1260,6 +1313,7 @@ SplineSet
  340 -149.354 339.69 -148.775 337.76 -148.716 c 0
  187.5 -144.125 136.5 -110 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexus2
@@ -1281,6 +1335,7 @@ SplineSet
  428 -297.729 427.688 -297.188 425.76 -297.091 c 0
  265 -289 107 -166 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexus3
@@ -1302,6 +1357,7 @@ SplineSet
  586 -460.229 585.679 -459.792 583.76 -459.591 c 0
  282 -428 86 -170 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexus4
@@ -1323,6 +1379,7 @@ SplineSet
  670 -579.229 669.666 -578.888 667.76 -578.591 c 4
  305 -522 98 -214 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexus5
@@ -1344,6 +1401,7 @@ SplineSet
  931 -777.229 930.646 -776.992 928.76 -776.591 c 4
  315 -646 70 -240 0 -16 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PesQuilismaOneNothing
@@ -1354,16 +1412,15 @@ HStem: -409 15 -94 15 221 15 536 15
 LayerCount: 2
 Fore
 SplineSet
-0 62.3301 m 1x80
- 0 62.3291 l 1x80
+0 62.3291 m 0x80
  -0 78.2891 2.42285 113.989 16.1025 113.989 c 0
  17.2422 113.989 18.3818 112.85 19.5215 111.71 c 2
  29.7812 101.45 l 1
  33.2012 127.67 38.9014 142.49 44.6016 142.49 c 0
- 45.7412 142.49 46.8809 141.351 48.0205 141.351 c 1
+ 45.7412 142.49 46.8809 141.351 48.0205 141.351 c 2
  79.9404 117.41 l 1
  82.2207 143.63 89.0605 158.45 94.7607 158.45 c 0
- 95.9004 158.45 97.04 157.311 98.1797 157.311 c 1
+ 95.9004 158.45 97.04 157.311 98.1797 157.311 c 2
  122.04 139.551 l 1
  135 139.98 136 154.98 138 164 c 1
  138 172 l 1x40
@@ -1379,13 +1436,14 @@ SplineSet
  142.499 -1.50977 141.359 -0.370117 141.359 -0.370117 c 1
  110.579 23.5703 l 1
  108.299 -2.64941 101.459 -17.4697 95.7588 -17.4697 c 0
- 94.6191 -17.4697 93.4795 -16.3301 92.3398 -16.3301 c 1
+ 94.6191 -17.4697 93.4795 -16.3301 92.3398 -16.3301 c 2
  57 11.0303 l 1
  54.7197 -17.4697 47.8799 -33.4297 42.1797 -33.4297 c 0
- 41.04 -33.4297 39.9004 -32.29 37.6201 -31.1504 c 1
+ 41.04 -33.4297 39.9004 -32.29 37.6201 -31.1504 c 2
  12.54 -6.07031 l 2
- 4.55957 3.0498 0 34.9697 0 62.3301 c 1x80
+ 4.55957 3.0498 0 34.9697 0 62.3291 c 0x80
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: StrophaAucta
@@ -1410,6 +1468,7 @@ SplineSet
  3.80957 -90.3076 -26.9697 -50.4072 -26.9697 -40.1475 c 0
  -26.9697 -32.168 -18.9902 -24.1875 -9.87012 -24.1875 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumInclinatumAuctus
@@ -1436,6 +1495,7 @@ SplineSet
  29.1455 -93.458 -7.60742 -65.7754 -8.99805 -49.876 c 0
  -9.69336 -41.9258 -2.43945 -33.2812 6.64551 -32.4863 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaLongqueue
@@ -1446,17 +1506,18 @@ HStem: -409 15 -94 15 221 15 536 15
 LayerCount: 2
 Fore
 SplineSet
-160.617 -355.627 m 5
- 161 130.938 l 6
- 161 157.157 91.4004 163.997 80 163.997 c 4
- 69.7402 163.997 0 157.191 0 130.972 c 5
- 0 -4.66504 l 5
- 0.384766 -13.7842 7.86523 -21.7686 17.0254 -21.7686 c 5
- 23.8652 -21.7686 44.3848 -5.80859 79.7246 -5.80859 c 4
- 118.485 -5.80859 126.333 -9.33301 139 -21.5 c 5
- 138.5 -352.5 l 5
- 142.125 -355 160.617 -355.627 160.617 -355.627 c 5
+160.617 -355.627 m 1
+ 160.617 -355.627 142.125 -355 138.5 -352.5 c 1
+ 139 -21.5 l 1
+ 126.333 -9.33301 118.485 -5.80859 79.7246 -5.80859 c 0
+ 44.3848 -5.80859 23.8652 -21.7686 17.0254 -21.7686 c 1
+ 7.86523 -21.7686 0.384766 -13.7842 0 -4.66504 c 1
+ 0 130.972 l 1
+ 0 157.191 69.7402 163.997 80 163.997 c 0
+ 91.4004 163.997 161 157.157 161 130.938 c 2
+ 160.617 -355.627 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: AuctumMora
@@ -1474,6 +1535,7 @@ SplineSet
  53.5186 119.25 71.25 104.121 71.25 83.5 c 4
  71.25 62.8447 53.5273 47.75 35.5 47.75 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VEpisemus
@@ -1493,6 +1555,7 @@ SplineSet
  5.2002 -23.5996 -6 -15.2002 -6 -5.40039 c 6
  -6 81.4004 l 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumDeminutus
@@ -1514,6 +1577,7 @@ SplineSet
  68.4502 -3.12012 66.1699 6 47.9297 6 c 4
  29.6904 6 27.4102 -3.12012 17.1504 -3.12012 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: hepisemus_base
@@ -1531,6 +1595,7 @@ SplineSet
  1 64 l 25
  0 64 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: PesOneNothing
@@ -1558,6 +1623,7 @@ SplineSet
  161 -14.9297 91.4004 -21.7695 80 -21.7695 c 0
  69.7402 -21.7695 0 -14.96 0 11.2598 c 2x80
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosUpMedium
@@ -1580,6 +1646,7 @@ SplineSet
  53.8896 -52.9297 l 6
  32.2305 -52.9297 18.5498 -31.2695 0.30957 -21.0098 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CustosDownMedium
@@ -1602,6 +1669,7 @@ SplineSet
  76.6904 189.93 l 5
  76.6904 -255.81 l 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Accentus
@@ -1623,6 +1691,7 @@ SplineSet
  43.1035 -57.1094 l 5
  39.9111 -65.0898 31.9316 -69.8779 22.3555 -69.8779 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: AccentusReversus
@@ -1644,6 +1713,7 @@ SplineSet
  3.25195 35.0527 l 5
  0.0595703 38.2451 0.0595703 43.0332 0.0595703 46.2236 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: SemicirculusReversus
@@ -1663,6 +1733,7 @@ SplineSet
  97.3564 50.6104 124.488 23.4766 124.488 -11.6357 c 1
  95.7607 -11.6357 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Semicirculus
@@ -1682,6 +1753,7 @@ SplineSet
  28.4834 -7.53027 42.8486 -21.8936 62 -21.8936 c 0
  81.1514 -21.8936 95.5166 -7.53027 95.5166 11.623 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Circulus
@@ -1704,6 +1776,7 @@ SplineSet
  28.4834 -62.2441 -0.244141 -36.708 -0.244141 0 c 0
  -0.244141 33.5166 25.292 62.2441 62 62.2441 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CClefChange
@@ -1732,6 +1805,7 @@ SplineSet
  143 342.26 140.221 275.046 132.241 275.046 c 0
  127.681 275.046 114.001 291.006 86.6406 291.006 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: FClefChange
@@ -1772,6 +1846,7 @@ SplineSet
  99.1797 186.72 74.0996 189 62.7002 189 c 0
  33.0596 189 10.2598 175.32 10.2598 175.32 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VEpisemus.circumflexus
@@ -1795,6 +1870,7 @@ SplineSet
  23.166 -24.5 16.5 -25.5 9 -23.5 c 0
  4.59668 -22.3252 0 -18.6667 0 -14 c 9
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavum
@@ -1824,6 +1900,7 @@ SplineSet
  134.65 -36.25 118.69 -20.29 79.9297 -20.29 c 4
  44.5898 -20.29 24.0703 -36.25 17.2305 -36.25 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: LineaPunctum
@@ -1859,6 +1936,7 @@ SplineSet
  182.58 -35.7598 166.62 -19.7998 129 -19.7998 c 4
  90.2402 -19.7998 74.2803 -35.7598 65.1602 -35.7598 c 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: LineaPunctumCavum
@@ -1902,6 +1980,7 @@ SplineSet
  182.58 -35.7598 166.62 -19.7998 129 -19.7998 c 0
  90.2402 -19.7998 74.2803 -35.7598 65.1602 -35.7598 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumSmall
@@ -1922,6 +2001,7 @@ SplineSet
  86 164 151 157 151 131 c 6
  151 -22 l 5
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: hepisemusright
@@ -1939,6 +2019,7 @@ SplineSet
  2 96 l 29
  0 64 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: mpdeminutus
@@ -1959,6 +2040,7 @@ SplineSet
  118.485 141.306 130.5 155.997 139 156.997 c 4
  140.905 157.221 161 156.997 161 156.997 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumDescendens
@@ -1981,6 +2063,7 @@ SplineSet
  127.676 -31.9609 111.716 4.51953 79.7959 4.51953 c 0
  42.1758 4.51953 22.7959 -4.60059 17.0967 -4.60059 c 0x40
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumAscendens
@@ -1992,17 +2075,18 @@ LayerCount: 2
 Fore
 SplineSet
 0 150.708 m 1x80
- 0 -23.75 l 2
- 0 -27.1699 2.28027 -31.7305 4.56055 -35.1504 c 0
- 13.6797 -44.2705 59.2803 -49.9707 79.7998 -49.9707 c 0
- 129.96 -49.9707 161 2.41992 161 56 c 2
- 161 206.479 l 2x40
- 161 214.46 152.76 222.49 143.64 222.49 c 0x40
- 134.521 222.49 127.68 214.51 127.68 206.529 c 0
- 127.68 170.05 111.72 133.569 79.7998 133.569 c 0
- 49.4831 133.569 32.75 133.75 21.5 138.25 c 5
- 17.5 139.25 6.5 145.208 0 150.708 c 1x80
+ 6.5 145.208 17.5 139.25 21.5 138.25 c 1
+ 32.75 133.75 49.4831 133.569 79.7998 133.569 c 0
+ 111.72 133.569 127.68 170.05 127.68 206.529 c 0
+ 127.68 214.51 134.521 222.49 143.64 222.49 c 0x40
+ 152.76 222.49 161 214.46 161 206.479 c 2x40
+ 161 56 l 2
+ 161 2.41992 129.96 -49.9707 79.7998 -49.9707 c 0
+ 59.2803 -49.9707 13.6797 -44.2705 4.56055 -35.1504 c 0
+ 2.28027 -31.7305 0 -27.1699 0 -23.75 c 2
+ 0 150.708 l 1x80
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: mnbdeminutus
@@ -2023,6 +2107,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 6
  161 -21.5 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: mnbpdeminutus
@@ -2043,6 +2128,7 @@ SplineSet
  118.485 147.867 129 157.559 139 163.559 c 4
  140.645 164.545 161 163.559 161 163.559 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb1
@@ -2063,6 +2149,7 @@ SplineSet
  143.49 48.2977 204 -2.125 318 -6 c 5
  334.25 -3.75 336.5 -0.5 340 3.25 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb2
@@ -2083,6 +2170,7 @@ SplineSet
  98 9 278 -148.625 406 -154 c 5
  422.75 -154.25 424.75 -152.5 428 -149 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb3
@@ -2103,6 +2191,7 @@ SplineSet
  96 -16 328 -271 564 -315.5 c 5
  582 -317.75 584.25 -310.25 586 -306.5 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb4
@@ -2123,6 +2212,7 @@ SplineSet
  109 -52 374 -395 648 -440.5 c 5
  661.75 -442.75 668 -437.75 670 -434 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: porrectusflexusnb5
@@ -2143,6 +2233,7 @@ SplineSet
  122.5 -117.5 382.5 -511 909 -631 c 5
  919 -633.333 929 -626.667 931 -620.326 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: p2base
@@ -2163,6 +2254,7 @@ SplineSet
  118.485 148.037 130.5 162.729 139 163.729 c 4
  140.905 163.952 161 163.729 161 163.729 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: rvlbase
@@ -2185,6 +2277,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 2
  160.992 -363.002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: msdeminutus
@@ -2207,6 +2300,7 @@ SplineSet
  118.485 147.867 129 157.559 139 163.559 c 0
  140.645 164.545 161 163.559 161 163.559 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: mademinutus
@@ -2229,6 +2323,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 2
  161 -21.5 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumHole
@@ -2248,6 +2343,7 @@ SplineSet
  114.985 -55.21 97.4287 -52.7021 79.873 -52.7021 c 4
  62.3164 -52.7021 46.0156 -55.21 28.459 -60.2266 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: LineaPunctumCavumHole
@@ -2267,6 +2363,7 @@ SplineSet
  164.112 -54.7197 146.556 -52.2119 129 -52.2119 c 4
  111.444 -52.2119 93.8877 -54.7197 77.5859 -59.7363 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: NaturalHole
@@ -2284,6 +2381,7 @@ SplineSet
  23.0459 71.0635 l 5
  117.951 123.795 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: FlatHole
@@ -2303,6 +2401,7 @@ SplineSet
  148.827 1.52539 141.303 -3.49023 131.271 -3.49023 c 4
  98.667 -3.49023 9.63379 61.7178 9.63379 61.7178 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: odbase
@@ -2327,6 +2426,7 @@ SplineSet
  192 24.5596 192 -21.5 192 -42 c 5
  182.5 -42 179 -42 170 -42 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: DivisioDominican
@@ -2344,6 +2444,7 @@ SplineSet
  22 -94 l 29
  0 -94 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: DivisioDominicanAlt
@@ -2361,6 +2462,7 @@ SplineSet
  22 -246 l 29
  0 -246 l 29
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: Sharp
@@ -2423,6 +2525,7 @@ SplineSet
  118 73 l 5
  129 58.7002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: SharpHole
@@ -2440,6 +2543,7 @@ SplineSet
  141.1 73 l 5
  129 57.2705 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: Linea
@@ -2467,6 +2571,7 @@ SplineSet
  176.867 -6.09961 48.5 -6.09961 19 -7.7998 c 1
  19 -54.8037 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: RoundBrace
@@ -2492,6 +2597,7 @@ SplineSet
  18.5613 695 l 2
  11.032 695 -1.91563 695.081 -1.91563 703.473 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: CurlyBrace
@@ -2519,6 +2625,7 @@ SplineSet
  610.8 698 550.6 710.6 503 748.4 c 1
  455.4 710.6 395.2 698 333.6 698 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: BarBrace
@@ -2544,6 +2651,7 @@ SplineSet
  12.9932 682 l 2
  8.25 682 0.0927734 682.081 0.0927734 690.474 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusDeminutus
@@ -2568,6 +2676,7 @@ SplineSet
  190.86 96.3135 192 68.9541 192 50.7139 c 1
  191.193 -22.9396 136.5 -67 118 -65 c 1
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: obase4
@@ -2591,6 +2700,7 @@ SplineSet
  91.6807 150.009 109.92 116.948 140.7 116.948 c 4
  174.9 116.948 168.061 151.148 177.181 151.148 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: SalicusOriscus
@@ -2619,6 +2729,7 @@ SplineSet
  0.0136719 55.9541 1.15332 83.3135 5.71387 100.414 c 4
  12.5537 127.774 33.0732 148.294 59.293 148.294 c 4
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: VirgaReversaDescendens
@@ -2643,6 +2754,7 @@ SplineSet
  22.125 -220.875 l 6
  22.125 -223.375 0 -224.002 0 -224.002 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens
@@ -2667,6 +2779,7 @@ SplineSet
  22.125 -351.875 l 2
  22.125 -354.375 0 -355.002 0 -355.002 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: vbase2
@@ -2689,6 +2802,7 @@ SplineSet
  22.125 -333.875 l 5
  18.5 -336.375 0 -337.002 0 -337.002 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: vbase3
@@ -2711,6 +2825,7 @@ SplineSet
  22.125 -490.875 l 5
  18.5 -493.375 0 -494.002 0 -494.002 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: vbase4
@@ -2733,6 +2848,7 @@ SplineSet
  22.125 -648.875 l 5
  18.5 -651.375 0 -652.002 0 -652.002 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: vbase5
@@ -2755,6 +2871,7 @@ SplineSet
  22.125 -805.875 l 5
  18.5 -808.375 0 -809.002 0 -809.002 c 5
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: vbase1
@@ -2776,6 +2893,7 @@ SplineSet
  22.125 -175.875 l 5
  18.5 -178.375 0 -179.002 0 -179.002 c 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: OriscusScapusLongqueue
@@ -2800,6 +2918,7 @@ SplineSet
  18.875 -362.845 0.382812 -355.627 0.382812 -355.627 c 1
  0 37.3613 l 2
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: OriscusScapus
@@ -2824,6 +2943,7 @@ SplineSet
  18.5 -223.375 0.0078125 -224.002 0.0078125 -224.002 c 1
  0.0136719 37.7139 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase1
@@ -2834,20 +2954,21 @@ HStem: -473.822 17.1 -114.722 17.1 244.378 17.1 603.478 17.1
 LayerCount: 2
 Fore
 SplineSet
-22 -29 m 5
- 25 -19 31.2755 -7.88574 51.3135 -7.88574 c 0
- 82.0938 -7.88574 100.333 -40.9463 132.254 -40.9463 c 0
- 157.333 -40.9463 178.993 -20.4258 185.833 6.93359 c 0
- 189.254 24.0342 192 51.3848 192 69.625 c 0
- 192 87.8652 188.113 149.435 176.714 149.435 c 0
- 166.453 149.435 174.434 115.234 140.233 115.234 c 0
- 109.453 115.234 90.0732 148.294 59.293 148.294 c 0
- 33.0732 148.294 12.5537 127.774 5.71387 100.414 c 0
- 1.15332 83.3135 0.0146484 55.9541 0.0136719 37.7139 c 2
- 0 -179.002 l 1
- 0 -179.002 18.5 -178.375 22.125 -175.875 c 1
- 22 -29 l 5
+22 -29 m 1
+ 22.125 -175.875 l 1
+ 18.5 -178.375 0 -179.002 0 -179.002 c 1
+ 0.0136719 37.7139 l 2
+ 0.0146484 55.9541 1.15332 83.3135 5.71387 100.414 c 0
+ 12.5537 127.774 33.0732 148.294 59.293 148.294 c 0
+ 90.0732 148.294 109.453 115.234 140.233 115.234 c 0
+ 174.434 115.234 166.453 149.435 176.714 149.435 c 0
+ 188.113 149.435 192 87.8652 192 69.625 c 0
+ 192 51.3848 189.254 24.0342 185.833 6.93359 c 0
+ 178.993 -20.4258 157.333 -40.9463 132.254 -40.9463 c 0
+ 100.333 -40.9463 82.0938 -7.88574 51.3135 -7.88574 c 0
+ 31.2755 -7.88574 25 -19 22 -29 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase2
@@ -2874,6 +2995,7 @@ SplineSet
  31.2755 -7.88574 25 -19 22 -29 c 5
  22.125 -333.875 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase3
@@ -2900,6 +3022,7 @@ SplineSet
  31.2755 -7.88574 25 -19 22 -29 c 5
  22.125 -490.875 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase4
@@ -2926,6 +3049,7 @@ SplineSet
  18.5 -651.375 0 -652.002 0 -652.002 c 5
  0.0136719 37.7139 l 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: osbase5
@@ -2952,6 +3076,7 @@ SplineSet
  18.5 -808.375 0 -809.002 0 -809.002 c 1
  0.0136719 37.7139 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: oslbase
@@ -2978,6 +3103,7 @@ SplineSet
  31.2755 -7.88574 25 -19 22 -29 c 5
  22.1172 -359.873 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: hepisemusleft
@@ -2995,6 +3121,7 @@ SplineSet
  1 64 l 25
  -2 64 l 25
 EndSplineSet
+Validated: 1
 EndChar
 
 StartChar: RoundBraceDown
@@ -3005,19 +3132,20 @@ LayerCount: 2
 Fore
 SplineSet
 -1.91602 246.527 m 0
- -1.91602 244.75 -1.33496 242.6 -3.57437e-08 240 c 0
- 19 203 177.993 55 471 55 c 0
- 759.007 55 918 203 937 240 c 0
- 938.335 242.6 938.916 244.75 938.916 246.527 c 0
- 938.916 254.919 925.968 255 918.439 255 c 2
- 918 255 l 2
- 909 255 907.881 246.701 899 237 c 0
- 780 107 552 86 471 86 c 0
- 385 86 157 107 38 237 c 0
- 29.1191 246.701 28 255 19 255 c 2
- 18.5615 255 l 2
- 11.0322 255 -1.916 254.919 -1.91602 246.527 c 0
+ -1.916 254.919 11.0322 255 18.5615 255 c 2
+ 19 255 l 2
+ 28 255 29.1191 246.701 38 237 c 0
+ 157 107 385 86 471 86 c 0
+ 552 86 780 107 899 237 c 0
+ 907.881 246.701 909 255 918 255 c 2
+ 918.439 255 l 2
+ 925.968 255 938.916 254.919 938.916 246.527 c 0
+ 938.916 244.75 938.335 242.6 937 240 c 0
+ 918 203 759.007 55 471 55 c 0
+ 177.993 55 19 203 -3.57437e-08 240 c 0
+ -1.33496 242.6 -1.91602 244.75 -1.91602 246.527 c 0
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaDescendens_op
@@ -3040,6 +3168,7 @@ SplineSet
  91.4004 163.997 161 157.157 161 130.938 c 2
  160.992 -224.002 l 5
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueueDescendens_op
@@ -3062,6 +3191,7 @@ SplineSet
  160.992 -224.002 142.5 -223.375 138.875 -220.875 c 5
  139 -21.5 l 4
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaAscendens_op
@@ -3084,6 +3214,7 @@ SplineSet
  138.875 356.372 l 1
  142.5 358.872 160.992 359.499 160.992 359.499 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueueAscendens_op
@@ -3106,6 +3237,7 @@ SplineSet
  161 -21.6602 91.4004 -28.5 80 -28.5 c 0
  69.7402 -28.5 0 -21.6943 0 4.52539 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaAscendens
@@ -3128,6 +3260,7 @@ SplineSet
  22.125 -220.875 l 2
  22.127 -223.375 0 -224.002 0 -224.002 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: VirgaReversaLongqueueAscendens
@@ -3150,6 +3283,7 @@ SplineSet
  141 -9.31934 114 -55.3193 70 -55.3193 c 0
  50 -55.3193 29.4775 -52.1631 22.001 -49.3252 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumDescendens_op
@@ -3173,6 +3307,7 @@ SplineSet
  161 -67.8799 l 2
  160.992 -224.002 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumAscendens_op
@@ -3195,6 +3330,7 @@ SplineSet
  138.875 356.372 l 1
  142.5 358.872 160.992 359.499 160.992 359.499 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusd1_op
@@ -3218,6 +3354,7 @@ SplineSet
  42.1758 4.51953 22.7959 -4.60059 17.0967 -4.60059 c 0x40
  7.97656 -4.60059 -0.00390625 2.23926 -0.00390625 11.3594 c 6
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusa1_op
@@ -3241,6 +3378,7 @@ SplineSet
  59.2803 -49.9707 13.6797 -44.2705 4.56055 -35.1504 c 0
  2.28027 -31.7305 0 -27.1699 0 -23.75 c 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: auctusa2_op
@@ -3264,6 +3402,7 @@ SplineSet
  0 122.251 l 1x80
  0 131.371 7.98047 138.21 17.1006 138.21 c 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumAuctusLineBL_op
@@ -3287,6 +3426,7 @@ SplineSet
  30 180.681 50 183.681 70 183.681 c 0
  114 183.681 141 137.681 141 90.6807 c 2x80
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: pesdeminutus_op
@@ -3309,6 +3449,7 @@ SplineSet
  69.7402 -21.7686 0 -14.9629 0 11.2568 c 1
  0 146.894 l 1
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatum
@@ -3346,6 +3487,7 @@ SplineSet
  93.666 -54.9922 88.958 -53.0371 86.3652 -48.6465 c 2
  3.43652 58.6895 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatumHole
@@ -3370,6 +3512,7 @@ SplineSet
  92.3262 -16.6865 89.0303 -15.3174 87.2148 -12.2441 c 2
  29.165 62.8906 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 
 StartChar: PunctumCavumInclinatumAuctus
@@ -3409,6 +3552,7 @@ SplineSet
  29.1455 -93.458 -7.60742 -65.7754 -8.99805 -49.876 c 0
  -9.69336 -41.9258 -2.43945 -33.2812 6.64551 -32.4863 c 0
 EndSplineSet
+Validated: 524321
 EndChar
 
 StartChar: PunctumCavumInclinatumAuctusHole
@@ -3433,6 +3577,7 @@ SplineSet
  89.8594 -37.0947 86.5635 -35.7256 84.748 -32.6523 c 2
  26.6982 42.4824 l 2
 EndSplineSet
+Validated: 524289
 EndChar
 EndChars
 EndSplineFont


### PR DESCRIPTION
I upgraded fontforge to version 20150612 and got the `Internal Error (overlap) in {some character}: The end of the monotonic does not match that of the containing spline.` error when running `squarize.py` that has been mentioned by @eschwab and @jakubjelinek on the mailing list.

In trying to find a fix, I discovered the fontforge validation feature, which flagged multiple self-intersecting and wrong-direction glyphs.  This pull request fixes those errors.

The validator also flagged missing points at extrema, but I don't want to "fix" that until I understand the impact of the fix.

Unfortunately, these things don't seem to make any appreciable dent into the "monotonic...containing spline" errors.

That said, I do think this somewhat improves the quality of the fonts.  The generated fonts still have some remaining self-intersection and wrong-direction problems, so something else is additionally at play here.

Using the older version of fontforge, this change causes minor test failures, which I expected given earlier experience.  However the results are visually fine.

It's also interesting to note that, using the newer version of fontforge, there are many more test failures.  While still visually fine, the detected differences are at the join points of the glyphs combined by `squarize.py` (which may or may not be a coincidental thing).

I think this change is ready for review/merge.  I probably won't have much time to do more investigation into the other font issues until at least this weekend.