### PR TITLE
Fixed spaces after abbreviations.

### DIFF
--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -338,7 +338,7 @@ Macro for setting whether the staff lines behind an alternation (\ie, an acciden
 
 
 \subsubsection{Score Font}
-Gregorio\TeX\ currently supports 3 different fonts for the glyphs in a score (neumes, clefs, alterations, \etc): Greciliae (a customized version of Caeciliae by Fr. Matthew Spencer, OSJ), Gregorio, and Parmesan (developed for Lilypond by Juergen Reuter).
+Gregorio\TeX\ currently supports 3 different fonts for the glyphs in a score (neumes, clefs, alterations, \etc): Greciliae (a customized version of Caeciliae by Fr.\ Matthew Spencer, OSJ), Gregorio, and Parmesan (developed for Lilypond by Juergen Reuter).
 
 \macroname{\textbackslash gresetgregoriofont}{[\optional{\#1}]\{\#2\}}{gregoriotex-main.tex}
 Set the font used for the neumes.  The optional argument \texttt{[\#1]}
@@ -594,7 +594,7 @@ Command to change styling of a score element.
 \begin{argtable}
   \#1 & string & element whose styling is to be changed (see list above for options)\\
   \#2 & \TeX\ code & the code necessary to turn on the styling\\
-  \#3 & \TeX\ code & Optional.  The code necessary to turn off the styling (e.g. if the code to turn on the styling contains a \verb=\begin{environment}= then the code to turn it off must have the matching \verb=\end{environment}=.
+  \#3 & \TeX\ code & Optional.  The code necessary to turn off the styling (\eg, if the code to turn on the styling contains a \verb=\begin{environment}= then the code to turn it off must have the matching \verb=\end{environment}=.
 \end{argtable}
 
 Examples:\par\medskip
@@ -859,7 +859,7 @@ Minimum space between two notes of different syllables.
 Default: \unit[0.25523]{cm} plus \unit[0.31903]{cm} minus \unit[0]{cm}
 
 \macroname{spacebeforecusto}{}{gsp-default.tex}
-Space before custo.  
+Space before custos.  
 
 Default: \unit[0.1823]{cm} plus \unit[0.31903]{cm} minus \unit[0.0638]{cm}
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -156,7 +156,7 @@ defined and re-defined by the \verb=\gresetgregoriofont= macro.
 \end{argtable}
 
 \macroname{\textbackslash GreCusto}{\#1}{gregoriotex-signs.tex}
-Typesets a custo.
+Typesets a custos.
 
 \begin{argtable}
   \#1 & integer & Height number of custos.\\
@@ -421,7 +421,7 @@ in gabc.
 \end{argtable}
 
 \macroname{\textbackslash GreLastOfLine}{}{gregoriotex-main.tex}
-Macro to set \verb=\gre@lastoflinecount= to 1 (i.e. mark that this syllable is the last of the line).
+Macro to set \verb=\gre@lastoflinecount= to 1 (\ie, mark that this syllable is the last of the line).
 
 \macroname{\textbackslash GreLastOfScore}{}{gregoriotex-main.tex}
 Macro to mark the syllable as the last of the score.

--- a/doc/GregorioNabcRef.tex
+++ b/doc/GregorioNabcRef.tex
@@ -90,7 +90,7 @@
 \setlength\parindent{0cm}
 
 The \texttt{nabc} language provides the ability to describe some adiastematic neumes, for
-now just the St. Gallen style.  The language is partially based on Dom
+now just the St.\ Gallen style.  The language is partially based on Dom
 Eugène Cardine's Table of neumatic signs, but for more complex neumes
 doesn't always match how the neumes are called; instead attempts to make it
 easier to compose complex neumes from basic glyphs.  To describe
@@ -116,8 +116,8 @@ snippets.  With \texttt{nabc-lines: 1;} the
 \texttt{gabc} and \texttt{nabc} snippets form an alternating pattern, like
 \texttt{(gabc|nabc|gabc|nabc|gabc)}, in this case the last \texttt{gabc}
 snippet does not have any corresponding \texttt{nabc} neumes.  With
-\texttt{nabc-lines: 2;} the snippets ordering could be e.g.
-\texttt{(gabc|nabc1|nabc2|gabc|nabc1)}.
+\texttt{nabc-lines: 2;} the snippets ordering could be
+e.g.\ \texttt{(gabc|nabc1|nabc2|gabc|nabc1)}.
 
 Each \texttt{nabc} snippet consists of a sequence of \textit{complex neume
 descriptors}.  Each \textit{complex neume descriptor} consists of
@@ -189,7 +189,7 @@ characters optionally followed by a number:
   \item ~~\texttt{\~} diminutive liquescence
 \end{itemize}
 If Dom Cardine's table contains multiple glyphs with the same modifiers,
-a positive number is added afterwards.  E.g. for augmentive liquescent
+a positive number is added afterwards.  E.g.\ for augmentive liquescent
 clivis the table shows two different glyphs, the ancus \texttt{cl>} \sneume{cl>}
 and then another neume - \texttt{cl>1} \sneume{cl>1}, the first neume does
 not contain any number after it, while the \texttt{1} indicates first
@@ -221,11 +221,11 @@ punctum.
   \item \texttt{y} \sneume{gr-} gravis with episema
 \end{itemize}
 Only subpunctis are normally used in neume classification, the prepunctis is
-a \texttt{nabc} concept to describe the rising sequence of punctis, tractulis etc.
-in the left low corner of some neume.  While e.g. \texttt{vipp2}
+a \texttt{nabc} concept to describe the rising sequence of punctis, tractulis
+etc.\ in the left low corner of some neume.  While e.g.\ \texttt{vipp2}
 \sneume{sc} describes the same neume as \texttt{sc} \sneume{sc}, the
 former form allows better control on how many punctis or tractulis or
-tractulis with episema etc. there are.  Some examples:
+tractulis with episema etc.\ there are.  Some examples:
 \texttt{ppt3} \sneume{ppt3} stands for 3 raising tractulis with episema,
 while \texttt{su1sut1sux1} \sneume{su1sut1sux1} stands for a punctum,
 followed by tractulus, followed by liquescens stropha.
@@ -342,8 +342,8 @@ Names of & Simple & \multicolumn{4}{c|}{Symbols differentiated by} & \multicolum
 Symbols & Symbols & \multicolumn{4}{c|}{} & \multicolumn{3}{c|}{a special meaning} \\ \hline
 & & \multicolumn{2}{c|}{the addition} & \multicolumn{2}{c|}{the modification} & melodic & \multicolumn{2}{c|}{phonetic} \\ \cline{3-9}
 & & of letters & of episemas & of the mark & of the grouping & & \multicolumn{2}{c|}{liquescence} \\ \cline{8-9}
-& & & & & (neumatic break) & & augment. & dimi \\
-& & & & & & & & nut. \\ \cline{3-6}\cline{8-9}
+& & & & & (neumatic break) & & augment.\ & dimi \\
+& & & & & & & & nut.\ \\ \cline{3-6}\cline{8-9}
 virga & \neume{vi} & \neume{vilsc3}\neume{vilst1}\neume{vippt1lsc2} & \neume{vi-} & & & & \neume{vi>} & \\
 tractulus & \neume{ta} & \neume{talsc3}\neume{talst2} & & & & & \neume{ta>} & \\
 punctum & \neume{pu} & & & & & & \neume{st}\neume{visu1sux1} & \\
@@ -377,7 +377,7 @@ quilisma & \neume{ql}\neume{qi} & & \neume{ql-}\neume{qi-} & & & & \neume{ql>}\n
 }
 
 \begin{center}
-Table from Cardine's Gregorian Semiology, pp. 12-13 with nabc strings and gregall glyphs.
+Table from Cardine's Gregorian Semiology, pp.\ 12-13 with nabc strings and gregall glyphs.
 \end{center}
 
 \vfill
@@ -443,7 +443,7 @@ propers, antiphons or responsories.}
 
 \textit{Most of the glyphs taken from the e-codices Virtual Manuscript Library
 of Switzerland, \url{http://www.e-codices.unifr.ch/en}, with permission
-from Stiftsbibliothek, St. Gallen \url{http://www.stibi.ch/} and
+from Stiftsbibliothek, St.\ Gallen \url{http://www.stibi.ch/} and
 Stiftsbibliothek, Einsiedeln\\
 \url{http://kloster-einsiedeln.ch/}, the picture fragments from there are
 only present in the font source file to help drawing the glyphs.}
@@ -637,7 +637,7 @@ only present in the font source file to help drawing the glyphs.}
 \texttt{H424M} Magnificat\\
 \texttt{H428A} Ascendens Iesus \texttt{AM593}
 
-\noindent\textbf{St. Gall codex 339}
+\noindent\textbf{St.\ Gall codex 339}
 
 \noindent
 \texttt{G1} = \url{http://www.e-codices.unifr.ch/en/download/csg-0339_033/max}\\
@@ -671,7 +671,7 @@ only present in the font source file to help drawing the glyphs.}
 \texttt{G140O} Oremus dilectissimi nobis\\
 \texttt{G141O} Omnipotens Deus
 
-\noindent\textbf{St. Gall codex 376}
+\noindent\textbf{St.\ Gall codex 376}
 
 \noindent
 \texttt{N1} = \url{http://www.e-codices.unifr.ch/en/download/csg-0376_001/max}\\
@@ -694,7 +694,7 @@ only present in the font source file to help drawing the glyphs.}
 \texttt{N368L} Letamente canamus Domino nostro\\
 \texttt{N372O} O quam mira sunt Deus
 
-\noindent\textbf{St. Gall codex 374}
+\noindent\textbf{St.\ Gall codex 374}
 
 \noindent
 \texttt{A1} = \url{http://www.e-codices.unifr.ch/en/download/csg-0374_001/max}\\
@@ -707,7 +707,7 @@ only present in the font source file to help drawing the glyphs.}
 \texttt{A174A} Alleluia. Eripe me \texttt{GT308}
 
 \noindent
-\textbf{Bamberg, lit. 6, Gradual of St. Emmeram}
+\textbf{Bamberg, lit.\ 6, Gradual of St.\ Emmeram}
 
 \noindent
 \texttt{B9v} = \url{http://bsbsbb.bsb.lrz-muenchen.de/~db/0000/sbb00000128/images/index.html?id=00000128no=19&seite=22&signatur=Msc.Lit.6}\\

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -30,7 +30,7 @@ GregorioRef-@FILENAME_VERSION@.pdf: $(SRCFILES)
 	$(MAKE) $(AM_MAKEFLAGS) -C ../src gregorio
 	../src/gregorio -o factus.gtex $(<D)/factus.gabc
 	TEXINPUTS=$(<D):$(<D)/../tex: LUAINPUTS=$(<D):$(<D)/../tex: \
-		 TEXFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -recorder -pdf \
+		 TTFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -recorder -pdf \
 		 -pdflatex='lualatex --shell-escape %O %S' \
 		 -jobname=GregorioRef-@FILENAME_VERSION@ $<
 
@@ -38,7 +38,7 @@ GregorioNabcRef-@FILENAME_VERSION@.pdf: $(NABCSRCFILES)
 	$(MAKE) $(AM_MAKEFLAGS) -C ../src gregorio
 	../src/gregorio -o veni.gtex $(<D)/veni.gabc
 	TEXINPUTS=$(<D):$(<D)/../tex: LUAINPUTS=$(<D):$(<D)/../tex: \
-		 TEXFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -recorder -pdf \
+		 TTFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -recorder -pdf \
 		 -pdflatex='lualatex --shell-escape %O %S' \
 		 -jobname=GregorioNabcRef-@FILENAME_VERSION@ $<
 


### PR DESCRIPTION
An additional fix for #551.

I also found a bug in the `Makefile.am` which was not finding not-installed fonts for building the PDFs.  This is also fixed.

This is ready for review/merge.