### PR TITLE
More TeXLive-related fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ Makefile
 config.status
 lib/gregorio.pc
 src/gregorio
+src/utf8strings.h
+src/encode_utf8strings
 
 #emacs auto gen files
 auto/

--- a/configure.ac
+++ b/configure.ac
@@ -28,16 +28,17 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AM_INIT_AUTOMAKE([-Wall -Wno-portability subdir-objects foreign dist-bzip2 no-dist-gzip])
 
-AC_PROG_CC
+AC_PROG_CC_C89
 dnl AM_PROG_CC_C_O is deprecated since Automake 1.14, to be removed in the future
 AM_PROG_CC_C_O
-AC_PROG_CC_STDC
 AC_PROG_CPP
 AM_PROG_LEX
 AC_PROG_YACC
 AC_CHECK_TOOL([RC], [windres], [no])
 AM_CONDITIONAL([HAVE_RC], [test x$RC != xno])
 
+AX_CHECK_COMPILE_FLAG([-std=gnu89], [CFLAGS+=" -std=gnu89"])
+AX_CHECK_COMPILE_FLAG([-pedantic-errors], [CFLAGS+=" -pedantic-errors"])
 AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [CFLAGS+=" -fstack-protector-strong"])
 AX_CHECK_COMPILE_FLAG([-fPIE], [CFLAGS+=" -fPIE"])
 AX_CHECK_COMPILE_FLAG([-Wformat], [CFLAGS+=" -Wformat"])

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,8 @@ AX_CHECK_LINK_FLAG([-pie], [LDFLAGS+=" -pie"])
 
 AC_HEADER_STDC
 
+AC_CHECK_HEADER_STDBOOL
+
 # linux has integer types in stdint.h, solaris, vms in inttypes.h
 AC_CHECK_HEADERS([stdint.h])
 AC_CHECK_HEADERS([stdalign.h])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,12 +22,13 @@ gregorio_CFLAGS = $(KPSE_CFLAGS)
 gregorio_LDADD = $(KPSE_LIBS)
 
 bin_PROGRAMS = gregorio
-gregorio_SOURCES = characters.c gregorio-utils.c messages.c struct.c \
-					unicode.c struct.h messages.h unicode.h characters.h \
-					sha1.c sha1.h plugins.h config.h bool.h dump/dump.c \
-					gregoriotex/gregoriotex-write.c \
-					gregoriotex/gregoriotex-position.c \
-					gregoriotex/gregoriotex.h
+gregorio_SOURCES = gregorio-utils.c characters.c characters.h \
+				   messages.c messages.h struct.c struct.h \
+				   unicode.c unicode.h sha1.c sha1.h support.c support.h \
+				   config.h bool.h plugins.h dump/dump.c \
+				   gregoriotex/gregoriotex-write.c \
+				   gregoriotex/gregoriotex-position.c \
+				   gregoriotex/gregoriotex.h
 
 @MK@ifneq ($(wildcard ../.git),)
 @MK@  _tag_ = $(shell git describe --exact-match HEAD 2>/dev/null)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,12 +23,12 @@ gregorio_LDADD = $(KPSE_LIBS)
 
 bin_PROGRAMS = gregorio
 gregorio_SOURCES = gregorio-utils.c characters.c characters.h \
-				   messages.c messages.h struct.c struct.h \
-				   unicode.c unicode.h sha1.c sha1.h support.c support.h \
-				   config.h bool.h plugins.h dump/dump.c \
-				   gregoriotex/gregoriotex-write.c \
-				   gregoriotex/gregoriotex-position.c \
-				   gregoriotex/gregoriotex.h
+					messages.c messages.h struct.c struct.h \
+					unicode.c unicode.h sha1.c sha1.h support.c support.h \
+					config.h bool.h plugins.h utf8strings.h dump/dump.c \
+					gregoriotex/gregoriotex-write.c \
+					gregoriotex/gregoriotex-position.c \
+					gregoriotex/gregoriotex.h
 
 @MK@ifneq ($(wildcard ../.git),)
 @MK@  _tag_ = $(shell git describe --exact-match HEAD 2>/dev/null)
@@ -66,16 +66,19 @@ gregorio_SOURCES += gabc/gabc-elements-determination.c gabc/gabc-write.c \
 					vowel/vowel-rules-l.h vowel/vowel-rules-l.c \
 					vowel/vowel-rules-y.h vowel/vowel-rules-y.c
 
-EXTRA_DIST = gabc/gabc-score-determination.l gabc/gabc-score-determination.y \
+EXTRA_DIST = encode_utf8strings.c utf8strings.h.in utf8strings.h \
 					gabc/gabc-notes-determination.l \
+					gabc/gabc-notes-determination-l.c \
 					gabc/gabc-score-determination.h \
+					gabc/gabc-score-determination.y \
 					gabc/gabc-score-determination-y.h \
 					gabc/gabc-score-determination-y.c \
+					gabc/gabc-score-determination.l \
 					gabc/gabc-score-determination-l.h \
 					gabc/gabc-score-determination-l.c \
-					gabc/gabc-notes-determination-l.c \
-					vowel/vowel-rules.l vowel/vowel-rules.y \
+					vowel/vowel-rules.l \
 					vowel/vowel-rules-l.h vowel/vowel-rules-l.c \
+					vowel/vowel-rules.y \
 					vowel/vowel-rules-y.h vowel/vowel-rules-y.c
 
 gabc/gabc-score-determination-y.c: gabc/gabc-score-determination.y
@@ -121,8 +124,16 @@ vowel/vowel-rules-l.h: vowel/vowel-rules-l.c
 		$(MAKE) $(AM_MAKEFLAGS) vowel/vowel-rules-l.c; \
 	fi
 
-BUILT_SOURCES = gabc/gabc-score-determination-l.c \
+utf8strings.h: utf8strings.h.in
+	$(MAKE) $(AM_MAKEFLAGS) encode_utf8strings${EXEEXT}
+	encode_utf8strings${EXEEXT} $< $@
+
+encode_utf8strings${EXEEXT}: encode_utf8strings.c
+	$(CC) -o $@ $<
+
+BUILT_SOURCES = utf8strings.h \
 					gabc/gabc-notes-determination-l.c \
+					gabc/gabc-score-determination-l.c \
 					gabc/gabc-score-determination-l.h \
 					gabc/gabc-score-determination-y.c \
 					gabc/gabc-score-determination-y.h \
@@ -130,4 +141,6 @@ BUILT_SOURCES = gabc/gabc-score-determination-l.c \
 					vowel/vowel-rules-l.h \
 					vowel/vowel-rules-y.c \
 					vowel/vowel-rules-y.h
+
+CLEANFILES = encode_utf8strings${EXEEXT}
 MAINTAINERCLEANFILES = $(BUILT_SOURCES)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,7 @@ gregorio_LDADD = $(KPSE_LIBS)
 bin_PROGRAMS = gregorio
 gregorio_SOURCES = characters.c gregorio-utils.c messages.c struct.c \
 					unicode.c struct.h messages.h unicode.h characters.h \
-					sha1.c sha1.h plugins.h config.h dump/dump.c \
+					sha1.c sha1.h plugins.h config.h bool.h dump/dump.c \
 					gregoriotex/gregoriotex-write.c \
 					gregoriotex/gregoriotex-position.c \
 					gregoriotex/gregoriotex.h

--- a/src/bool.h
+++ b/src/bool.h
@@ -23,7 +23,7 @@
 #ifdef HAVE__BOOL
 #include <stdbool.h>
 #else
-typedef int bool;
+typedef unsigned int bool;
 #define true 1
 #define false 0
 #endif

--- a/src/bool.h
+++ b/src/bool.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
+ * 
+ * This file is part of Gregorio.
+ *
+ * Gregorio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gregorio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BOOL_H
+#define BOOL_H
+
+#ifdef HAVE__BOOL
+#include <stdbool.h>
+#else
+typedef int bool;
+#define true 1
+#define false 0
+#endif
+
+#endif

--- a/src/characters.c
+++ b/src/characters.c
@@ -28,7 +28,6 @@
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
@@ -37,6 +36,7 @@
 #ifdef USE_KPSE
     #include <kpathsea/kpathsea.h>
 #endif
+#include "bool.h"
 #include "struct.h"
 #include "unicode.h"
 #include "characters.h"

--- a/src/characters.c
+++ b/src/characters.c
@@ -43,7 +43,7 @@
 #include "messages.h"
 #include "vowel/vowel.h"
 
-#ifdef __MINGW32__
+#ifdef _WIN32
 #ifndef PATH_MAX
 #define PATH_MAX _MAX_PATH
 #endif

--- a/src/characters.c
+++ b/src/characters.c
@@ -41,6 +41,7 @@
 #include "unicode.h"
 #include "characters.h"
 #include "messages.h"
+#include "utf8strings.h"
 #include "vowel/vowel.h"
 
 #ifdef _WIN32
@@ -171,12 +172,7 @@ void gregorio_set_centering_language(char *const language)
         }
 
         gregorio_vowel_tables_init();
-        // This is a superset of Latin vowels which includes some French,
-        // Vietnamese, Slavic, Hungarian, and Norwegian vowels which don't
-        // interfere with Latin itself.  For something more accurate, the user
-        // should consider the use of custom centering rules.
-        gregorio_vowel_table_add("aàáâăąåAÀÁÂĂĄÅeèéêëěęEÈÉÊËĚĘiìíîIÌÍÎ"
-                "oòóôơőøOÒÓÔƠŐØuùúûưůűUÙÚÛƯŮŰyỳýYỲÝæǽÆǼœŒ");
+        gregorio_vowel_table_add(DEFAULT_VOWELS);
         gregorio_prefix_table_add("i");
         gregorio_prefix_table_add("I");
         gregorio_prefix_table_add("u");

--- a/src/characters.c
+++ b/src/characters.c
@@ -53,9 +53,10 @@
 #define VOWEL_FILE "gregorio-vowels.dat"
 
 #ifndef USE_KPSE
-static inline void rtrim(char *buf)
+static __inline void rtrim(char *buf)
 {
-    for (char *p = buf + strlen(buf) - 1; p >= buf && isspace(*p); --p) {
+    char *p;
+    for (p = buf + strlen(buf) - 1; p >= buf && isspace(*p); --p) {
         *p = '\0';
     }
 }
@@ -64,8 +65,9 @@ static inline void rtrim(char *buf)
 static bool read_vowel_rules(char *const lang) {
     char *language = lang;
     rulefile_parse_status status = RFPS_NOT_FOUND;
-    char **filenames, *filename;
+    char **filenames, *filename, **p;
     const char *description;
+    int tries;
 
 #ifdef USE_KPSE
     filenames = kpse_find_file_generic(VOWEL_FILE, kpse_tex_format, true, true);
@@ -117,12 +119,11 @@ static bool read_vowel_rules(char *const lang) {
 #endif
 
     gregorio_vowel_tables_init();
-    // only need to try twice
-    // if it's not resolved by then, there is an alias loop
-    for (int tries = 0; tries < 2; ++tries) {
-        for (char **p = filenames; status != RFPS_FOUND && (filename = *p);
-                ++p) {
-            // read and parse the file
+    /* only need to try twice; if it's not resolved by then, there is an alias
+     * loop */
+    for (tries = 0; tries < 2; ++tries) {
+        for (p = filenames; status != RFPS_FOUND && (filename = *p); ++p) {
+            /* read and parse the file */
             gregorio_messagef("read_rules", VERBOSITY_INFO, 0,
                     _("Looking for %s in %s"), language, filename);
             gregorio_vowel_tables_load(filename, &language, &status);
@@ -141,7 +142,7 @@ static bool read_vowel_rules(char *const lang) {
                     description, language, filename);
         }
         if (status != RFPS_ALIASED) {
-            // if it's not aliased, there's no reason to scan again
+            /* if it's not aliased, there's no reason to scan again */
             break;
         }
     }
@@ -150,8 +151,8 @@ static bool read_vowel_rules(char *const lang) {
                 _("Unable to resolve alias for %s"), lang);
     }
 
-    // free the allocated memory
-    for (char **p = filenames; *p; ++p) {
+    /* free the allocated memory */
+    for (p = filenames; *p; ++p) {
         free(*p);
     }
     free(filenames);
@@ -180,10 +181,10 @@ void gregorio_set_centering_language(char *const language)
     }
 }
 
-static inline gregorio_character *skip_verbatim_or_special(
+static __inline gregorio_character *skip_verbatim_or_special(
         gregorio_character *ch)
 {
-    // skip past verbatim and special characters
+    /* skip past verbatim and special characters */
     if (ch->cos.s.type == ST_T_BEGIN && (ch->cos.s.style == ST_VERBATIM
                 || ch->cos.s.style == ST_SPECIAL_CHAR)) {
         if (ch->next_character) {
@@ -236,7 +237,7 @@ static void determine_center(gregorio_character *character, int *start,
  * special-character. It places current_character to the character next to the
  * end of the verbatim or special_char charachters.
  */
-static inline void verb_or_sp(gregorio_character **ptr_character,
+static __inline void verb_or_sp(gregorio_character **ptr_character,
         grestyle_style style, FILE *f, void (*function) (FILE *, grewchar *))
 {
     int i, j;
@@ -341,7 +342,7 @@ void gregorio_write_text(bool skip_initial,
                     begin(f, current_character->cos.s.style);
                     break;
                 }
-            } else {            // ST_T_END
+            } else { /* ST_T_END */
                 end(f, current_character->cos.s.style);
             }
         }
@@ -350,8 +351,8 @@ void gregorio_write_text(bool skip_initial,
     }
 }
 
-// the default behaviour is to write only the initial, that is to say things
-// between the styles ST_INITIAL
+/* the default behaviour is to write only the initial, that is to say things
+ * between the styles ST_INITIAL */
 void gregorio_write_initial(gregorio_character *current_character,
         FILE *f, void (*printverb) (FILE *, grewchar *),
         void (*printchar) (FILE *, grewchar),
@@ -359,7 +360,7 @@ void gregorio_write_initial(gregorio_character *current_character,
         void (*end) (FILE *, grestyle_style),
         void (*printspchar) (FILE *, grewchar *))
 {
-    // we loop until we see the beginning of the initial style
+    /* we loop until we see the beginning of the initial style */
     gregorio_go_to_first_character(&current_character);
     while (current_character) {
         if (!current_character->is_character
@@ -371,7 +372,7 @@ void gregorio_write_initial(gregorio_character *current_character,
 
         current_character = current_character->next_character;
     }
-    // then we loop until we see the end of the initial style, but we print
+    /* then we loop until we see the end of the initial style, but we print */
     while (current_character) {
         if (current_character->is_character) {
             printchar(f, current_character->cos.character);
@@ -389,7 +390,7 @@ void gregorio_write_initial(gregorio_character *current_character,
                     begin(f, current_character->cos.s.style);
                     break;
                 }
-            } else {            // ST_T_END
+            } else { /* ST_T_END */
                 if (current_character->cos.s.style == ST_INITIAL) {
                     return;
                 } else {
@@ -661,7 +662,7 @@ static void gregorio_suppress_this_character(gregorio_character *to_suppress)
  * 
  */
 
-static inline void close_style(gregorio_character *current_character,
+static __inline void close_style(gregorio_character *current_character,
         det_style *current_style)
 {
     if (!current_character->previous_character->is_character
@@ -685,8 +686,8 @@ static inline void close_style(gregorio_character *current_character,
  * 
  */
 
-// type is ST_CENTER or ST_FORCED_CENTER
-static inline void end_center(grestyle_style type,
+/* type is ST_CENTER or ST_FORCED_CENTER */
+static __inline void end_center(grestyle_style type,
         gregorio_character *current_character, det_style **ptr_style)
 {
     det_style *current_style;
@@ -718,7 +719,7 @@ static inline void end_center(grestyle_style type,
  * about the same, but adding a { 
  */
 
-static inline void begin_center(grestyle_style type,
+static __inline void begin_center(grestyle_style type,
         gregorio_character *current_character, det_style **ptr_style)
 {
     det_style *current_style;
@@ -755,14 +756,14 @@ static inline void begin_center(grestyle_style type,
  */
 
 #define end_c() if (_end_c(&current_character)) continue; else break;
-static inline bool _end_c(gregorio_character **ptr_character)
+static __inline bool _end_c(gregorio_character **ptr_character)
 {
     if ((*ptr_character)->next_character) {
         *ptr_character = (*ptr_character)->next_character;
-        // continue
+        /* continue */
         return true;
     } else {
-        // break
+        /* break */
         return false;
     }
 }
@@ -774,12 +775,13 @@ static inline bool _end_c(gregorio_character **ptr_character)
  */
 
 #define suppress_char_and_end_c() if (_suppress_char_and_end_c(&current_character)) continue; else break;
-static inline bool _suppress_char_and_end_c(gregorio_character **ptr_character)
+static __inline bool _suppress_char_and_end_c(
+        gregorio_character **ptr_character)
 {
     if ((*ptr_character)->next_character) {
         *ptr_character = (*ptr_character)->next_character;
         gregorio_suppress_this_character((*ptr_character)->previous_character);
-        // continue
+        /* continue */
         return true;
     } else {
         if ((*ptr_character)->previous_character) {
@@ -789,7 +791,7 @@ static inline bool _suppress_char_and_end_c(gregorio_character **ptr_character)
             gregorio_suppress_this_character(*ptr_character);
             *ptr_character = NULL;
         }
-        // break
+        /* break */
         return false;
     }
 }
@@ -802,7 +804,7 @@ static bool gregorio_go_to_end_initial(gregorio_character **param_character)
         return false;
     }
     gregorio_go_to_first_character(&current_character);
-    // skip past any initial
+    /* skip past any initial */
     if (!current_character->is_character
             && current_character->cos.s.type == ST_T_BEGIN
             && current_character->cos.s.style == ST_INITIAL) {
@@ -839,20 +841,20 @@ static bool gregorio_go_to_end_initial(gregorio_character **param_character)
 void gregorio_rebuild_characters(gregorio_character **param_character,
         gregorio_center_determination center_is_determined, bool skip_initial)
 {
-    // a det_style, to walk through the list
+    /* a det_style, to walk through the list */
     det_style *current_style = NULL;
-    // the current_character
+    /* the current_character */
     gregorio_character *current_character = *param_character;
-    // a char that we will use in a very particular case
+    /* a char that we will use in a very particular case */
     grestyle_style this_style;
     det_style *first_style = NULL;
-    grestyle_style center_type = ST_NO_STYLE;  // determining the type of centering
+    /* determining the type of centering (forced or not) */
+    grestyle_style center_type = ST_NO_STYLE;
     int start = -1, end = -1, index = -1; 
-    // (forced or not)
-    // so, here we start: we go to the first_character
+    /* so, here we start: we go to the first_character */
     if (gregorio_go_to_end_initial(&current_character)) {
         if (!current_character->next_character) {
-            // nothing else to rebuild, but the initial needs to be ST_CENTER
+            /* nothing else to rebuild, but the initial needs to be ST_CENTER */
             gregorio_insert_style_after(ST_T_END, ST_CENTER,
                     &current_character);
             gregorio_go_to_first_character(&current_character);
@@ -863,55 +865,55 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
             return;
         }
         if (skip_initial) {
-            // move to the character after the initial
+            /* move to the character after the initial */
             current_character = current_character->next_character;
         } else {
             gregorio_go_to_first_character(&current_character);
         }
     }
-    // first we see if there is already a center determined
+    /* first we see if there is already a center determined */
     if (center_is_determined == 0) {
         center_type = ST_CENTER;
         determine_center(current_character, &start, &end);
     } else {
         center_type = ST_FORCED_CENTER;
     }
-    // we loop until there isn't any character
+    /* we loop until there isn't any character */
     while (current_character) {
-        // the first part of the function deals with real characters (not
-        // styles)
+        /* the first part of the function deals with real characters (not
+         * styles) */
         if (current_character->is_character) {
             ++index;
-            // the firstcase is if the user has'nt determined the middle, and
-            // we have only seen vowels so far (else center_is_determined
-            // would be DETERMINING_MIDDLE). The current_character is the
-            // first vowel, so we start the center here. 
+            /* the firstcase is if the user has'nt determined the middle, and
+             * we have only seen vowels so far (else center_is_determined
+             * would be DETERMINING_MIDDLE). The current_character is the
+             * first vowel, so we start the center here. */
             if (!center_is_determined && index == start) {
                 begin_center(center_type, current_character, &current_style);
                 center_is_determined = CENTER_DETERMINING_MIDDLE;
                 end_c();
             }
-            // the case where the user has not determined the middle and we
-            // are in the middle section of the syllable, but there we
-            // encounter something that is not a vowel, so the center ends
-            // there.
+            /* the case where the user has not determined the middle and we
+             * are in the middle section of the syllable, but there we
+             * encounter something that is not a vowel, so the center ends
+             * there. */
             if (center_is_determined == CENTER_DETERMINING_MIDDLE
                     && index == end) {
                 end_center(center_type, current_character, &current_style);
                 center_is_determined = CENTER_FULLY_DETERMINED;
             }
-            // in the case where it is just a normal character... we simply
-            // pass.
+            /* in the case where it is just a normal character... we simply
+             * pass. */
             end_c();
         }
-        // there starts the second part of the function that deals with the
-        // styles characters
+        /* there starts the second part of the function that deals with the
+         * styles characters */
         if (current_character->cos.s.type == ST_T_BEGIN
                 && current_character->cos.s.style != ST_CENTER
                 && current_character->cos.s.style != ST_FORCED_CENTER) {
-            // first, if it it the beginning of a style, which is not center.
-            // We check if the style is not already in the stack. If it is the
-            // case, we suppress the character and pass (with the good macro)
+            /* first, if it it the beginning of a style, which is not center.
+             * We check if the style is not already in the stack. If it is the
+             * case, we suppress the character and pass (with the good macro) */
             while (current_style
                     && current_style->style != current_character->cos.s.style) {
                 current_style = current_style->next_style;
@@ -920,8 +922,9 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
                 current_style = first_style;
                 suppress_char_and_end_c();
             }
-            // if we are determining the end of the middle and we have a
-            // VERBATIM or SPECIAL_CHAR style, we end the center determination
+            /* if we are determining the end of the middle and we have a
+             * VERBATIM or SPECIAL_CHAR style, we end the center
+             * determination */
             if ((current_character->cos.s.style == ST_VERBATIM
                             || current_character->cos.s.style ==
                             ST_SPECIAL_CHAR)
@@ -929,12 +932,12 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
                 end_center(center_type, current_character, &current_style);
                 center_is_determined = CENTER_FULLY_DETERMINED;
             }
-            // if it is something to add then we just push the style in the
-            // stack and continue.
+            /* if it is something to add then we just push the style in the
+             * stack and continue. */
             gregorio_style_push(&first_style, current_character->cos.s.style);
             current_style = first_style;
-            // Here we pass all the characters after a verbatim (or special
-            // char) beginning, until we find a style (begin or end)
+            /* Here we pass all the characters after a verbatim (or special
+             * char) beginning, until we find a style (begin or end) */
             if (current_character->cos.s.style == ST_VERBATIM
                     || current_character->cos.s.style == ST_SPECIAL_CHAR) {
                 if (current_character->next_character) {
@@ -948,7 +951,7 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
                 end_c();
             }
         }
-        // if it is a beginning of a center, we call the good macro and end.
+        /* if it is a beginning of a center, we call the good macro and end. */
         if (current_character->cos.s.type == ST_T_BEGIN
                 && (current_character->cos.s.style == ST_CENTER
                         || current_character->cos.s.style ==
@@ -961,23 +964,23 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
             if (center_is_determined) {
                 end_c();
             }
-            // center_is_determined = DETERMINING_MIDDLE; // TODO: not really
-            // sure, but shouldn't be there
+            /* center_is_determined = DETERMINING_MIDDLE; */
+            /* TODO: not really sure, but shouldn't be there */
             begin_center(center_type, current_character, &current_style);
             end_c();
         }
         if (current_character->cos.s.type == ST_T_END
                 && current_character->cos.s.style != ST_CENTER
                 && current_character->cos.s.style != ST_FORCED_CENTER) {
-            // the case of the end of a style (the most complex). First, we
-            // have to see if the style is in the stack. If there is no stack,
-            // we just suppress and continue.
+            /* the case of the end of a style (the most complex). First, we
+             * have to see if the style is in the stack. If there is no stack,
+             * we just suppress and continue. */
             if (!current_style) {
                 suppress_char_and_end_c();
             }
-            // so, we look if it is in the stack. If it is we put
-            // current_style to the style just before the style corresponding
-            // to the character that we are trating (still there ?)
+            /* so, we look if it is in the stack. If it is we put
+             * current_style to the style just before the style corresponding
+             * to the character that we are trating (still there ?) */
             if (current_style->style != current_character->cos.s.style) {
                 while (current_style->next_style
                         && current_style->next_style->style !=
@@ -987,21 +990,21 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
                 if (current_style->next_style) {
                     current_style = first_style;
                     while (current_style) {
-                        // if there are styles before in the stack, we close
-                        // them
+                        /* if there are styles before in the stack, we close
+                         * them */
                         gregorio_insert_style_before(ST_T_END,
                                 current_style->style, current_character);
                         current_style = current_style->previous_style;
                     }
                     current_style = first_style;
                     this_style = current_character->cos.s.style;
-                    // and then we reopen them
+                    /* and then we reopen them */
                     while (current_style && current_style->style != this_style) {
                         gregorio_insert_style_after(ST_T_BEGIN,
                                 current_style->style, &current_character);
                         current_style = current_style->next_style;
                     }
-                    // we delete the style in the stack
+                    /* we delete the style in the stack */
                     gregorio_style_pop(&first_style, current_style);
                     current_style = first_style;
                 } else {
@@ -1012,8 +1015,8 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
                 current_style = first_style;
                 end_c();
             }
-        } else {                // ST_T_END && ST_CENTER
-            // a quite simple case, we just call the good macro.
+        } else { /* ST_T_END && ST_CENTER */
+            /* a quite simple case, we just call the good macro. */
             if (!center_is_determined) {
                 suppress_char_and_end_c();
             }
@@ -1023,21 +1026,21 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
     if (!current_character) {
         return;
     }
-    // we terminate all the styles that are still in the stack
+    /* we terminate all the styles that are still in the stack */
     while (current_style) {
         gregorio_insert_style_after(ST_T_END, current_style->style,
                 &current_character);
         current_style = current_style->next_style;
     }
-    // current_character is at the end of the list now, so if we havn't closed
-    // the center, we do it at the end.
+    /* current_character is at the end of the list now, so if we havn't closed
+     * the center, we do it at the end. */
     if (center_is_determined != CENTER_FULLY_DETERMINED) {
         gregorio_insert_style_after(ST_T_END, center_type, &current_character);
     }
-    // these three lines are for the case where the user didn't tell anything
-    // about the middle and there aren't any vowel in the syllable, so we
-    // begin the center before the first character (you can notice that there
-    // is no problem of style).
+    /* these three lines are for the case where the user didn't tell anything
+     * about the middle and there aren't any vowel in the syllable, so we
+     * begin the center before the first character (you can notice that there
+     * is no problem of style). */
     if (!center_is_determined) {
         if (skip_initial && gregorio_go_to_end_initial(&current_character)) {
             current_character = current_character->next_character;
@@ -1046,7 +1049,7 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
         }
         gregorio_insert_style_before(ST_T_BEGIN, ST_CENTER, current_character);
     }
-    // well.. you're quite brave if you reach this comment.
+    /* well.. you're quite brave if you reach this comment. */
     gregorio_go_to_first_character(&current_character);
     (*param_character) = current_character;
     gregorio_free_styles(&first_style);
@@ -1071,28 +1074,28 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
 void gregorio_rebuild_first_syllable(gregorio_character **param_character,
         bool separate_initial)
 {
-    // the current_character
+    /* the current_character */
     gregorio_character *current_character = *param_character;
     gregorio_character *first_character;
     gregorio_character *start_of_special;
-    // so, here we start: we go to the first_character
+    /* so, here we start: we go to the first_character */
     gregorio_go_to_first_character(&current_character);
-    // first we look at the styles, to see if there is a FORCED_CENTER
-    // somewhere
-    // and we also remove the CENTER styles if the syllable starts at CENTER
+    /* first we look at the styles, to see if there is a FORCED_CENTER
+     * somewhere and we also remove the CENTER styles if the syllable starts at
+     * CENTER */
     if (!param_character) {
         return;
     }
     while (current_character) {
         if (!current_character->is_character) {
             if (current_character->cos.s.style == ST_FORCED_CENTER) {
-                // we can break here, as there won't be forced center plus
-                // center
+                /* we can break here, as there won't be forced center plus
+                 * center */
                 break;
             }
             if (current_character->cos.s.style == ST_CENTER) {
-                // we have to do it in case param_character (the first
-                // character) is a ST_CENTER beginning
+                /* we have to do it in case param_character (the first
+                 * character) is a ST_CENTER beginning */
                 if (!current_character->previous_character
                         && current_character == *param_character) {
                     *param_character = (*param_character)->next_character;
@@ -1106,12 +1109,12 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
     current_character = *param_character;
     gregorio_go_to_first_character(&current_character);
     first_character = current_character;
-    // now we are going to place the two INITIAL styles (begin and end)
+    /* now we are going to place the two INITIAL styles (begin and end) */
     while (current_character) {
         if (!current_character->is_character
                 && current_character->cos.s.style == ST_FORCED_CENTER) {
-            // we don't touch anything after a FORCED_CENTER, so we put an
-            // empty INITIAL style just before
+            /* we don't touch anything after a FORCED_CENTER, so we put an
+             * empty INITIAL style just before */
             current_character = first_character;
             gregorio_insert_style_before(ST_T_BEGIN, ST_INITIAL,
                     current_character);
@@ -1120,8 +1123,8 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
                     &current_character);
             break;
         }
-        // this if is a hack to make gregorio consider verbatim blocks and
-        // special chars like one block, not a sequence of letters
+        /* this if is a hack to make gregorio consider verbatim blocks and
+         * special chars like one block, not a sequence of letters */
         if (!current_character->is_character
                 && current_character->cos.s.type == ST_T_BEGIN
                 && (current_character->cos.s.style == ST_VERBATIM
@@ -1129,7 +1132,7 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
             gregorio_insert_style_before(ST_T_BEGIN, ST_INITIAL,
                     current_character);
             start_of_special = current_character->previous_character;
-            // ... which is now the begin-initial style
+            /* ... which is now the begin-initial style */
 
             if (current_character->next_character) {
                 current_character = current_character->next_character;
@@ -1141,7 +1144,7 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
             gregorio_insert_style_after(ST_T_END, ST_INITIAL,
                     &current_character);
             if (separate_initial && start_of_special->previous_character) {
-                // we need to move the initial to the front
+                /* we need to move the initial to the front */
                 start_of_special->previous_character->next_character =
                         current_character->next_character;
                 current_character->next_character->previous_character =
@@ -1158,7 +1161,7 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
         }
         if (current_character->is_character) {
             if (separate_initial && current_character->previous_character) {
-                // we need to move the initial to the front
+                /* we need to move the initial to the front */
                 current_character->previous_character->next_character =
                         current_character->next_character;
                 current_character->next_character->previous_character =
@@ -1179,7 +1182,7 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
         }
         current_character = current_character->next_character;
     }
-    // now apply the first syllable style
+    /* now apply the first syllable style */
     current_character = *param_character;
     if (separate_initial) {
         if (gregorio_go_to_end_initial(&current_character)) {
@@ -1205,7 +1208,7 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
                 gregorio_insert_style_before(ST_T_BEGIN,
                         ST_FIRST_SYLLABLE_INITIAL, current_character);
                 if (!current_character->is_character) {
-                    // skip past the verbatim or special character
+                    /* skip past the verbatim or special character */
                     if (current_character->next_character) {
                         current_character = current_character->next_character;
                     }

--- a/src/characters.h
+++ b/src/characters.h
@@ -20,7 +20,7 @@
 #ifndef CHARACTERS_H
 #define CHARACTERS_H
 
-#include <stdbool.h>
+#include "bool.h"
 #include "struct.h"
 
 /*

--- a/src/characters.h
+++ b/src/characters.h
@@ -41,10 +41,10 @@ typedef enum gregorio_center_determination {
     CENTER_NOT_DETERMINED = 0,
     CENTER_HALF_DETERMINED,
     CENTER_FULLY_DETERMINED,
-    CENTER_DETERMINING_MIDDLE,
+    CENTER_DETERMINING_MIDDLE
 } gregorio_center_determination;
 
-// this is a temporary structure that will be used for style determination
+/* this is a temporary structure that will be used for style determination */
 
 typedef struct det_style {
     unsigned char style;

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -25,10 +25,11 @@
 #include "unicode.h"
 #include "messages.h"
 #include "plugins.h"
+#include "support.h"
 
 static const char *unknown(int value) {
     static char buf[20];
-    snprintf(buf, 20, "?%d", value);
+    gregorio_snprintf(buf, 20, "?%d", value);
     return buf;
 }
 
@@ -509,9 +510,9 @@ static const char *dump_vposition(gregorio_vposition vpos) {
 static const char *dump_pitch(const char height) {
     static char buf[20];
     if (height >= LOWEST_PITCH && height <= HIGHEST_PITCH) {
-        snprintf(buf, 20, "%c", height + 'a' - LOWEST_PITCH);
+        gregorio_snprintf(buf, 20, "%c", height + 'a' - LOWEST_PITCH);
     } else {
-        snprintf(buf, 20, "?%d", height);
+        gregorio_snprintf(buf, 20, "?%d", height);
     }
     return buf;
 }

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -451,7 +451,7 @@ static const char *dump_signs(gregorio_sign signs)
     }
 }
 
-// a function dumping special signs
+/* a function dumping special signs */
 static const char *dump_special_sign(gregorio_sign special_sign)
 {
     switch (special_sign) {
@@ -522,6 +522,7 @@ void dump_write_score(FILE *f, gregorio_score *score)
     gregorio_voice_info *voice_info = score->first_voice_info;
     int i;
     int annotation_num;
+    gregorio_syllable *syllable;
 
     if (!f) {
         gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
@@ -637,8 +638,9 @@ void dump_write_score(FILE *f, gregorio_score *score)
             "=====================================================================\n"
             " SCORE\n"
             "=====================================================================\n");
-    for (gregorio_syllable *syllable = score->first_syllable; syllable;
+    for (syllable = score->first_syllable; syllable;
             syllable = syllable->next_syllable) {
+        gregorio_element *element;
         if (syllable->type) {
             fprintf(f, "   type                      %d (%s)\n",
                     syllable->type, dump_type(syllable->type));
@@ -679,8 +681,8 @@ void dump_write_score(FILE *f, gregorio_score *score)
         if (syllable->abovelinestext) {
             fprintf(f, "\n  Abovelinestext\n    %s", syllable->abovelinestext);
         }
-        for (gregorio_element *element = *syllable->elements; element;
-                element = element->next) {
+        for (element = *syllable->elements; element; element = element->next) {
+            gregorio_glyph *glyph;
             fprintf(f, "---------------------------------------------------------------------\n");
             if (element->type) {
                 fprintf(f, "     type                    %d (%s)\n",
@@ -756,8 +758,9 @@ void dump_write_score(FILE *f, gregorio_score *score)
                 }
                 break;
             case GRE_ELEMENT:
-                for (gregorio_glyph *glyph = element->u.first_glyph;
-                        glyph; glyph = glyph->next) {
+                for (glyph = element->u.first_glyph; glyph;
+                        glyph = glyph->next) {
+                    gregorio_note *note;
                     fprintf(f, "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\n");
                     if (glyph->type) {
                         fprintf(f, "       type                  %d (%s)\n",
@@ -814,8 +817,8 @@ void dump_write_score(FILE *f, gregorio_score *score)
                         break;
                     }
                     if (glyph->type == GRE_GLYPH) {
-                        for (gregorio_note *note = glyph->u.notes.first_note;
-                                note; note = note->next) {
+                        for (note = glyph->u.notes.first_note; note;
+                                note = note->next) {
                             fprintf(f, "-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  \n");
                             if (note->type) {
                                 fprintf(f, "         type                   %d (%s)\n",
@@ -905,7 +908,7 @@ void dump_write_score(FILE *f, gregorio_score *score)
                 break;
 
             default:
-                // do nothing
+                /* do nothing */
                 break;
             }
             if (element->nabc_lines) {

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -20,7 +20,7 @@
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
+#include "bool.h"
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"

--- a/src/encode_utf8strings.c
+++ b/src/encode_utf8strings.c
@@ -1,0 +1,75 @@
+/*
+ * Utility program to convert utf8strings.h.in into utf8strings.h
+ *
+ * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
+ *
+ * This file is part of Gregorio.
+ *
+ * Gregorio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gregorio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+int main(int argc, char **argv)
+{
+    char buf[5];
+    FILE *input, *output;
+    int c;
+
+    if (argc != 3) {
+        fprintf(stderr, "Incorrect arguments\n");
+        return -1;
+    }
+
+    input = fopen(argv[1], "rb");
+    if (input == NULL) {
+        fprintf(stderr, "Error opening %s: %s\n", argv[1], strerror(errno));
+        return -1;
+    }
+
+    output = fopen(argv[2], "wb");
+    if (output == NULL) {
+        fprintf(stderr, "Error creating %s: %s\n", argv[2], strerror(errno));
+        return -1;
+    }
+
+    while ((c = fgetc(input)) != EOF) {
+        if (c & 0x80) {
+            snprintf(buf, sizeof(buf), "\\%03o", c);
+            if (fwrite(buf, sizeof(buf) - sizeof(char), 1, output) != 1) {
+                fprintf(stderr, "Error writing %s: %s\n", argv[2],
+                        strerror(errno));
+                return -1;
+            }
+        } else {
+            if (fputc(c, output) != c) {
+                fprintf(stderr, "Error writing %s: %s\n", argv[2],
+                        strerror(errno));
+                return -1;
+            }
+        }
+    }
+
+    if (fclose(output) != 0) {
+        fprintf(stderr, "Error closing %s: %s\n", argv[2], strerror(errno));
+        return -1;
+    }
+    if (fclose(input) != 0) {
+        fprintf(stderr, "Error closing %s: %s\n", argv[1], strerror(errno));
+        return -1;
+    }
+    return 0;
+}

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -19,7 +19,7 @@
 
 #include "config.h"
 #include <stdio.h>
-#include <stdbool.h>
+#include "bool.h"
 #include "struct.h"
 #include "messages.h"
 

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -33,7 +33,7 @@
  * 
  */
 
-static inline bool is_puncta_ascendens(char glyph)
+static __inline bool is_puncta_ascendens(char glyph)
 {
     return glyph == G_2_PUNCTA_INCLINATA_ASCENDENS
         || glyph == G_3_PUNCTA_INCLINATA_ASCENDENS
@@ -42,7 +42,7 @@ static inline bool is_puncta_ascendens(char glyph)
         || glyph == G_PUNCTUM_INCLINATUM;
 }
 
-static inline bool is_puncta_descendens(char glyph)
+static __inline bool is_puncta_descendens(char glyph)
 {
     return glyph == G_2_PUNCTA_INCLINATA_DESCENDENS
         || glyph == G_3_PUNCTA_INCLINATA_DESCENDENS
@@ -78,14 +78,14 @@ static void close_element(gregorio_element **current_element,
  * inline function to automatically do two or three things
  * 
  */
-static inline void cut_before(gregorio_glyph *current_glyph,
+static __inline void cut_before(gregorio_glyph *current_glyph,
                               gregorio_glyph **first_glyph,
                               gregorio_glyph **previous_glyph,
                               gregorio_element **current_element)
 {
     if (*first_glyph != current_glyph) {
         close_element(current_element, first_glyph, current_glyph);
-        // yes, this is changing value close_element sets for first_glyph
+        /* yes, this is changing value close_element sets for first_glyph */
         *first_glyph = current_glyph;
         *previous_glyph = current_glyph;
     }
@@ -100,28 +100,27 @@ static inline void cut_before(gregorio_glyph *current_glyph,
 static gregorio_element *gabc_det_elements_from_glyphs(
         gregorio_glyph *current_glyph)
 {
-    // the last element we have successfully added to the list of elements
+    /* the last element we have successfully added to the list of elements */
     gregorio_element *current_element = NULL;
-    // the first element, that we will return at the end. We have to consider
-    // it
-    // because the gregorio_element struct does not have previous_element
-    // element.
+    /* the first element, that we will return at the end. We have to consider
+     * it because the gregorio_element struct does not have previous_element
+     * element. */
     gregorio_element *first_element = NULL;
-    // the first_glyph of the element that we are currently determining
+    /* the first_glyph of the element that we are currently determining */
     gregorio_glyph *first_glyph = current_glyph;
-    // the last real (GRE_GLYPH) that we have processed, often the same as
-    // first_glyph
+    /* the last real (GRE_GLYPH) that we have processed, often the same as
+     * first_glyph */
     gregorio_glyph *previous_glyph = current_glyph;
-    // a char that is necessary to determine some cases
+    /* a char that is necessary to determine some cases */
     bool do_not_cut = false;
-    // a char that is necesarry to determine the type of the current_glyph
+    /* a char that is necesarry to determine the type of the current_glyph */
     char current_glyph_type;
 
     if (!current_glyph) {
         return NULL;
     }
-    // first we go to the first glyph in the chained list of glyphs (maybe to
-    // suppress ?)
+    /* first we go to the first glyph in the chained list of glyphs (maybe to
+     * suppress ?) */
     gregorio_go_to_first_glyph(&current_glyph);
 
     while (current_glyph) {
@@ -132,7 +131,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
                 current_glyph = current_glyph->next;
                 continue;
             }
-            // we ignore flats and naturals, except if they are alone
+            /* we ignore flats and naturals, except if they are alone */
             if (current_glyph->type == GRE_NATURAL
                 || current_glyph->type == GRE_FLAT
                 || current_glyph->type == GRE_SHARP) {
@@ -143,7 +142,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
                 current_glyph = current_glyph->next;
                 continue;
             }
-            // we must not cut after a zero_width_space
+            /* we must not cut after a zero_width_space */
             if (current_glyph->type == GRE_SPACE
                 && current_glyph->u.misc.unpitched.info.space == SP_ZERO_WIDTH) {
                 if (!current_glyph->next) {
@@ -153,7 +152,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
                 do_not_cut = true;
                 continue;
             }
-            // we must not cut after a zero_width_space
+            /* we must not cut after a zero_width_space */
             if (current_glyph->type == GRE_TEXVERB_GLYPH) {
                 if (!current_glyph->next) {
                     close_element(&current_element, &first_glyph, current_glyph);
@@ -161,14 +160,14 @@ static gregorio_element *gabc_det_elements_from_glyphs(
                 current_glyph = current_glyph->next;
                 continue;
             }
-            // clef change or space or end of line
+            /* clef change or space or end of line */
             cut_before(current_glyph, &first_glyph, &previous_glyph,
                        &current_element);
-            // if statement to make neumatic cuts not appear in elements, as
-            // there is always one between elements 
+            /* if statement to make neumatic cuts not appear in elements, as
+             * there is always one between elements */
             if (current_glyph->type != GRE_SPACE
                 || current_glyph->u.misc.unpitched.info.space != SP_NEUMATIC_CUT)
-                // clef change or space other thant neumatic cut
+                /* clef change or space other thant neumatic cut */
             {
                 if (!first_element) {
                     first_element = current_element;
@@ -204,7 +203,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
             }
             break;
         case G_PUNCTA_DESCENDENS:
-            // we don't cut before, so we don't do anything
+            /* we don't cut before, so we don't do anything */
             if (do_not_cut) {
                 do_not_cut = false;
             }
@@ -214,7 +213,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
                 && (current_glyph->u.notes.first_note->u.note.shape == S_STROPHA
                     || current_glyph->u.notes.first_note->u.note.shape == S_VIRGA
                     || current_glyph->u.notes.first_note->u.note.shape == S_VIRGA_REVERSA)) {
-                // we determine the last pitch
+                /* we determine the last pitch */
                 char last_pitch;
                 gregorio_note *tmp_note;
                 tmp_note = previous_glyph->u.notes.first_note;
@@ -227,7 +226,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
                     break;
                 }
             }
-            // else we fall in the default case
+            /* else we fall in the default case */
         default:
             if (do_not_cut) {
                 do_not_cut = false;
@@ -246,7 +245,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
             close_element(&current_element, &first_glyph, current_glyph);
         }
         current_glyph = current_glyph->next;
-    } // end of while
+    } /* end of while */
 
     /*
      * we must determine the first element, that we will return 

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -19,8 +19,8 @@
 
 #include "config.h"
 #include <stdio.h>
-#include <stdbool.h>
 #include <assert.h>
+#include "bool.h"
 #include "struct.h"
 #include "messages.h"
 

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -26,7 +26,7 @@
 
 #include "gabc.h"
 
-static inline gregorio_scanner_location *copy_note_location(
+static __inline gregorio_scanner_location *copy_note_location(
         const gregorio_note *const note, gregorio_scanner_location *const loc)
 {
     loc->first_line = note->src_line;
@@ -57,11 +57,11 @@ static void close_glyph(gregorio_glyph **last_glyph,
         gregorio_liquescentia liquescentia, gregorio_note *current_note)
 {
     gregorio_scanner_location loc;
-    // a variable necessary for the patch for G_BIVIRGA & co.
+    /* a variable necessary for the patch for G_BIVIRGA & co. */
     gregorio_note *added_notes = NULL;
 
-    // patch to have good glyph type in the case where a glyph ends by a note
-    // with shape S_QUADRATUM
+    /* patch to have good glyph type in the case where a glyph ends by a note
+     * with shape S_QUADRATUM */
     if (glyph_type == G_PES_QUADRATUM_FIRST_PART
             || glyph_type == G_PES_QUILISMA_QUADRATUM_FIRST_PART) {
         glyph_type = G_PUNCTUM;
@@ -73,11 +73,10 @@ static void close_glyph(gregorio_glyph **last_glyph,
         *first_note = current_note->next;
         current_note->next = NULL;
     }
-    // here we "patch" the structure for bivirga, tristropha, etc.
-    // the idea is not to have a S_BIVIRGA in the shape of the note (which is
-    // dirty)
-    // but rather a G_BIVIRGA in the glyph (which is the case now) and two
-    // virgas
+    /* here we "patch" the structure for bivirga, tristropha, etc. */
+    /* the idea is not to have a S_BIVIRGA in the shape of the note (which is
+     * dirty) but rather a G_BIVIRGA in the glyph (which is the case now) and
+     * two virgas */
 
     if (glyph_type == G_BIVIRGA || glyph_type == G_DISTROPHA
             || glyph_type == G_TRIVIRGA || glyph_type == G_TRISTROPHA
@@ -134,13 +133,13 @@ static void close_glyph(gregorio_glyph **last_glyph,
                     break;
                 }
             }
-            // this is the case of two separate virga that have been spotted
-            // as a bivirga
+            /* this is the case of two separate virga that have been spotted
+             * as a bivirga */
             if (!added_notes) {
                 break;
             }
-            // now we have what we want, we set up the links and free the old
-            // note
+            /* now we have what we want, we set up the links and free the old
+             * note */
             if (current_note->next) {
                 current_note->next->previous = added_notes;
                 added_notes->next = current_note->next;
@@ -155,19 +154,19 @@ static void close_glyph(gregorio_glyph **last_glyph,
                 break;
             } else {
                 gregorio_free_one_note(&current_note);
-                // automatically sets first_note to the next note
+                /* automatically sets first_note to the next note */
             }
         }
         gregorio_go_to_first_note(&current_note);
-        // finally we set the just added glyph first_note to current_note
+        /* finally we set the just added glyph first_note to current_note */
         (*last_glyph)->u.notes.first_note = current_note;
     }
 }
 
-// a small function to automatically determine the pitch of a custo : it is
-// the pitch of the next note, but we must take care of the clef changes, as
-// custo are (normally and for now) only present before clef changes.
-// TODO: there may be a side effect with the flated keys...
+/* a small function to automatically determine the pitch of a custo : it is
+ * the pitch of the next note, but we must take care of the clef changes, as
+ * custo are (normally and for now) only present before clef changes. */
+/* TODO: there may be a side effect with the flated keys... */
 
 static char gabc_determine_custo_pitch(gregorio_note *current_note,
         int current_key)
@@ -252,15 +251,15 @@ static char gregorio_add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
         gabc_determination * end_of_glyph)
 {
 
-    // next glyph type is the type of the glyph that will be returned (the
-    // new type of the glyph with the note added to it, or the type of the
-    // new glyph with the note alone.
+    /* next glyph type is the type of the glyph that will be returned (the
+     * new type of the glyph with the note added to it, or the type of the
+     * new glyph with the note alone. */
     gregorio_glyph_type next_glyph_type = G_UNDETERMINED;
 
     *end_of_glyph = DET_NO_END;
 
-    // here we separate notes that would be logically in the same glyph
-    // but that are too far to be so
+    /* here we separate notes that would be logically in the same glyph
+     * but that are too far to be so */
     if (last_pitch) {
         if (current_pitch - last_pitch > MAX_INTERVAL
                 || current_pitch - last_pitch < -MAX_INTERVAL) {
@@ -548,7 +547,7 @@ static char gregorio_add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
     default:
         break;
     }
-    // end of the main switch
+    /* end of the main switch */
 
     if (current_glyph_type == G_UNDETERMINED) {
         /*
@@ -568,10 +567,10 @@ static char gregorio_add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
      * WARNING : Ugly section of the code, just some kind of patch for it to work
      * with fonts that can't handle large intervals.
      */
-    // here we separate notes that would be logically in the same glyph
-    // but that are too far to be so, we already said to the function that
-    // it was not the same glyph, there we must say that the previous
-    // glyph has ended.
+    /* here we separate notes that would be logically in the same glyph
+     * but that are too far to be so, we already said to the function that
+     * it was not the same glyph, there we must say that the previous
+     * glyph has ended. */
     if (last_pitch) {
         if (current_pitch - last_pitch > MAX_INTERVAL
                 || current_pitch - last_pitch < -MAX_INTERVAL) {
@@ -623,32 +622,33 @@ static char gregorio_add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
  *
 ****************************/
 
-// this function updates current_key with the new values (with clef changes)
+/* this function updates current_key with the new values (with clef changes) */
 
 gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
         int *current_key)
 {
-    // the first note of the current glyph, to be able to close it well:
-    // later we will cut the link (next_notes and previous_note) between
-    // this note and the previous one
+    /* the first note of the current glyph, to be able to close it well:
+     * later we will cut the link (next_notes and previous_note) between
+     * this note and the previous one */
     gregorio_note *current_glyph_first_note = current_note;
 
-    // the last glyph we have totally determined. It is automatically
-    // updated by close_glyph().
+    /* the last glyph we have totally determined. It is automatically
+     * updated by close_glyph(). */
     gregorio_glyph *last_glyph = NULL;
 
-    // type of the glyph we are currently determining
+    /* type of the glyph we are currently determining */
     gregorio_glyph_type current_glyph_type = G_UNDETERMINED;
     gregorio_glyph_type next_glyph_type = G_UNDETERMINED;
     char last_pitch = USELESS_VALUE;
-    // a variable for the signs of bars and to tell if a key is flatted or not
+    /* a variable for the signs of bars and to tell if a key is flatted or
+     * not */
     gregorio_note *next_note = NULL;
 
-    // determination of end of glyphs, see comments on
-    // gregorio_add_note_to_a_glyph
+    /* determination of end of glyphs, see comments on
+     * gregorio_add_note_to_a_glyph */
     gabc_determination end_of_glyph = DET_NO_END;
 
-    // a char representing the liquescentia of the current glyph
+    /* a char representing the liquescentia of the current glyph */
     gregorio_liquescentia liquescentia = L_NO_LIQUESCENTIA;
 
     if (current_note == NULL) {
@@ -704,7 +704,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                 break;
 
             case GRE_BAR:
-                // we calculate the signs of the bars
+                /* we calculate the signs of the bars */
                 if (current_note->signs == _V_EPISEMUS) {
                     sign = _V_EPISEMUS;
                 } else {
@@ -726,7 +726,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                 break;
 
             default:
-                // do nothing
+                /* do nothing */
                 break;
             }
 
@@ -770,8 +770,8 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                 current_note->u.note.liquescentia,
                 current_glyph_first_note, &end_of_glyph);
 
-        // patch to have good shapes in the special cases of pes quadratum and
-        // pes quilisma quadratum.
+        /* patch to have good shapes in the special cases of pes quadratum and
+         * pes quilisma quadratum. */
         switch (current_note->u.note.shape) {
         case S_QUADRATUM:
             current_note->u.note.shape = S_PUNCTUM;
@@ -782,12 +782,12 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
             break;
 
         default:
-            // do nothing
+            /* do nothing */
             break;
         }
 
-        // see comments on gregorio_add_note_to_a_glyph for the meaning of
-        // end_of_glyph
+        /* see comments on gregorio_add_note_to_a_glyph for the meaning of
+         * end_of_glyph */
         switch (end_of_glyph) {
         case DET_NO_END:
             current_glyph_type = next_glyph_type;
@@ -795,8 +795,8 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
              * we deal with liquescentia
              */
             if (is_liquescentia(current_note->u.note.liquescentia)) {
-                // special cases of oriscus auctus, treated like normal oriscus
-                // in some cases.
+                /* special cases of oriscus auctus, treated like normal oriscus
+                 * in some cases. */
                 if (current_note->u.note.shape == S_ORISCUS_AUCTUS
                         && current_note->next
                         && current_note->next->type == GRE_NOTE
@@ -808,7 +808,8 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                     current_note = next_note;
                     continue;
                 }
-                // special cases of the punctum inclinatum deminutus and auctus
+                /* special cases of the punctum inclinatum deminutus and
+                 * auctus */
                 if (current_note->u.note.shape == S_PUNCTUM_INCLINATUM) {
                     if (current_note->u.note.liquescentia == L_DEMINUTUS) {
                         current_note->u.note.shape =
@@ -846,7 +847,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                         break;
 
                     default:
-                        // do nothing
+                        /* do nothing */
                         break;
                     }
 
@@ -862,9 +863,8 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                     }
                 }
                 liquescentia += current_note->u.note.liquescentia;
-                /*
-                 * once again, only works with the good values in the header file
-                 */
+                /* once again, only works with the good values in the header
+                 * file */
                 close_glyph(&last_glyph, current_glyph_type,
                         &current_glyph_first_note, liquescentia, current_note);
                 current_glyph_type = G_UNDETERMINED;
@@ -874,7 +874,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
         case DET_END_OF_PREVIOUS:
             if (current_note->previous)
             {
-                // we don't want to close previous glyph twice
+                /* we don't want to close previous glyph twice */
                 close_glyph(&last_glyph, current_glyph_type,
                         &current_glyph_first_note, liquescentia,
                         current_note->previous);
@@ -882,14 +882,13 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
             current_glyph_type = next_glyph_type;
             liquescentia = L_NO_LIQUESCENTIA;
             last_pitch = USELESS_VALUE;
-            /*
-             * we deal with liquescentia
-             */
+            /* we deal with liquescentia */
             if (is_liquescentia(current_note->u.note.liquescentia))
-                // not an initio debilis, because we considered it in the first
-                // part...
+                /* not an initio debilis, because we considered it in the first
+                 * part... */
             {
-                // special cases of the punctum inclinatum deminutus and auctus
+                /* special cases of the punctum inclinatum deminutus and
+                 * auctus */
                 if (current_note->u.note.shape == S_PUNCTUM_INCLINATUM) {
                     if (current_note->u.note.liquescentia == L_DEMINUTUS) {
                         current_note->u.note.shape =
@@ -925,7 +924,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                         break;
 
                     default:
-                        // do nothing
+                        /* do nothing */
                         break;
                     }
 
@@ -947,18 +946,16 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
             break;
         case DET_END_OF_CURRENT:
             liquescentia += current_note->u.note.liquescentia;
-            /*
-             * once again, only works with the good values in the header file
-             */
+            /* once again, only works with the good values in the header file */
             close_glyph(&last_glyph, next_glyph_type,
                     &current_glyph_first_note, liquescentia, current_note);
             current_glyph_type = G_UNDETERMINED;
             liquescentia = L_NO_LIQUESCENTIA;
             break;
-        default:               // case DET_END_OF_BOTH:
+        default: /* case DET_END_OF_BOTH: */
             if (current_note->previous)
             {
-                // we don't want to close previous glyph twice
+                /* we don't want to close previous glyph twice */
                 close_glyph(&last_glyph, current_glyph_type,
                         &current_glyph_first_note, liquescentia,
                         current_note->previous);
@@ -972,7 +969,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
         }
 
         if (!next_note && current_glyph_type != G_UNDETERMINED) {
-            // we must end the determination here
+            /* we must end the determination here */
             close_glyph(&last_glyph, current_glyph_type,
                     &current_glyph_first_note, liquescentia, current_note);
         }
@@ -980,7 +977,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
         last_pitch = current_note->u.note.pitch;
         current_note = next_note;
     }
-    // end of while
+    /* end of while */
 
     gregorio_go_to_first_glyph(&last_glyph);
     return last_glyph;

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -20,8 +20,8 @@
 
 #include "config.h"
 #include <stdio.h>
-#include <stdbool.h>
 #include <ctype.h>              /* for tolower */
+#include "bool.h"
 #include "struct.h"
 #include "messages.h"
 

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -20,7 +20,7 @@
 
 #include "config.h"
 #include <stdio.h>
-#include <ctype.h>              /* for tolower */
+#include <ctype.h> /* for tolower */
 #include "bool.h"
 #include "struct.h"
 #include "messages.h"
@@ -43,7 +43,7 @@ static int brace_var_counter;
 static int overbrace_var, underbrace_var;
 static const char *overbrace_var_kind;
 
-static inline char pitch_letter_to_height(const char pitch) {
+static __inline char pitch_letter_to_height(const char pitch) {
     return pitch - 'a' + LOWEST_PITCH;
 }
 
@@ -56,7 +56,7 @@ static gregorio_shape punctum(const char pitch)
     }
 }
 
-static inline void lex_add_note(int i, gregorio_shape shape, char signs,
+static __inline void lex_add_note(int i, gregorio_shape shape, char signs,
         char liquescentia)
 {
     nbof_isolated_episemus = 0;
@@ -65,13 +65,13 @@ static inline void lex_add_note(int i, gregorio_shape shape, char signs,
             shape, signs, liquescentia, NULL, &notes_lloc);
 }
 
-static inline void add_bar_as_note(gregorio_bar bar)
+static __inline void add_bar_as_note(gregorio_bar bar)
 {
     nbof_isolated_episemus = 0;
     gregorio_add_bar_as_note(&current_note, bar, &notes_lloc);
 }
 
-static inline void error(void)
+static __inline void error(void)
 {
     gregorio_messagef("gabc_notes_determination", VERBOSITY_ERROR, 0,
             _("undefined macro used: m%d"),
@@ -85,7 +85,7 @@ static void add_h_episemus(void) {
 
     char *ptr = gabc_notes_determination_text;
     char current;
-    // first character is the underscore
+    /* first character is the underscore */
     while ((current = *(++ptr))) {
         switch(current) {
         case '0':
@@ -131,7 +131,7 @@ static void add_sign(gregorio_sign sign) {
     gregorio_add_sign(current_note, sign, vposition);
 }
 
-static inline void add_alteration(const gregorio_type type) {
+static __inline void add_alteration(const gregorio_type type) {
     gregorio_add_alteration_as_note(&current_note, type,
             pitch_letter_to_height(gabc_notes_determination_text[0]),
             &notes_lloc);
@@ -174,7 +174,7 @@ static inline void add_alteration(const gregorio_type type) {
         BEGIN(INITIAL);
     }
 <comments>[^\n\r]* {
-        //ignored
+        /* ignored */
     }
 <INITIAL>\[cs: {
         BEGIN(choralsign);
@@ -678,13 +678,13 @@ gregorio_note *gabc_det_notes_from_string(char *str, char *newmacros[10],
     notes_lloc.first_line = loc->first_line;
     notes_lloc.first_column = loc->first_column;
     notes_lloc.first_offset = loc->first_offset;
-    // yes... I do mean to set values from loc->first_*
+    /* yes... I do mean to set values from loc->first_* */
     notes_lloc.last_line = loc->first_line;
     notes_lloc.last_column = loc->first_column;
     notes_lloc.last_offset = loc->first_offset;
 
-    // a small optimization could uccur here: we could do it only once at the
-    // beginning of the score, not at each syllable
+    /* a small optimization could uccur here: we could do it only once at the
+     * beginning of the score, not at each syllable */
     for (i = 0; i < 10; i++) {
         notesmacros[i] = newmacros[i];
     }

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -24,6 +24,7 @@
 #include "bool.h"
 #include "struct.h"
 #include "messages.h"
+#include "support.h"
 
 #include "gabc.h"
 
@@ -206,7 +207,8 @@ static inline void add_alteration(const gregorio_type type) {
             char_for_brace = gabc_notes_determination_text[4]-'0';
             overbrace_var = ++brace_var_counter;
             overbrace_var_kind = "ob";
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{1}"
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
@@ -220,7 +222,8 @@ static inline void add_alteration(const gregorio_type type) {
         } else {
             char_for_brace = gabc_notes_determination_text[4]-'0';
             underbrace_var = ++brace_var_counter;
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{1}"
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreUnderBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     underbrace_var, char_for_brace, underbrace_var, char_for_brace);
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
@@ -235,7 +238,8 @@ static inline void add_alteration(const gregorio_type type) {
             char_for_brace = gabc_notes_determination_text[5]-'0';
             overbrace_var = ++brace_var_counter;
             overbrace_var_kind = "ocb";
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{1}"
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{0}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
@@ -250,7 +254,8 @@ static inline void add_alteration(const gregorio_type type) {
             char_for_brace = gabc_notes_determination_text[6]-'0';
             overbrace_var = ++brace_var_counter;
             overbrace_var_kind = "ocba";
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{1}"
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{1}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
@@ -268,8 +273,9 @@ static inline void add_alteration(const gregorio_type type) {
                               overbrace_var_kind);
         } else {
             char_for_brace = gabc_notes_determination_text[4]-'0';
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{2}",
-                    overbrace_var, char_for_brace);
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
+                    char_for_brace);
             overbrace_var = 0;
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
         }
@@ -281,8 +287,9 @@ static inline void add_alteration(const gregorio_type type) {
                                 "variable underbrace start"));
         } else {
             char_for_brace = gabc_notes_determination_text[4]-'0';
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{2}",
-                    underbrace_var, char_for_brace);
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{2}", underbrace_var,
+                    char_for_brace);
             underbrace_var = 0;
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
         }
@@ -299,8 +306,9 @@ static inline void add_alteration(const gregorio_type type) {
                               overbrace_var_kind);
         } else {
             char_for_brace = gabc_notes_determination_text[5]-'0';
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{2}",
-                    overbrace_var, char_for_brace);
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
+                    char_for_brace);
             overbrace_var = 0;
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
         }
@@ -317,8 +325,9 @@ static inline void add_alteration(const gregorio_type type) {
                               overbrace_var_kind);
         } else {
             char_for_brace = gabc_notes_determination_text[6]-'0';
-            snprintf(tempstr, sizeof tempstr, "\\GreVarBraceSavePos{%d}{%d}{2}",
-                    overbrace_var, char_for_brace);
+            gregorio_snprintf(tempstr, sizeof tempstr,
+                    "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
+                    char_for_brace);
             overbrace_var = 0;
             gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
         }
@@ -369,22 +378,26 @@ static inline void add_alteration(const gregorio_type type) {
         gregorio_add_nlba_as_note(&current_note, NLBA_END, &notes_lloc);
     }
 <overbrace>[^\]]+ {
-        snprintf(tempstr, sizeof tempstr, "\\GreOverBrace{%s}{0pt}{0pt}{%d}",
+        gregorio_snprintf(tempstr, sizeof tempstr,
+                "\\GreOverBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
         gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
     }
 <underbrace>[^\]]+ {
-        snprintf(tempstr, sizeof tempstr, "\\GreUnderBrace{%s}{0pt}{0pt}{%d}",
+        gregorio_snprintf(tempstr, sizeof tempstr,
+                "\\GreUnderBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
         gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
     }
 <overcurlybrace>[^\]]+ {
-        snprintf(tempstr, sizeof tempstr, "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{0}",
+        gregorio_snprintf(tempstr, sizeof tempstr,
+                "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{0}",
                 gabc_notes_determination_text, char_for_brace);
         gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
     }
 <overcurlyaccentusbrace>[^\]]+ {
-        snprintf(tempstr, sizeof tempstr, "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{1}",
+        gregorio_snprintf(tempstr, sizeof tempstr,
+                "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{1}",
                 gabc_notes_determination_text, char_for_brace);
         gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
     }

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -226,10 +226,9 @@ semicolon. */
        return END_OF_DEFINITIONS;
     }
 <INITIAL>. {
-        char *dirtyvar = malloc(71*sizeof(char));
-        snprintf(dirtyvar,70,_("unrecognized character: \"%c\" in definition part"),
-                 gabc_score_determination_text[0]);
-        gregorio_message (dirtyvar, "det_score", VERBOSITY_ERROR, 0);
+        gregorio_messagef("det_score", VERBOSITY_ERROR, 0,
+                _("unrecognized character: \"%c\" in definition part"),
+                gabc_score_determination_text[0]);
     }
 <score>[^\{\}\(\[\]<%]+ {
         gabc_score_determination_lval.text = strdup(gabc_score_determination_text);

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -101,10 +101,10 @@ semicolon. */
 
 %%
 <INITIAL>^(\xBB|\xEF|\xBF)* {
-        //BOM written by a lot of windows softwares when they write UTF-8
+        /* BOM written by a lot of windows softwares when they write UTF-8 */
     }
 <INITIAL>^[\n\r]+ {
-        // ignoring empty lines
+        /* ignoring empty lines */
     }
 <INITIAL>^[\%#] {
         BEGIN(inicomments);
@@ -113,7 +113,7 @@ semicolon. */
         BEGIN(INITIAL);
     }
 <inicomments>[^\n\r]* {
-        //ignored
+        /* ignored */
     }
 <INITIAL>:(\ )? {
         BEGIN(attribute);
@@ -335,7 +335,7 @@ semicolon. */
         BEGIN(score);
     }
 <comments>[^\n\r]* {
-        //ignored
+        /* ignored */
     }
 <style,score><v> {
         BEGIN(verb);

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -29,8 +29,8 @@
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <assert.h>
+#include "bool.h"
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -67,8 +67,6 @@
  * 
  */
 
-// the error string
-static char error[200];
 // the score that we will determine and return
 static gregorio_score *score;
 // an array of elements that we will use for each syllable
@@ -311,21 +309,21 @@ static void end_definitions(void)
         score->number_of_voices = voice;
     } else {
         if (number_of_voices > voice) {
-            snprintf(error, 62, ngt_("not enough voice infos found: %d found, "
-                    "%d waited, %d assumed", "not enough voice infos found: %d "
-                    "found, %d waited, %d assumed", voice), voice,
+            gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                    ngt_("not enough voice infos found: %d found, %d waited, "
+                    "%d assumed", "not enough voice infos found: %d found, %d "
+                    "waited, %d assumed", voice), voice,
                     number_of_voices, voice);
-            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
             score->number_of_voices = voice;
             number_of_voices = voice;
         } else {
             if (number_of_voices < voice) {
-                snprintf(error, 62, ngt_("too many voice infos found: %d "
-                        "found, %d waited, %d assumed", "not enough voice "
-                        "infos found: %d found, %d waited, %d assumed",
+                gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                        ngt_("too many voice infos found: %d found, %d "
+                        "waited, %d assumed", "not enough voice infos found: "
+                        "%d found, %d waited, %d assumed",
                         number_of_voices), voice, number_of_voices,
                         number_of_voices);
-                gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
             }
         }
     }
@@ -665,9 +663,9 @@ number_of_voices_definition:
     NUMBER_OF_VOICES attribute {
         number_of_voices=atoi($2.text);
         if (number_of_voices > MAX_NUMBER_OF_VOICES) {
-            snprintf(error, 40, _("can't define %d voices, maximum is %d"),
-                     number_of_voices, MAX_NUMBER_OF_VOICES);
-            gregorio_message(error,"det_score", VERBOSITY_WARNING, 0);
+            gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                    _("can't define %d voices, maximum is %d"),
+                    number_of_voices, MAX_NUMBER_OF_VOICES);
         }
         gregorio_set_score_number_of_voices (score, number_of_voices);
     }
@@ -810,9 +808,9 @@ initial_style_definition:
 annotation_definition:
     ANNOTATION attribute {
         if (score->annotation [MAX_ANNOTATIONS - 1]) {
-            snprintf(error,99,_("too many definitions of annotation found, "
-                                "only the first %d will be taken"), MAX_ANNOTATIONS);
-            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
+            gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                    _("too many definitions of annotation found, only the "
+                    "first %d will be taken"), MAX_ANNOTATIONS);
         }
         gregorio_set_score_annotation (score, $2.text);
     }
@@ -879,10 +877,9 @@ transcription_date_definition:
 style_definition:
     STYLE attribute {
         if (current_voice_info->style) {
-            snprintf(error, 99, _("several definitions of style found for "
-                    "voice %d, only the last will be taken into consideration"),
-                    voice);
-            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
+            gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                    _("several definitions of style found for voice %d, only "
+                    "the last will be taken into consideration"), voice);
         }
         gregorio_set_voice_style (current_voice_info, $2.text);
     }
@@ -891,10 +888,10 @@ style_definition:
 virgula_position_definition:
     VIRGULA_POSITION attribute {
         if (current_voice_info->virgula_position) {
-            snprintf(error, 105, _("several definitions of virgula position "
-                    "found for voice %d, only the last will be taken into "
-                    "consideration"), voice);
-            gregorio_message(error, "det_score", VERBOSITY_WARNING, 0);
+            gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                    _("several definitions of virgula position found for "
+                    "voice %d, only the last will be taken into consideration"),
+                    voice);
         }
         gregorio_set_voice_virgula_position (current_voice_info, $2.text);
     }
@@ -970,18 +967,17 @@ note:
             free($1.text);
         }
         else {
-            snprintf(error,105,ngt_("too many voices in note : %d found, %d expected",
-                                    "too many voices in note : %d found, %d expected",
-                                    number_of_voices), voice+1, number_of_voices);
-            gregorio_message(error, "det_score", VERBOSITY_ERROR, 0);
+            gregorio_messagef("det_score", VERBOSITY_ERROR, 0,
+                    ngt_("too many voices in note : %d found, %d expected",
+                    "too many voices in note : %d found, %d expected",
+                    number_of_voices), voice+1, number_of_voices);
         }
         if (voice<number_of_voices-1) {
-            snprintf(error,105,ngt_("not enough voices in note : %d found, %d "
-                                    "expected, completing with empty neume",
-                                    "not enough voices in note : %d found, "
-                                    "%d expected, completing with empty neume",
-                                    voice+1), voice+1, number_of_voices);
-            gregorio_message(error, "det_score", VERBOSITY_INFO, 0);
+            gregorio_messagef("det_score", VERBOSITY_INFO, 0,
+                    ngt_("not enough voices in note : %d found, %d expected, "
+                    "completing with empty neume", "not enough voices in note "
+                    ": %d found, %d expected, completing with empty neume",
+                    voice+1), voice+1, number_of_voices);
             complete_with_nulls(voice);
         }
         voice=0;
@@ -993,18 +989,17 @@ note:
             free($1.text);
         }
         else {
-            snprintf(error,105,ngt_("too many voices in note : %d found, %d expected",
-                                    "too many voices in note : %d found, %d expected",
-                                    number_of_voices), voice+1, number_of_voices);
-            gregorio_message(error, "det_score", VERBOSITY_ERROR, 0);
+            gregorio_messagef("det_score", VERBOSITY_ERROR, 0,
+                    ngt_("too many voices in note : %d found, %d expected",
+                    "too many voices in note : %d found, %d expected",
+                    number_of_voices), voice+1, number_of_voices);
         }
         if (voice<number_of_voices-1) {
-            snprintf(error,105,ngt_("not enough voices in note : %d found, %d "
-                                    "expected, completing with empty neume",
-                                    "not enough voices in note : %d found, %d "
-                                    "expected, completing with empty neume",
-                                    voice+1), voice+1, number_of_voices);
-            gregorio_message(error, "det_score", VERBOSITY_INFO, 0);
+            gregorio_messagef("det_score", VERBOSITY_INFO, 0,
+                    ngt_("not enough voices in note : %d found, %d expected, "
+                    "completing with empty neume", "not enough voices in note "
+                    ": %d found, %d expected, completing with empty neume",
+                    voice+1), voice+1, number_of_voices);
             complete_with_nulls(voice);
         }
         voice=0;
@@ -1018,10 +1013,10 @@ note:
             voice++;
         }
         else {
-            snprintf(error,105,ngt_("too many voices in note : %d found, %d expected",
-                                    "too many voices in note : %d found, %d expected",
-                                    number_of_voices), voice+1, number_of_voices);
-            gregorio_message(error, "det_score", VERBOSITY_ERROR, 0);
+            gregorio_messagef("det_score", VERBOSITY_ERROR, 0,
+                    ngt_("too many voices in note : %d found, %d expected",
+                    "too many voices in note : %d found, %d expected",
+                    number_of_voices), voice+1, number_of_voices);
         }
     }
     | NOTES NABC_CUT {

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -56,9 +56,9 @@
 #include "gabc-score-determination.h"
 #include "gabc-score-determination-l.h"
 
-// uncomment it if you want to have an interactive shell to understand the
-// details on how bison works for a certain input
-// int gabc_score_determination_debug=1;
+/* uncomment it if you want to have an interactive shell to understand the
+ * details on how bison works for a certain input */
+/* int gabc_score_determination_debug=1; */
 
 /*
  * 
@@ -67,16 +67,16 @@
  * 
  */
 
-// the score that we will determine and return
+/* the score that we will determine and return */
 static gregorio_score *score;
-// an array of elements that we will use for each syllable
+/* an array of elements that we will use for each syllable */
 static gregorio_element **elements;
 gregorio_element *current_element;
-// a table containing the macros to use in gabc file
+/* a table containing the macros to use in gabc file */
 static char *macros[10];
-// forward declaration of the flex/bison process function
+/* forward declaration of the flex/bison process function */
 static int gabc_score_determination_parse(void);
-// other variables that we will have to use
+/* other variables that we will have to use */
 static gregorio_character *current_character;
 static gregorio_character *first_text_character;
 static gregorio_character *first_translation_character;
@@ -86,15 +86,15 @@ static gregorio_euouae euouae;
 static gregorio_voice_info *current_voice_info;
 static int number_of_voices;
 static int voice;
-// see comments on text to understand this
+/* see comments on text to understand this */
 static gregorio_center_determination center_is_determined;
-// current_key is... the current key... updated by each notes determination
-// (for key changes)
+/* current_key is... the current key... updated by each notes determination
+ * (for key changes) */
 static int current_key = DEFAULT_KEY;
 static bool got_language = false;
 static struct sha1_ctx digester;
 
-static inline void check_multiple(const char *name, bool exists) {
+static __inline void check_multiple(const char *name, bool exists) {
     if (exists) {
         gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
                 _("several %s definitions found, only the last will be taken "
@@ -128,7 +128,7 @@ static void gabc_fix_custos(gregorio_score *score_to_check)
         while (current_element) {
             if (current_element->type == GRE_CUSTO) {
                 custo_element = current_element;
-                // we look for the key
+                /* we look for the key */
                 while (current_element) {
                     switch (current_element->type) {
                     case GRE_C_KEY_CHANGE:
@@ -218,13 +218,13 @@ static int check_infos_integrity(gregorio_score *score_to_check)
 static void initialize_variables(void)
 {
     int i;
-    // build a brand new empty score
+    /* build a brand new empty score */
     score = gregorio_new_score();
-    // initialization of the first voice info to an empty voice info
+    /* initialization of the first voice info to an empty voice info */
     current_voice_info = NULL;
     gregorio_add_voice_info(&current_voice_info);
     score->first_voice_info = current_voice_info;
-    // other initializations
+    /* other initializations */
     number_of_voices = 0;
     voice = 1;
     current_character = NULL;
@@ -253,7 +253,7 @@ static void free_variables(void)
     }
 }
 
-// see whether a voice_info is empty
+/* see whether a voice_info is empty */
 static int voice_info_is_not_empty(const gregorio_voice_info *voice_info)
 {
     return (voice_info->initial_key != 5 || voice_info->style
@@ -265,8 +265,8 @@ static int voice_info_is_not_empty(const gregorio_voice_info *voice_info)
  */
 static void next_voice_info(void)
 {
-    // we must do this test in the case where there would be a "--" before
-    // first_declarations
+    /* we must do this test in the case where there would be a "--" before
+     * first_declarations */
     if (voice_info_is_not_empty(current_voice_info)) {
         gregorio_add_voice_info(&current_voice_info);
         voice++;
@@ -327,8 +327,8 @@ static void end_definitions(void)
             }
         }
     }
-    voice = 0;                  // voice is now voice-1, so that it can be the
-    // index of elements
+    /* voice is now voice-1, so that it can be the index of elements */
+    voice = 0;
     elements = (gregorio_element **) malloc(number_of_voices *
             sizeof(gregorio_element *));
     for (i = 0; i < number_of_voices; i++) {
@@ -398,7 +398,7 @@ static void gregorio_set_translation_center_beginning(
         }
         syllable = syllable->previous_syllable;
     }
-    // we didn't find any beginning...
+    /* we didn't find any beginning... */
     gregorio_message("encountering translation centering end but cannot find "
             "translation centering beginning...",
             "set_translation_center_beginning", VERBOSITY_ERROR, 0);
@@ -409,9 +409,9 @@ static void rebuild_characters(gregorio_character **param_character,
         gregorio_center_determination center_is_determined)
 {
     bool has_initial = score->initial_style != NO_INITIAL;
-    // we rebuild the first syllable text if it is the first syllable, or if
-    // it is the second when the first has no text.
-    // it is a patch for cases like (c4) Al(ab)le(ab)
+    /* we rebuild the first syllable text if it is the first syllable, or if
+     * it is the second when the first has no text.
+     * it is a patch for cases like (c4) Al(ab)le(ab) */
     if ((!score->first_syllable && has_initial && current_character)
             || (current_syllable && !current_syllable->previous_syllable
             && !current_syllable->text && current_character)) {
@@ -433,13 +433,13 @@ static void close_syllable(YYLTYPE *loc)
             first_text_character, first_translation_character, position,
             abovelinestext, translation_type, no_linebreak_area, euouae, loc);
     if (!score->first_syllable) {
-        // we rebuild the first syllable if we have to
+        /* we rebuild the first syllable if we have to */
         score->first_syllable = current_syllable;
     }
     if (translation_type == TR_WITH_CENTER_END) {
         gregorio_set_translation_center_beginning(current_syllable);
     }
-    // we update the position
+    /* we update the position */
     if (position == WORD_BEGINNING) {
         position = WORD_MIDDLE;
     }
@@ -460,13 +460,13 @@ static void close_syllable(YYLTYPE *loc)
     current_element = NULL;
 }
 
-// a function called when we see a [, basically, all characters are added to
-// the translation pointer instead of the text pointer
+/* a function called when we see a [, basically, all characters are added to
+ * the translation pointer instead of the text pointer */
 static void start_translation(unsigned char asked_translation_type)
 {
     rebuild_characters(&current_character, center_is_determined);
     first_text_character = current_character;
-    // the middle letters of the translation have no sense
+    /* the middle letters of the translation have no sense */
     center_is_determined = CENTER_FULLY_DETERMINED;
     current_character = NULL;
     translation_type = asked_translation_type;
@@ -550,11 +550,12 @@ void gabc_digest(const void *const buf, const size_t size)
 
 gregorio_score *gabc_read_score(FILE *f_in)
 {
-    // compute the SHA-1 digest while parsing, for I/O efficiency
+    /* compute the SHA-1 digest while parsing, for I/O efficiency */
     sha1_init_ctx(&digester);
-    // digest GREGORIO_VERSION to get a different value when the version changes
+    /* digest GREGORIO_VERSION to get a different value when the version
+    changes */
     sha1_process_bytes(GREGORIO_VERSION, strlen(GREGORIO_VERSION), &digester);
-    // the input file that flex will parse
+    /* the input file that flex will parse */
     gabc_score_determination_in = f_in;
     if (!f_in) {
         gregorio_message(_("can't read stream from argument, returning NULL "
@@ -562,13 +563,13 @@ gregorio_score *gabc_read_score(FILE *f_in)
         return NULL;
     }
     initialize_variables();
-    // the flex/bison main call, it will build the score (that we have
-    // initialized)
+    /* the flex/bison main call, it will build the score (that we have
+     * initialized) */
     gabc_score_determination_parse();
     gregorio_fix_initial_keys(score, DEFAULT_KEY);
     gabc_fix_custos(score);
     free_variables();
-    // the we check the validity and integrity of the score we have built.
+    /* the we check the validity and integrity of the score we have built. */
     if (!check_score_integrity(score)) {
         gregorio_free_score(score);
         score = NULL;
@@ -764,9 +765,9 @@ arranger_definition:
 
 gabc_version_definition:
     GABC_VERSION attribute {
-        // So far this handling of the version is rudimentary.  When
-        // we start supporting multiple input versions, it will become
-        // more complex.  For the moment, just issue a warning.
+        /* So far this handling of the version is rudimentary.  When
+         * we start supporting multiple input versions, it will become
+         * more complex.  For the moment, just issue a warning. */
         if (strcmp ($2.text, GABC_CURRENT_VERSION) != 0) {
             gregorio_message(_("gabc-version is not the current one "
                     GABC_CURRENT_VERSION " ; there may be problems"),
@@ -863,7 +864,7 @@ transcriber_definition:
     TRANSCRIBER attribute {
         check_multiple("transcriber", score->si.transcriber);
         gregorio_set_score_transcriber (score, $2.text);
-        //free($2.text);
+        /* free($2.text); */
     }
     ;
 
@@ -900,7 +901,7 @@ virgula_position_definition:
 
 generated_by_definition:
     GENERATED_BY attribute {
-        //set_voice_generated_by (current_voice_info, $2.text);
+        /* set_voice_generated_by (current_voice_info, $2.text); */
     }
     ;
 

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #include <ctype.h>
 #include <stdio.h>
-#include <string.h>             // for strchr
+#include <string.h> /* for strchr */
 #include "bool.h"
 #include "characters.h"
 #include "struct.h"
@@ -33,7 +33,7 @@
 
 #include "gabc.h"
 
-static inline char pitch_letter(const char height) {
+static __inline char pitch_letter(const char height) {
     return height + 'a' - LOWEST_PITCH;
 }
 
@@ -67,7 +67,7 @@ static void gabc_write_voice_info(FILE *f, gregorio_voice_info *voice_info)
     if (voice_info->virgula_position) {
         fprintf(f, "virgula-position: %s;\n", voice_info->virgula_position);
     }
-    // The clef, voice_info->initial_key, is now output in the gabc proper.
+    /* The clef, voice_info->initial_key, is now output in the gabc proper. */
 }
 
 /*
@@ -254,8 +254,8 @@ static void gabc_write_space(FILE *f, char type)
         fprintf(f, "!/");
         break;
     case SP_NEUMATIC_CUT:
-        // do not uncomment it, the code is strangely done but it works
-        // fprintf (f, "/");
+        /* do not uncomment it, the code is strangely done but it works */
+        /* fprintf (f, "/"); */
         break;
     default:
         gregorio_message(_("space type is unknown"), "gabc_write_space",
@@ -313,7 +313,7 @@ static void gabc_write_bar(FILE *f, char type)
     }
 }
 
-// writing the signs of a bar
+/* writing the signs of a bar */
 
 static void gabc_write_bar_signs(FILE *f, char type)
 {
@@ -350,7 +350,7 @@ static void gabc_hepisemus(FILE *f, const char *prefix, bool connect,
         fprintf(f, "5");
         break;
     case H_NORMAL:
-        // nothing to print
+        /* nothing to print */
         break;
     }
 }
@@ -407,7 +407,7 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         shape = note->u.note.shape;
     }
     switch (shape) {
-        // first we write the letters that determine the shapes
+        /* first we write the letters that determine the shapes */
     case S_PUNCTUM:
         fprintf(f, "%c", pitch_letter(note->u.note.pitch));
         break;
@@ -451,11 +451,11 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         break;
     case S_ORISCUS_AUCTUS:
         fprintf(f, "%co", pitch_letter(note->u.note.pitch));
-        // we consider that the AUCTUS is also in the liquescentia
+        /* we consider that the AUCTUS is also in the liquescentia */
         break;
     case S_ORISCUS_DEMINUTUS:
         fprintf(f, "%co", pitch_letter(note->u.note.pitch));
-        // we consider that the AUCTUS is also in the liquescentia
+        /* we consider that the AUCTUS is also in the liquescentia */
         break;
     case S_QUILISMA:
         fprintf(f, "%cw", pitch_letter(note->u.note.pitch));
@@ -612,7 +612,7 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
         current_note = glyph->u.notes.first_note;
         while (current_note) {
             gabc_write_gregorio_note(f, current_note, glyph->u.notes.glyph_type);
-            // third argument necessary for the special shape pes quadratum
+            /* third argument necessary for the special shape pes quadratum */
             current_note = current_note->next;
         }
         gabc_write_end_liquescentia(f, glyph->u.notes.liquescentia);
@@ -699,7 +699,7 @@ static void gabc_write_gregorio_elements(FILE *f, gregorio_element *element)
 {
     while (element) {
         gabc_write_gregorio_element(f, element);
-        // we don't want a bar after an end of line
+        /* we don't want a bar after an end of line */
         if (element->type != GRE_END_OF_LINE
             && (element->type != GRE_SPACE
                 || (element->type == GRE_SPACE
@@ -727,8 +727,8 @@ static void gabc_write_gregorio_syllable(FILE *f, gregorio_syllable *syllable,
         return;
     }
     if (syllable->text) {
-        // we call the magic function (defined in struct_utils.c), that will
-        // write our text.
+        /* we call the magic function (defined in struct_utils.c), that will
+         * write our text. */
         gregorio_write_text(false, syllable->text, f,
                             (&gabc_write_verb),
                             (&gabc_print_char),
@@ -746,19 +746,18 @@ static void gabc_write_gregorio_syllable(FILE *f, gregorio_syllable *syllable,
     }
     fprintf(f, "(");
     while (voice < number_of_voices - 1) {
-        // we enter this loop only in polyphony
+        /* we enter this loop only in polyphony */
         gabc_write_gregorio_elements(f, syllable->elements[voice]);
         fprintf(f, "&");
         voice++;
     }
-    // we write all the elements of the syllable.
+    /* we write all the elements of the syllable. */
     gabc_write_gregorio_elements(f, syllable->elements[voice]);
     if (syllable->position == WORD_END
         || syllable->position == WORD_ONE_SYLLABLE
         || gregorio_is_only_special(syllable->elements[0]))
-        // we assume here that if the first voice is only special, all will be
-        // only 
-        // specials too
+        /* we assume here that if the first voice is only special, all will be
+         * only specials too */
     {
         fprintf(f, ") ");
     } else {
@@ -800,10 +799,10 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     gabc_write_str_attribute(f, "meter", score->meter);
     gabc_write_str_attribute(f, "commentary", score->commentary);
     gabc_write_str_attribute(f, "arranger", score->arranger);
-    // We always create gabc of the current version; this is not derived
-    // from the input.
+    /* We always create gabc of the current version; this is not derived
+     * from the input. */
     fprintf(f, "gabc-version: %s;\n", GABC_CURRENT_VERSION);
-    // And since the gabc is generated by this program, note this.
+    /* And since the gabc is generated by this program, note this. */
     fprintf(f, "generated-by: %s %s;\n", "gregorio", GREGORIO_VERSION);
     gabc_write_str_attribute(f, "author", score->si.author);
     gabc_write_str_attribute(f, "date", score->si.date);
@@ -849,7 +848,7 @@ void gabc_write_score(FILE *f, gregorio_score *score)
             }
         }
     }
-    // at present we only allow for one clef at the start of the gabc
+    /* at present we only allow for one clef at the start of the gabc */
     gregorio_det_step_and_line_from_key(score->first_voice_info->initial_key,
                                         &step, &line);
     if (score->first_voice_info->flatted_key) {
@@ -858,7 +857,7 @@ void gabc_write_score(FILE *f, gregorio_score *score)
         fprintf(f, "(%c%d)", step, line);
     }
     syllable = score->first_syllable;
-    // the we write every syllable
+    /* the we write every syllable */
     while (syllable) {
         gabc_write_gregorio_syllable(f, syllable, score->number_of_voices);
         syllable = syllable->next_syllable;
@@ -866,4 +865,4 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     fprintf(f, "\n");
 }
 
-// And that's it... not really hard isn't it?
+/* And that's it... not really hard isn't it? */

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -24,7 +24,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>             // for strchr
-#include <stdbool.h>
+#include "bool.h"
 #include "characters.h"
 #include "struct.h"
 #include "unicode.h"

--- a/src/gabc/gabc.h
+++ b/src/gabc/gabc.h
@@ -24,7 +24,7 @@
 
 #include "struct.h"
 
-// functions to read gabc
+/* functions to read gabc */
 gregorio_note *gabc_det_notes_from_string(char *str, char *macros[10],
         gregorio_scanner_location *loc);
 gregorio_element *gabc_det_elements_from_string(char *str, int *current_key,
@@ -35,38 +35,41 @@ void gabc_digest(const void *buf, size_t size);
 int gabc_score_determination_lex_destroy(void);
 int gabc_notes_determination_lex_destroy(void);
 
-// see comments on gregorio_add_note_to_a_glyph for meaning of these variables
+/* see comments on gregorio_add_note_to_a_glyph for meaning of these
+ * variables */
 typedef enum gabc_determination {
     DET_NO_END,
     DET_END_OF_CURRENT,
     DET_END_OF_PREVIOUS,
-    DET_END_OF_BOTH,
+    DET_END_OF_BOTH
 } gabc_determination;
 
-// defines the maximal interval between two notes of the same glyph
+/* defines the maximal interval between two notes of the same glyph */
 #define MAX_INTERVAL 5
 
-static inline void gabc_update_location(gregorio_scanner_location *const loc,
+static __inline void gabc_update_location(gregorio_scanner_location *const loc,
         const char *const bytes, const size_t length)
 {
-    // to be compatible with LilyPond, this algorithm is based on Lilypond's
-    // Source_file::get_counts
+    size_t i;
 
-    // possible future enhancement: make the tabstop size configurable
+    /* to be compatible with LilyPond, this algorithm is based on Lilypond's
+     * Source_file::get_counts */
+
+    /* possible future enhancement: make the tabstop size configurable */
 
     loc->first_line = loc->last_line;
     loc->first_column = loc->last_column;
     loc->first_offset = loc->last_offset;
 
-    for (size_t i = 0; i < length; ++i) {
+    for (i = 0; i < length; ++i) {
         if (bytes[i] == '\n') {
             ++loc->last_line;
             loc->last_column = 0;
             loc->last_offset = 0;
         } else if (((unsigned char)bytes[i] & 0xc0u) != 0x80u) {
-            // if two highest bits are 1 and 0, it's a continuation byte,
-            // so count everything else, which is either a single-byte
-            // character or the first byte of a multi-byte sequence
+            /* if two highest bits are 1 and 0, it's a continuation byte,
+             * so count everything else, which is either a single-byte
+             * character or the first byte of a multi-byte sequence */
 
             if (bytes[i] == '\t') {
                 loc->last_column = (loc->last_column / 8 + 1) * 8;

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -34,6 +34,7 @@
 #include "plugins.h"
 #include "messages.h"
 #include "characters.h"
+#include "support.h"
 #include "gabc/gabc.h"
 #include "vowel/vowel.h"
 
@@ -126,7 +127,7 @@ static char *get_base_filename(char *fbasename)
     }
     l = strlen(fbasename) - strlen(p);
     ret = (char *) malloc((l + 1) * sizeof(char));
-    snprintf(ret, l + 1, "%s", fbasename);
+    gregorio_snprintf(ret, l + 1, "%s", fbasename);
     ret[l] = '\0';
     return ret;
 }

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -23,11 +23,13 @@
 #include <stdlib.h>
 #ifdef USE_KPSE
 #include <kpathsea/kpathsea.h>
+#define gregorio_basename xbasename
 #else
 #include <getopt.h>
+#include <libgen.h> /* for basename */
+#define gregorio_basename basename
 #endif
-#include <libgen.h>             /* for basename */
-#include <string.h>             /* for strcmp */
+#include <string.h> /* for strcmp */
 #include <locale.h>
 #include <limits.h>
 #include "struct.h"
@@ -558,7 +560,7 @@ int main(int argc, char **argv)
                     input_file_name);
             exit(-1);
         }
-        gregorio_set_file_name(basename(input_file_name));
+        gregorio_set_file_name(gregorio_basename(input_file_name));
         if (point_and_click) {
             point_and_click_filename = encode_point_and_click_filename(
                     input_file_name);

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
                 exit(-1);
             }
         #endif
-        output_file = fopen(output_file_name, "w");
+        output_file = fopen(output_file_name, "wb");
         if (!output_file) {
             fprintf(stderr, "error: can't write in file %s",
                     output_file_name);
@@ -571,7 +571,7 @@ int main(int argc, char **argv)
         error_file = stderr;
         gregorio_set_error_out(error_file);
     } else {
-        error_file = fopen(error_file_name, "w");
+        error_file = fopen(error_file_name, "wb");
         if (!error_file) {
             fprintf(stderr, "error: can't open file %s for writing\n",
                     error_file_name);

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -57,7 +57,7 @@ typedef enum gregorio_file_format {
 #define DEFAULT_OUTPUT_FORMAT   GTEX
 
 // realpath is not in mingw32
-#ifdef __MINGW32__
+#ifdef _WIN32
 #ifndef PATH_MAX
 #define PATH_MAX _MAX_PATH
 #endif
@@ -70,7 +70,7 @@ static char *define_path(char *current_directory, char *string)
     char *file_name;
     char temp_name[PATH_MAX];
     char *base_name;
-#ifdef __MINGW32__
+#ifdef _WIN32
     char *last_backslash;
 #endif
 
@@ -78,7 +78,7 @@ static char *define_path(char *current_directory, char *string)
 
     strcpy(temp_name, string);
     base_name = strrchr(temp_name, '/');
-#ifdef __MINGW32__
+#ifdef _WIN32
     last_backslash = strrchr(temp_name, '\\');
     if (last_backslash > base_name) {
         base_name = last_backslash;
@@ -236,12 +236,12 @@ static char *encode_point_and_click_filename(char *input_file_name)
     // 2 extra characters for a possible leading slash and final NUL
     r = result = malloc((strlen(filename) * 4 + 2) * sizeof(char));
 
-#ifdef __MINGW32__
+#ifdef _WIN32
     *(r++) = '/';
 #endif
 
     for (char *p = filename; *p; ++p) {
-#ifdef __MINGW32__
+#ifdef _WIN32
         if (*p == '\\') {
             *p = '/';
         }
@@ -251,7 +251,7 @@ static char *encode_point_and_click_filename(char *input_file_name)
         // because they cause trouble in TeX; we will percent-encode them
         if ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p < 'z')
                 || (*p >= '0' && *p <= '9') || *p == '.' || *p == '/'
-#ifdef __MINGW32__
+#ifdef _WIN32
                 || *p == ':'
 #endif
                 ) {

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -48,7 +48,7 @@ typedef enum gregorio_file_format {
     FORMAT_UNSET = 0,
     GABC,
     GTEX,
-    DUMP,
+    DUMP
 } gregorio_file_format;
 
 #define GABC_STR "gabc"
@@ -58,7 +58,7 @@ typedef enum gregorio_file_format {
 #define DEFAULT_INPUT_FORMAT    GABC
 #define DEFAULT_OUTPUT_FORMAT   GTEX
 
-// realpath is not in mingw32
+/* realpath is not in mingw32 */
 #ifdef _WIN32
 #ifndef PATH_MAX
 #define PATH_MAX _MAX_PATH
@@ -87,37 +87,37 @@ static char *define_path(char *current_directory, char *string)
     }
 #endif
     if (base_name) {
-        // some path was supplied
+        /* some path was supplied */
 
         *base_name = '\0';
         base_name++;
 
-        // try to resolve it
+        /* try to resolve it */
         if (!realpath(temp_name, file_name)) {
             fprintf(stderr, "the directory %s for %s does not exist\n",
                     file_name, base_name);
             exit(-1);
         }
     } else {
-        // no path was supplied
+        /* no path was supplied */
         base_name = string;
         strcpy(file_name, current_directory);
     }
 
-    // make sure we're not bigger than PATH_MAX
+    /* make sure we're not bigger than PATH_MAX */
     length = strlen(file_name);
     if (length + strlen(base_name) + 1 >= PATH_MAX) {
         fprintf(stderr, "filename too long: %s/%s\n", file_name, base_name);
         exit(-1);
     }
-    // build the file name
+    /* build the file name */
     file_name[length] = '/';
     strcpy(file_name + length + 1, base_name);
 
     return file_name;
 }
 
-// function that returns the filename without the extension
+/* function that returns the filename without the extension */
 static char *get_base_filename(char *fbasename)
 {
     char *p;
@@ -134,7 +134,7 @@ static char *get_base_filename(char *fbasename)
     return ret;
 }
 
-// function that adds the good extension to a basename (without extension)
+/* function that adds the good extension to a basename (without extension) */
 static char *get_output_filename(char *fbasename, const char *extension)
 {
     char *output_filename = NULL;
@@ -226,31 +226,31 @@ static void check_input_clobber(char *input_file_name, char *output_file_name)
 
 static char *encode_point_and_click_filename(char *input_file_name)
 {
-    // percent-encoding favors capital hex digits
+    /* percent-encoding favors capital hex digits */
     static const char *const hex = "0123456789ABCDEF";
-    char filename[PATH_MAX], *result = NULL, *r = NULL;
+    char filename[PATH_MAX], *result = NULL, *r = NULL, *p;
 
     if (!realpath(input_file_name, filename)) {
         fprintf(stderr, "error: unable to resolve %s\n", input_file_name);
         exit(-1);
     }
 
-    // 2 extra characters for a possible leading slash and final NUL
+    /* 2 extra characters for a possible leading slash and final NUL */
     r = result = malloc((strlen(filename) * 4 + 2) * sizeof(char));
 
 #ifdef _WIN32
     *(r++) = '/';
 #endif
 
-    for (char *p = filename; *p; ++p) {
+    for (p = filename; *p; ++p) {
 #ifdef _WIN32
         if (*p == '\\') {
             *p = '/';
         }
 #endif
 
-        // note that -, _ and ~ are conspicuously missing from this list
-        // because they cause trouble in TeX; we will percent-encode them
+        /* note that -, _ and ~ are conspicuously missing from this list
+         * because they cause trouble in TeX; we will percent-encode them */
         if ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p < 'z')
                 || (*p >= '0' && *p <= '9') || *p == '.' || *p == '/'
 #ifdef _WIN32
@@ -260,8 +260,8 @@ static char *encode_point_and_click_filename(char *input_file_name)
             *(r++) = *p;
         }
         else {
-            // percent-encode anything else
-            *(r++) = '\\'; // must escape it because it's TeX
+            /* percent-encode anything else */
+            *(r++) = '\\'; /* must escape it because it's TeX */
             *(r++) = '%';
             *(r++) = hex[(*p >> 4) & 0x0FU];
             *(r++) = hex[*p & 0x0FU];
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
                         output_file_name);
                 break;
             }
-            if (output_file) {  // means that stdout is defined
+            if (output_file) {  /* means that stdout is defined */
                 fprintf(stderr,
                         "warning: can't write to file and stdout, writing on stdout\n");
                 break;
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
                         output_file_name);
                 break;
             }
-            if (output_file) {  // means that stdout is defined
+            if (output_file) {  /* means that stdout is defined */
                 fprintf(stderr, "warning: option used two times: %c\n", c);
                 break;
             }
@@ -404,7 +404,7 @@ int main(int argc, char **argv)
                         input_file_name);
                 break;
             }
-            if (input_file) {   // means that stdin is defined
+            if (input_file) { /* means that stdin is defined */
                 fprintf(stderr, "warning: option used two times: %c\n", c);
                 break;
             }
@@ -456,9 +456,9 @@ int main(int argc, char **argv)
             break;
         }
         number_of_options++;
-    }                           // end of while
+    } /* end of while */
     if (optind == argc) {
-        if (!input_file) {      // input not undefined (could be stdin)
+        if (!input_file) { /* input not undefined (could be stdin) */
             fprintf(stderr, "error: no input file specified\n");
             print_usage(argv[0]);
             exit(-1);
@@ -497,7 +497,7 @@ int main(int argc, char **argv)
         }
     #endif
 
-    // then we act...
+    /* then we act... */
 
     if (!output_file_name && !output_file) {
         if (!output_basename) {
@@ -546,7 +546,7 @@ int main(int argc, char **argv)
         }
     }
 
-    // we always have input_file or input_file_name
+    /* we always have input_file or input_file_name */
     if (input_file) {
         if (point_and_click) {
             fprintf(stderr,

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -24,69 +24,70 @@
 
 #include "gregoriotex.h"
 
-// TODO: The numbers in the comments are a vestige of the older code; I'm
-// leaving them here for now, in case the refactor missed an instance
-// somewhere, but the numbers should evenually be removed
+/* TODO: The numbers in the comments are a vestige of the older code; I'm
+ * leaving them here for now, in case the refactor missed an instance
+ * somewhere, but the numbers should evenually be removed */
 
-// (loose) naming convention, employing camel case to be TeX-csname-compliant:
-// {specific-glyph-shape}{note-position}{note-shape}{first-ambitus}{second-ambitus}
-OFFSET_CASE(FinalPunctum); // 0
-OFFSET_CASE(FinalDeminutus); // 1
-OFFSET_CASE(PenultBeforePunctumWide); // 2
-OFFSET_CASE(PenultBeforeDeminutus); // 3
-OFFSET_CASE(AntepenultBeforePunctum); // 4
-OFFSET_CASE(AntepenultBeforeDeminutus); // 5
-OFFSET_CASE(InitialPunctum); // 6
-OFFSET_CASE(InitioDebilis); // 7
-OFFSET_CASE(PorrNonAuctusInitialWide); // 8
-OFFSET_CASE(PorrNonAuctusInitialOne); // 9
-OFFSET_CASE(PorrAuctusInitialAny); // 10
-OFFSET_CASE(FinalInclinatum); // 12
-OFFSET_CASE(FinalInclinatumDeminutus); // 13
-OFFSET_CASE(FinalStropha); // 14
-OFFSET_CASE(FinalQuilisma); // 15
-OFFSET_CASE(FinalOriscus); // 16
-OFFSET_CASE(PenultBeforePunctumOne); // 17
-OFFSET_CASE(FinalUpperPunctum); // 18
-OFFSET_CASE(InitialOriscus); // 19
-OFFSET_CASE(InitialQuilisma); // 20
-OFFSET_CASE(TorcResNonAuctusSecondWideWide); // 21
-OFFSET_CASE(TorcResNonAuctusSecondOneWide); // 22
-OFFSET_CASE(TorcResDebilisNonAuctusSecondAnyWide); // 23
-OFFSET_CASE(FinalLineaPunctum); // 24
-OFFSET_CASE(TorcResQuilismaNonAuctusSecondWideWide); // 28
-OFFSET_CASE(TorcResOriscusNonAuctusSecondWideWide); // 29
-OFFSET_CASE(TorcResQuilismaNonAuctusSecondOneWide); // 30
-OFFSET_CASE(TorcResOriscusNonAuctusSecondOneWide); // 31
-OFFSET_CASE(TorcResNonAuctusSecondWideOne); // 32
-OFFSET_CASE(TorcResDebilisNonAuctusSecondAnyOne); // 33
-OFFSET_CASE(TorcResQuilismaNonAuctusSecondWideOne); // 34
-OFFSET_CASE(TorcResOriscusNonAuctusSecondWideOne); // 35
-OFFSET_CASE(TorcResNonAuctusSecondOneOne); // 36
-OFFSET_CASE(TorcResQuilismaNonAuctusSecondOneOne); // 37
-OFFSET_CASE(TorcResOriscusNonAuctusSecondOneOne); // 38
-OFFSET_CASE(TorcResAuctusSecondWideAny); // 39
-OFFSET_CASE(TorcResDebilisAuctusSecondAnyAny); // 40
-OFFSET_CASE(TorcResQuilismaAuctusSecondWideAny); // 41
-OFFSET_CASE(TorcResOriscusAuctusSecondWideAny); // 42
-OFFSET_CASE(TorcResAuctusSecondOneAny); // 43
-OFFSET_CASE(TorcResQuilismaAuctusSecondOneAny); // 44
-OFFSET_CASE(TorcResOriscusAuctusSecondOneAny); // 45
-OFFSET_CASE(ConnectedPenultBeforePunctumWide); // 46
-OFFSET_CASE(ConnectedPenultBeforePunctumOne); // 47
-OFFSET_CASE(InitialConnectedPunctum); // 48
-OFFSET_CASE(InitialConnectedVirga); // 49
-OFFSET_CASE(InitialConnectedQuilisma); // 50
-OFFSET_CASE(InitialConnectedOriscus); // 51
-OFFSET_CASE(FinalConnectedPunctum); // 52
-OFFSET_CASE(FinalConnectedAuctus); // 53
-OFFSET_CASE(FinalVirgaAuctus); // 54
-OFFSET_CASE(FinalConnectedVirga); // 55
-OFFSET_CASE(InitialVirga); // 56
+/* (loose) naming convention, employing camel case to be TeX-csname-compliant:
+ * {specific-glyph-shape}{note-position}{note-shape}{first-ambitus}{second-ambitus}
+ */
+OFFSET_CASE(FinalPunctum);
+OFFSET_CASE(FinalDeminutus);
+OFFSET_CASE(PenultBeforePunctumWide);
+OFFSET_CASE(PenultBeforeDeminutus);
+OFFSET_CASE(AntepenultBeforePunctum);
+OFFSET_CASE(AntepenultBeforeDeminutus);
+OFFSET_CASE(InitialPunctum);
+OFFSET_CASE(InitioDebilis);
+OFFSET_CASE(PorrNonAuctusInitialWide);
+OFFSET_CASE(PorrNonAuctusInitialOne);
+OFFSET_CASE(PorrAuctusInitialAny);
+OFFSET_CASE(FinalInclinatum);
+OFFSET_CASE(FinalInclinatumDeminutus);
+OFFSET_CASE(FinalStropha);
+OFFSET_CASE(FinalQuilisma);
+OFFSET_CASE(FinalOriscus);
+OFFSET_CASE(PenultBeforePunctumOne);
+OFFSET_CASE(FinalUpperPunctum);
+OFFSET_CASE(InitialOriscus);
+OFFSET_CASE(InitialQuilisma);
+OFFSET_CASE(TorcResNonAuctusSecondWideWide);
+OFFSET_CASE(TorcResNonAuctusSecondOneWide);
+OFFSET_CASE(TorcResDebilisNonAuctusSecondAnyWide);
+OFFSET_CASE(FinalLineaPunctum);
+OFFSET_CASE(TorcResQuilismaNonAuctusSecondWideWide);
+OFFSET_CASE(TorcResOriscusNonAuctusSecondWideWide);
+OFFSET_CASE(TorcResQuilismaNonAuctusSecondOneWide);
+OFFSET_CASE(TorcResOriscusNonAuctusSecondOneWide);
+OFFSET_CASE(TorcResNonAuctusSecondWideOne);
+OFFSET_CASE(TorcResDebilisNonAuctusSecondAnyOne);
+OFFSET_CASE(TorcResQuilismaNonAuctusSecondWideOne);
+OFFSET_CASE(TorcResOriscusNonAuctusSecondWideOne);
+OFFSET_CASE(TorcResNonAuctusSecondOneOne);
+OFFSET_CASE(TorcResQuilismaNonAuctusSecondOneOne);
+OFFSET_CASE(TorcResOriscusNonAuctusSecondOneOne);
+OFFSET_CASE(TorcResAuctusSecondWideAny);
+OFFSET_CASE(TorcResDebilisAuctusSecondAnyAny);
+OFFSET_CASE(TorcResQuilismaAuctusSecondWideAny);
+OFFSET_CASE(TorcResOriscusAuctusSecondWideAny);
+OFFSET_CASE(TorcResAuctusSecondOneAny);
+OFFSET_CASE(TorcResQuilismaAuctusSecondOneAny);
+OFFSET_CASE(TorcResOriscusAuctusSecondOneAny);
+OFFSET_CASE(ConnectedPenultBeforePunctumWide);
+OFFSET_CASE(ConnectedPenultBeforePunctumOne);
+OFFSET_CASE(InitialConnectedPunctum);
+OFFSET_CASE(InitialConnectedVirga);
+OFFSET_CASE(InitialConnectedQuilisma);
+OFFSET_CASE(InitialConnectedOriscus);
+OFFSET_CASE(FinalConnectedPunctum);
+OFFSET_CASE(FinalConnectedAuctus);
+OFFSET_CASE(FinalVirgaAuctus);
+OFFSET_CASE(FinalConnectedVirga);
+OFFSET_CASE(InitialVirga);
 OFFSET_CASE(SalicusOriscusWide);
 OFFSET_CASE(SalicusOriscusOne);
 
-static inline const char *note_before_last_note_case(
+static __inline const char *note_before_last_note_case(
         const gregorio_glyph *const current_glyph,
         const gregorio_note *const current_note)
 {
@@ -115,10 +116,10 @@ static inline const char *note_before_last_note_case(
     }
 }
 
-// num can be FinalPunctum or FinalUpperPunctum according if the last note is a
-// standard punctum or a smaller punctum (for pes, porrectus and torculus
-// resupinus
-static inline const char *last_note_case(
+/* num can be FinalPunctum or FinalUpperPunctum according if the last note is a
+ * standard punctum or a smaller punctum (for pes, porrectus and torculus
+ * resupinus */
+static __inline const char *last_note_case(
         const gregorio_glyph *const current_glyph, const char* offset_pos,
         gregorio_note *current_note, bool no_ambitus_one)
 {
@@ -149,7 +150,7 @@ static inline const char *last_note_case(
     }
 }
 
-static inline const char *first_note_case(
+static __inline const char *first_note_case(
         const gregorio_note *const current_note,
         const gregorio_glyph *const current_glyph)
 {
@@ -180,7 +181,7 @@ static inline const char *first_note_case(
     }
 }
 
-static inline gregorio_vposition above_if_auctus(
+static __inline gregorio_vposition above_if_auctus(
         const gregorio_glyph *const glyph)
 {
     if (glyph->u.notes.liquescentia &
@@ -190,7 +191,7 @@ static inline gregorio_vposition above_if_auctus(
     return VPOS_BELOW;
 }
 
-static inline gregorio_vposition below_if_auctus(
+static __inline gregorio_vposition below_if_auctus(
         const gregorio_glyph *const glyph)
 {
     if (glyph->u.notes.liquescentia &
@@ -200,7 +201,7 @@ static inline gregorio_vposition below_if_auctus(
     return VPOS_ABOVE;
 }
 
-static inline gregorio_vposition above_if_h_episemus(
+static __inline gregorio_vposition above_if_h_episemus(
         const gregorio_note *const note)
 {
     if (note && note->h_episemus_above) {
@@ -209,7 +210,7 @@ static inline gregorio_vposition above_if_h_episemus(
     return VPOS_BELOW;
 }
 
-static inline gregorio_vposition above_if_either_h_episemus(
+static __inline gregorio_vposition above_if_either_h_episemus(
         const gregorio_note *const note)
 {
     if ((note->previous && note->previous->h_episemus_above)
@@ -219,7 +220,7 @@ static inline gregorio_vposition above_if_either_h_episemus(
     return VPOS_BELOW;
 }
 
-static inline gregorio_vposition below_if_next_ambitus_allows(
+static __inline gregorio_vposition below_if_next_ambitus_allows(
         const gregorio_note *const note)
 {
     assert(note->next);
@@ -230,7 +231,7 @@ static inline gregorio_vposition below_if_next_ambitus_allows(
     return VPOS_ABOVE;
 }
 
-static inline void low_high_set_lower(const gregorio_glyph *const glyph,
+static __inline void low_high_set_lower(const gregorio_glyph *const glyph,
         gregorio_note *const note)
 {
     if ((glyph->u.notes.liquescentia & L_DEMINUTUS) ||
@@ -240,7 +241,7 @@ static inline void low_high_set_lower(const gregorio_glyph *const glyph,
     }
 }
 
-static inline void low_high_set_upper(const gregorio_glyph *const glyph,
+static __inline void low_high_set_upper(const gregorio_glyph *const glyph,
         gregorio_note *const note)
 {
     if ((glyph->u.notes.liquescentia & L_DEMINUTUS) ||
@@ -250,7 +251,7 @@ static inline void low_high_set_upper(const gregorio_glyph *const glyph,
     }
 }
 
-static inline void high_low_set_upper(const gregorio_glyph *const glyph,
+static __inline void high_low_set_upper(const gregorio_glyph *const glyph,
         gregorio_note *const note)
 {
     if (glyph->u.notes.liquescentia & L_DEMINUTUS) {
@@ -258,7 +259,7 @@ static inline void high_low_set_upper(const gregorio_glyph *const glyph,
     }
 }
 
-static inline void high_low_set_lower(const gregorio_glyph *const glyph,
+static __inline void high_low_set_lower(const gregorio_glyph *const glyph,
         gregorio_note *const note)
 {
     if (glyph->u.notes.liquescentia & L_DEMINUTUS) {
@@ -266,10 +267,10 @@ static inline void high_low_set_lower(const gregorio_glyph *const glyph,
     }
 }
 
-// a function that finds the good sign (additional line, vepisemus or
-// hepisemus) number, according to the gregoriotex convention (described in
-// gregoriotex.tex)
-// this function is REALLY a pain in the ass, but it is sadly necessary
+/* a function that finds the good sign (additional line, vepisemus or
+ * hepisemus) number, according to the gregoriotex convention (described in
+ * gregoriotex.tex)
+ * this function is REALLY a pain in the ass, but it is sadly necessary */
 /*
  *
  * For the first note of a porrectus (flexus), this table summarizes the sign
@@ -344,7 +345,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
     gregorio_vposition h_episemus = VPOS_AUTO, v_episemus = VPOS_AUTO;
     bool v_episemus_below_is_lower = false, done;
 
-    // no need to clear is_lower_note/is_upper_note because we used calloc
+    /* no need to clear is_lower_note/is_upper_note because we used calloc */
 
     switch (type) {
     case T_PES:
@@ -366,7 +367,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
                 h_episemus = above_if_auctus(glyph);
             }
             v_episemus = VPOS_BELOW;
-        } else { // i=2 
+        } else { /* i=2  */
             if (!(glyph->u.notes.liquescentia & L_INITIO_DEBILIS)) {
                 note->is_upper_note = true;
             }
@@ -386,7 +387,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
             note->gtex_offset_case = first_note_case(note, glyph);
             h_episemus = above_if_h_episemus(note->next);
             v_episemus = VPOS_BELOW;
-        } else { // i=2
+        } else { /* i=2 */
             if (glyph->u.notes.liquescentia & L_DEMINUTUS) {
                 note->gtex_offset_case = InitioDebilis;
             } else {
@@ -418,7 +419,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
             } else {
                 v_episemus = VPOS_BELOW;
             }
-        } else { // i=2
+        } else { /* i=2 */
             high_low_set_lower(glyph, note);
             note->gtex_offset_case = last_note_case(glyph, FinalPunctum, note,
                     false);
@@ -486,7 +487,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
         if (done) {
             break;
         }
-        // else fallthrough to the next case!
+        /* else fallthrough to the next case! */
     case T_PORRECTUS_FLEXUS:
         switch (i) {
         case HEPISEMUS_FIRST_TWO:
@@ -538,7 +539,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
         case 2:
             if (glyph->u.notes.liquescentia &
                     (L_AUCTUS_ASCENDENS | L_AUCTUS_DESCENDENS | L_AUCTA)) {
-                // auctus
+                /* auctus */
                 if (glyph->u.notes.liquescentia & L_INITIO_DEBILIS) {
                     note->gtex_offset_case = TorcResDebilisAuctusSecondAnyAny;
                 } else {
@@ -575,7 +576,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
                 }
             } else if (note->next->next->u.note.pitch -
                     note->next->u.note.pitch == 1) {
-                // non-auctus with a second ambitus of 1
+                /* non-auctus with a second ambitus of 1 */
                 if (glyph->u.notes.liquescentia & L_INITIO_DEBILIS) {
                     note->gtex_offset_case =
                             TorcResDebilisNonAuctusSecondAnyOne;
@@ -614,7 +615,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
                     }
                 }
             } else {
-                // non-auctus with a second ambitus of at least 2
+                /* non-auctus with a second ambitus of at least 2 */
                 if (glyph->u.notes.liquescentia & L_INITIO_DEBILIS) {
                     note->gtex_offset_case =
                             TorcResDebilisNonAuctusSecondAnyWide;
@@ -666,21 +667,21 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
         if (done) {
             break;
         }
-        // else fallthrough to the next case!
+        /* else fallthrough to the next case! */
     case T_PORRECTUS:
         switch (i) {
         case HEPISEMUS_FIRST_TWO:
         case 1:
             if (glyph->u.notes.liquescentia &
                     (L_AUCTUS_ASCENDENS | L_AUCTUS_DESCENDENS | L_AUCTA)) {
-                // auctus
+                /* auctus */
                 note->gtex_offset_case = PorrAuctusInitialAny;
             } else if (note->next->next->u.note.pitch -
                     note->next->u.note.pitch == 1) {
-                // non-auctus with a second ambitus of 1
+                /* non-auctus with a second ambitus of 1 */
                 note->gtex_offset_case = PorrNonAuctusInitialOne;
             } else {
-                // non-auctus with a second ambitus of at least 2
+                /* non-auctus with a second ambitus of at least 2 */
                 note->gtex_offset_case = PorrNonAuctusInitialWide;
             }
             h_episemus = VPOS_ABOVE;
@@ -700,7 +701,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
             h_episemus = above_if_h_episemus(note->previous);
             v_episemus = VPOS_BELOW;
             break;
-        default: // case 3
+        default: /* case 3 */
             low_high_set_upper(glyph, note);
             note->gtex_offset_case = last_note_case(glyph, FinalUpperPunctum,
                     note, true);
@@ -812,7 +813,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
             break;
         }
         break;
-    default: // case T_ONE_NOTE
+    default: /* case T_ONE_NOTE */
         h_episemus = VPOS_ABOVE;
         v_episemus = VPOS_BELOW;
         switch (note->u.note.shape) {
@@ -864,7 +865,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
     if (note->signs & _V_EPISEMUS) {
         if (note->v_episemus_height) {
             if (note->v_episemus_height > note->u.note.pitch) {
-                // above is always higher because of GregorioTeX's design
+                /* above is always higher because of GregorioTeX's design */
                 note->v_episemus_height += (int)VPOS_ABOVE;
             }
         }
@@ -872,7 +873,7 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
             note->v_episemus_height = note->u.note.pitch + (int)v_episemus;
             if ((v_episemus == VPOS_BELOW && v_episemus_below_is_lower)
                     || v_episemus == VPOS_ABOVE) {
-                // above is always higher because of GregorioTeX's design
+                /* above is always higher because of GregorioTeX's design */
                 note->v_episemus_height += (int)v_episemus;
             }
         }
@@ -881,8 +882,9 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
     return h_episemus;
 }
 
-static inline char compute_h_episemus_height(const gregorio_glyph *const glyph,
-        const gregorio_note *const note, const gregorio_vposition vpos)
+static __inline char compute_h_episemus_height(
+        const gregorio_glyph *const glyph, const gregorio_note *const note,
+        const gregorio_vposition vpos)
 {
     char height = note->u.note.pitch;
 
@@ -914,7 +916,7 @@ static bool is_bridgeable_space(const gregorio_element *const element)
         case SP_LARGER_SPACE_NB:
             return true;
         default:
-            // do nothing
+            /* do nothing */
             break;
         }
     }
@@ -994,7 +996,7 @@ static bool is_h_episemus_below_better_height(const signed char new_height,
     return new_height < old_height;
 }
 
-static inline void start_h_episemus(height_computation *const h,
+static __inline void start_h_episemus(height_computation *const h,
         const gregorio_element *const element,
         const gregorio_glyph *const glyph, gregorio_note *const note)
 {
@@ -1005,7 +1007,7 @@ static inline void start_h_episemus(height_computation *const h,
     h->height = compute_h_episemus_height(glyph, note, h->vpos);
 }
 
-static inline void set_h_episemus_height(const height_computation *const h,
+static __inline void set_h_episemus_height(const height_computation *const h,
         gregorio_note *const end)
 {
     gregorio_note *last_note = NULL;
@@ -1044,22 +1046,22 @@ static inline void set_h_episemus_height(const height_computation *const h,
     }
 }
 
-static inline bool is_connected_left(const grehepisemus_size size) {
+static __inline bool is_connected_left(const grehepisemus_size size) {
     return size == H_NORMAL || size == H_SMALL_LEFT;
 }
 
-static inline bool is_connected_right(const grehepisemus_size size) {
+static __inline bool is_connected_right(const grehepisemus_size size) {
     return size == H_NORMAL || size == H_SMALL_RIGHT;
 }
 
-static inline bool is_connectable_interglyph_ambitus(
+static __inline bool is_connectable_interglyph_ambitus(
         const gregorio_note *const first, const gregorio_note *const second)
 {
     return first && second
             && abs(first->u.note.pitch - second->u.note.pitch) < 3;
 }
 
-static inline bool has_space_to_left(const gregorio_note *const note) {
+static __inline bool has_space_to_left(const gregorio_note *const note) {
     switch (note->u.note.shape) {
     case S_PUNCTUM_INCLINATUM:
     case S_PUNCTUM_INCLINATUM_DEMINUTUS:
@@ -1071,13 +1073,13 @@ static inline bool has_space_to_left(const gregorio_note *const note) {
     }
 }
 
-static inline void end_h_episemus(height_computation *const h,
+static __inline void end_h_episemus(height_computation *const h,
         gregorio_note *const end)
 {
     signed char proposed_height;
 
     if (h->active) {
-        // don't let the episemus clash with the note before or after
+        /* don't let the episemus clash with the note before or after */
         if (is_connected_left(h->get_size(h->start_note))
                 && h->start_note->previous
                 && h->start_note->previous->type == GRE_NOTE
@@ -1088,7 +1090,7 @@ static inline void end_h_episemus(height_computation *const h,
                 h->height = proposed_height;
             }
         }
-        // end->previous checks that it's within the same glyph
+        /* end->previous checks that it's within the same glyph */
         if (end && end->type == GRE_NOTE && end->previous
                 && end->previous->type == GRE_NOTE
                 && is_connected_left(h->get_size(end))
@@ -1112,7 +1114,7 @@ static inline void end_h_episemus(height_computation *const h,
     }
 }
 
-static inline void compute_h_episemus(height_computation *const h,
+static __inline void compute_h_episemus(height_computation *const h,
         const gregorio_element *const element,
         const gregorio_glyph *const glyph, gregorio_note *const note,
         const int i)
@@ -1150,7 +1152,7 @@ static inline void compute_h_episemus(height_computation *const h,
     }
 }
 
-static inline void compute_note_positioning(height_computation *const above,
+static __inline void compute_note_positioning(height_computation *const above,
         height_computation *const below, const gregorio_element *const element,
         const gregorio_glyph *const glyph, gregorio_note *const note,
         const int i, const gtex_type type)
@@ -1162,7 +1164,7 @@ static inline void compute_note_positioning(height_computation *const above,
         if (default_vpos == VPOS_BELOW) {
             note->h_episemus_above = HEPISEMUS_NONE;
         }
-        else { // default_vpos == VPOS_ABOVE
+        else { /* default_vpos == VPOS_ABOVE */
             note->h_episemus_below = HEPISEMUS_NONE;
         }
     }
@@ -1174,38 +1176,38 @@ static inline void compute_note_positioning(height_computation *const above,
 void gregoriotex_compute_positioning(const gregorio_element *element)
 {
     height_computation above = {
-        .vpos = VPOS_ABOVE,
-        .is_applicable = &is_h_episemus_above_applicable,
-        .is_shown = &gtex_is_h_episemus_above_shown,
-        .is_connected = &is_h_episemus_above_connected,
-        .get_size = &get_h_episemus_above_size,
-        .is_better_height = &is_h_episemus_above_better_height,
-        .position = &gregorio_position_h_episemus_above,
+        /*.vpos =*/ VPOS_ABOVE,
+        /*.is_applicable =*/ &is_h_episemus_above_applicable,
+        /*.is_shown =*/ &gtex_is_h_episemus_above_shown,
+        /*.is_connected =*/ &is_h_episemus_above_connected,
+        /*.get_size =*/ &get_h_episemus_above_size,
+        /*.is_better_height =*/ &is_h_episemus_above_better_height,
+        /*.position =*/ &gregorio_position_h_episemus_above,
 
-        .active = false,
-        .height = 0,
-        .connected = false,
-        .start_element = NULL,
-        .start_glyph = NULL,
-        .start_note = NULL,
-        .last_connected_note = NULL,
+        /*.active =*/ false,
+        /*.height =*/ 0,
+        /*.connected =*/ false,
+        /*.start_element =*/ NULL,
+        /*.start_glyph =*/ NULL,
+        /*.start_note =*/ NULL,
+        /*.last_connected_note =*/ NULL,
     };
     height_computation below = {
-        .vpos = VPOS_BELOW,
-        .is_applicable = &is_h_episemus_below_applicable,
-        .is_shown = &gtex_is_h_episemus_below_shown,
-        .is_connected = &is_h_episemus_below_connected,
-        .get_size = &get_h_episemus_below_size,
-        .is_better_height = &is_h_episemus_below_better_height,
-        .position = &gregorio_position_h_episemus_below,
+        /*.vpos =*/ VPOS_BELOW,
+        /*.is_applicable =*/ &is_h_episemus_below_applicable,
+        /*.is_shown =*/ &gtex_is_h_episemus_below_shown,
+        /*.is_connected =*/ &is_h_episemus_below_connected,
+        /*.get_size =*/ &get_h_episemus_below_size,
+        /*.is_better_height =*/ &is_h_episemus_below_better_height,
+        /*.position =*/ &gregorio_position_h_episemus_below,
 
-        .active = false,
-        .height = 0,
-        .connected = false,
-        .start_element = NULL,
-        .start_glyph = NULL,
-        .start_note = NULL,
-        .last_connected_note = NULL,
+        /*.active =*/ false,
+        /*.height =*/ 0,
+        /*.connected =*/ false,
+        /*.start_element =*/ NULL,
+        /*.start_glyph =*/ NULL,
+        /*.start_note =*/ NULL,
+        /*.last_connected_note =*/ NULL,
     };
     int i;
     gtex_alignment ignored;
@@ -1213,13 +1215,15 @@ void gregoriotex_compute_positioning(const gregorio_element *element)
 
     for (; element; element = element->next) {
         if (element->type == GRE_ELEMENT) {
-            for (const gregorio_glyph *glyph = element->u.first_glyph; glyph;
+            const gregorio_glyph *glyph;
+            for (glyph = element->u.first_glyph; glyph;
                     glyph = glyph->next) {
                 if (glyph->type == GRE_GLYPH) {
+                    gregorio_note *note;
                     i = 0;
                     gregoriotex_determine_glyph_name(glyph, element, &ignored,
                             &type);
-                    for (gregorio_note *note = glyph->u.notes.first_note; note;
+                    for (note = glyph->u.notes.first_note; note;
                             note = note->next) {
                         if (note->type == GRE_NOTE) {
                             compute_note_positioning(&above, &below, element,

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -18,8 +18,8 @@
 
 #include "config.h"
 #include <stdlib.h>
-#include <stdbool.h>
 #include <assert.h>
+#include "bool.h"
 #include "struct.h"
 
 #include "gregoriotex.h"

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -33,6 +33,7 @@
 #include "messages.h"
 #include "characters.h"
 #include "plugins.h"
+#include "support.h"
 
 #include "gregoriotex.h"
 
@@ -218,7 +219,7 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
             }
             if (note->u.note.pitch - LOWEST_PITCH == 3) {
                 // if we're on the 'd' line, the queue could be long or short
-                snprintf(buf, sizeof buf,
+                gregorio_snprintf(buf, sizeof buf,
                         "VirgaReversaAscendensOnDLine{\\GreCP%s}", name);
                 return buf;
             }
@@ -414,7 +415,7 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
     }
     current_note = current_note->next;
     if (!current_note->next) {
-        snprintf(buf, BUFSIZE, "%s%s%s", shape, tex_ambitus[ambitus1],
+        gregorio_snprintf(buf, BUFSIZE, "%s%s%s", shape, tex_ambitus[ambitus1],
                 liquescentia);
         return buf;
     }
@@ -423,14 +424,14 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
     }
     current_note = current_note->next;
     if (!current_note->next) {
-        snprintf(buf, BUFSIZE, "%s%s%s%s", shape, tex_ambitus[ambitus1],
-                tex_ambitus[ambitus2], liquescentia);
+        gregorio_snprintf(buf, BUFSIZE, "%s%s%s%s", shape,
+                tex_ambitus[ambitus1], tex_ambitus[ambitus2], liquescentia);
         return buf;
     }
     if (!(ambitus3 = compute_ambitus(current_note))) {
         return "";
     }
-    snprintf(buf, BUFSIZE, "%s%s%s%s%s", shape, tex_ambitus[ambitus1],
+    gregorio_snprintf(buf, BUFSIZE, "%s%s%s%s%s", shape, tex_ambitus[ambitus1],
             tex_ambitus[ambitus2], tex_ambitus[ambitus3], liquescentia);
     return buf;
 }
@@ -2262,7 +2263,7 @@ static char *determine_leading_shape(gregorio_glyph *glyph)
         break;
     }
 
-    snprintf(buf, BUFSIZE, "Leading%s%s%s", head, tex_ambitus[ambitus],
+    gregorio_snprintf(buf, BUFSIZE, "Leading%s%s%s", head, tex_ambitus[ambitus],
             head_liquescence);
     return buf;
 }

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -25,9 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 #include <assert.h>
 #include <time.h>
+#include "bool.h"
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -34,6 +34,7 @@
 #include "characters.h"
 #include "plugins.h"
 #include "support.h"
+#include "utf8strings.h"
 
 #include "gregoriotex.h"
 
@@ -911,7 +912,7 @@ static void gtex_write_special_char(FILE *f, grewchar *special_char)
         fprintf(f, "\\Vbar{}");
         return;
     }
-    if (!gregorio_wcsbufcmp(special_char, "'æ")) {
+    if (!gregorio_wcsbufcmp(special_char, ACCENTED_AE)) {
         fprintf(f, "\\'\\ae{}");
         return;
     }
@@ -919,7 +920,7 @@ static void gtex_write_special_char(FILE *f, grewchar *special_char)
         fprintf(f, "\\'\\ae{}");
         return;
     }
-    if (!gregorio_wcsbufcmp(special_char, "'œ")) {
+    if (!gregorio_wcsbufcmp(special_char, ACCENTED_OE)) {
         fprintf(f, "\\'\\oe{}");
         return;
     }

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -40,22 +40,22 @@
 
 #define BUFSIZE 128
 
-// a structure containing the status
+/* a structure containing the status */
 typedef struct gregoriotex_status {
     bool point_and_click;
 
-    // true if the current_glyph will have an additional line under or not
-    // (useful to determine the length of the bar in case of a flexa starting
-    // at d
+    /* true if the current_glyph will have an additional line under or not
+     * (useful to determine the length of the bar in case of a flexa starting
+     * at d */
     bool bottom_line;
 
     signed char top_height;
     signed char bottom_height;
 
-    // indicates if there is a translation on the line
+    /* indicates if there is a translation on the line */
     bool translation;
 
-    // indicates if there is "above lines text" on the line
+    /* indicates if there is "above lines text" on the line */
     bool abovelinestext;
 } gregoriotex_status;
 
@@ -66,12 +66,12 @@ static const char *tex_ambitus[] = {
     NULL, "One", "Two", "Three", "Four", "Five"
 };
 
-// / the value indicating to GregorioTeX that there is no flat
+/* the value indicating to GregorioTeX that there is no flat */
 #define NO_KEY_FLAT LOWEST_PITCH
 #define PITCH_BELOW_STAFF (LOWEST_PITCH + 2)
 #define PITCH_ABOVE_STAFF (LOWEST_PITCH + 10)
 
-// a helper macro for the following function
+/* a helper macro for the following function */
 #define WHILEGLYPH(prevornext) \
         while(glyph) {\
             if (glyph->type == GRE_GLYPH) {\
@@ -86,18 +86,18 @@ static const char *tex_ambitus[] = {
             glyph = glyph->prevornext;\
         }
 
-static inline signed char pitch_value(const signed char height) {
-    // right now height == pitch, but this function allows us to change
-    // the offset easily
+static __inline signed char pitch_value(const signed char height) {
+    /* right now height == pitch, but this function allows us to change
+     * the offset easily */
     return height;
 }
 
-static inline int bool_to_int(bool value) {
+static __inline int bool_to_int(bool value) {
     return value? 1 : 0;
 }
 
-// a function that determines if we must use a long queue or not (less easy
-// that it might seem)
+/* a function that determines if we must use a long queue or not (less easy
+ * that it might seem) */
 
 static bool is_longqueue(const signed char pitch,
         const gregorio_glyph *const current_glyph,
@@ -114,7 +114,7 @@ static bool is_longqueue(const signed char pitch,
     case 11:
         return true;
     case 3:
-        // we first look forward to see if there is a note underneath c
+        /* we first look forward to see if there is a note underneath c */
         WHILEGLYPH(next);
         if (element && element->type == GRE_SPACE
                 && (element->u.misc.unpitched.info.space == SP_NEUMATIC_CUT
@@ -130,7 +130,7 @@ static bool is_longqueue(const signed char pitch,
             glyph = element->u.first_glyph;
             WHILEGLYPH(next);
         }
-        // and now something completely different
+        /* and now something completely different */
         glyph = current_glyph->previous;
         element = current_element->previous;
         WHILEGLYPH(previous);
@@ -154,11 +154,12 @@ static bool is_longqueue(const signed char pitch,
     }
 }
 
-// inline functions that we will use to determine if we need a short bar or not
+/* inline functions that we will use to determine if we need a short bar or
+ * not */
 
-// we define d to be short instead of long... may induce errors, but fixes
-// some too
-static inline bool is_shortqueue(const signed char pitch,
+/* we define d to be short instead of long... may induce errors, but fixes
+ * some too */
+static __inline bool is_shortqueue(const signed char pitch,
         const gregorio_glyph *const glyph,
         const gregorio_element *const element)
 {
@@ -219,7 +220,7 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
                 name = "VirgaReversaLongqueueAscendens";
             }
             if (note->u.note.pitch - LOWEST_PITCH == 3) {
-                // if we're on the 'd' line, the queue could be long or short
+                /* if we're on the 'd' line, the queue could be long or short */
                 gregorio_snprintf(buf, sizeof buf,
                         "VirgaReversaAscendensOnDLine{\\GreCP%s}", name);
                 return buf;
@@ -303,7 +304,7 @@ static const char *gregoriotex_determine_liquescentia(gtex_glyph_liquescentia ty
         liquescentia = L_AUCTUS_ASCENDENS_INITIO_DEBILIS;
         break;
     default:
-        // do nothing
+        /* do nothing */
         break;
     }
 
@@ -339,8 +340,8 @@ static const char *gregoriotex_determine_liquescentia(gtex_glyph_liquescentia ty
         break;
     }
 
-    // now we convert liquescentia into the good GregorioTeX liquescentia
-    // numbers
+    /* now we convert liquescentia into the good GregorioTeX liquescentia
+     * numbers */
 
     switch (liquescentia) {
     case L_DEMINUTUS:
@@ -360,14 +361,14 @@ static const char *gregoriotex_determine_liquescentia(gtex_glyph_liquescentia ty
     case L_AUCTUS_DESCENDENS_INITIO_DEBILIS:
         return "InitioDebilisDescendens";
     case L_NO_LIQUESCENTIA:
-        // break out and return "Nothing"
+        /* break out and return "Nothing" */
         break;
     }
 
     return "Nothing";
 }
 
-static inline int compute_ambitus(const gregorio_note *const current_note)
+static __inline int compute_ambitus(const gregorio_note *const current_note)
 {
     int first = current_note->u.note.pitch;
     int second = current_note->next->u.note.pitch;
@@ -393,7 +394,7 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
     const char *liquescentia = gregoriotex_determine_liquescentia(ltype,
             glyph->u.notes.liquescentia);
     gregorio_note *current_note;
-    // then we start making our formula
+    /* then we start making our formula */
     int ambitus1, ambitus2, ambitus3;
     if (!glyph) {
         gregorio_message(_("called with NULL pointer"),
@@ -437,9 +438,9 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
     return buf;
 }
 
-// the function that calculates the number of the glyph. It also
-// calculates the type, used for determining the position of signs. Type is
-// very basic, it is only the global dimensions : torculus, one_note, etc.
+/* the function that calculates the number of the glyph. It also
+ * calculates the type, used for determining the position of signs. Type is
+ * very basic, it is only the global dimensions : torculus, one_note, etc. */
 
 const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         const gregorio_element *const element, gtex_alignment *const  type,
@@ -465,8 +466,8 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         switch (glyph->u.notes.first_note->u.note.shape) {
         case S_QUILISMA:
             *type = AT_QUILISMA;
-            // the next if is because we made the choice that AUCTUS shapes
-            // look like pes quadratum.
+            /* the next if is because we made the choice that AUCTUS shapes
+             * look like pes quadratum. */
             if (glyph->u.notes.liquescentia == L_AUCTUS_ASCENDENS
                     || glyph->u.notes.liquescentia == L_AUCTUS_DESCENDENS
                     || glyph->u.notes.liquescentia ==
@@ -484,7 +485,7 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         case S_ORISCUS:
         case S_ORISCUS_SCAPUS:
             *type = AT_ORISCUS;
-            // TODO: we could factorize this code
+            /* TODO: we could factorize this code */
             if (glyph->u.notes.liquescentia == L_NO_LIQUESCENTIA
                     && is_longqueue(pitch, glyph, element)) {
                 *gtype = T_PESQUASSUS_LONGQUEUE;
@@ -675,7 +676,7 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
             }
             ltype = LG_ONLY_DEMINUTUS;
         } else {
-            // TODO...
+            /* TODO... */
             *type = AT_ONE_NOTE;
         }
         break;
@@ -731,7 +732,7 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
     if (shape) {
         shape = compute_glyph_name(glyph, shape, ltype);
     }
-    // we fix *type with initio_debilis
+    /* we fix *type with initio_debilis */
     if (*type == AT_ONE_NOTE) {
         if (is_initio_debilis(glyph->u.notes.liquescentia)) {
             *type = AT_INITIO_DEBILIS;
@@ -753,8 +754,8 @@ static void gregoriotex_write_voice_info(FILE *f, gregorio_voice_info *voice_inf
     }
 }
 
-// this function indicates if the syllable is the last of the line. If it's the
-// last of the score it returns false, as it's handled another way
+/* this function indicates if the syllable is the last of the line. If it's the
+ * last of the score it returns false, as it's handled another way */
 static bool gregoriotex_is_last_of_line(gregorio_syllable *syllable)
 {
     gregorio_element *current_element = NULL;
@@ -763,13 +764,13 @@ static bool gregoriotex_is_last_of_line(gregorio_syllable *syllable)
     }
     if ((syllable->next_syllable->elements)[0]
             && (syllable->next_syllable->elements)[0]->type == GRE_END_OF_LINE) {
-        // the next syllable start by an end of line
+        /* the next syllable start by an end of line */
         return true;
     }
     current_element = (syllable->elements)[0];
     while (current_element) {
         if (current_element->type == GRE_END_OF_LINE) {
-            // we return true only if the end of line is the last element
+            /* we return true only if the end of line is the last element */
             if (!(current_element->next)) {
                 return true;
             } else {
@@ -786,7 +787,7 @@ static bool gregoriotex_is_last_of_line(gregorio_syllable *syllable)
  * A small helper for the following function 
  */
 
-static inline bool is_clef(gregorio_type x)
+static __inline bool is_clef(gregorio_type x)
 {
     return x == GRE_C_KEY_CHANGE || x == GRE_F_KEY_CHANGE ||
             x == GRE_C_KEY_CHANGE_FLATED || x == GRE_F_KEY_CHANGE_FLATED;
@@ -805,7 +806,7 @@ static gregorio_element *gregoriotex_syllable_is_clef_change(gregorio_syllable
         return NULL;
     }
     element = syllable->elements[0];
-    // we just detect the foud cases
+    /* we just detect the foud cases */
     if (element->type == GRE_CUSTO && element->next
             && (is_clef(element->next->type)) && !element->next->next) {
         return element->next;
@@ -1009,8 +1010,8 @@ static void gtex_print_char(FILE *f, grewchar to_print)
     return;
 }
 
-// a function to map the internal ST_* styles to gregoriotex styles as defined
-// in gregoriotex-syllables.tex
+/* a function to map the internal ST_* styles to gregoriotex styles as defined
+ * in gregoriotex-syllables.tex */
 static unsigned char gregoriotex_internal_style_to_gregoriotex(grestyle_style
         style)
 {
@@ -1105,8 +1106,8 @@ static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
         }
         current_char = current_char->next_character;
     }
-    // if we reached here, this means that we there is only one style applied
-    // to all the syllables
+    /* if we reached here, this means that we there is only one style applied
+     * to all the syllables */
     return possible_fixed_style;
 }
 
@@ -1129,8 +1130,8 @@ static void gregoriotex_write_translation(FILE *f,
             (&gtex_write_begin), (&gtex_write_end), (&gtex_write_special_char));
 }
 
-// a function to compute the height of the flat of a key
-// the flat is always on the line of the
+/* a function to compute the height of the flat of a key
+ * the flat is always on the line of the */
 
 static char gregoriotex_clef_flat_height(char step, int line)
 {
@@ -1192,7 +1193,7 @@ OFFSET_CASE(BarDivisioFinalis);
 static void gregoriotex_write_bar(FILE *f, gregorio_bar type,
         gregorio_sign signs, bool is_inside_bar)
 {
-    // the type number of function vepisemusorrare
+    /* the type number of function vepisemusorrare */
     const char *offset_case = BarStandard;
     if (is_inside_bar) {
         fprintf(f, "\\GreIn");
@@ -1271,13 +1272,11 @@ static void gregoriotex_write_auctum_duplex(FILE *f,
 {
     char pitch = current_note->u.note.pitch;
     char previous_pitch = 0;
-    // second_pitch is the second argument of the \augmentumduplex macro,
-    // that's
-    // what this function is all about.
+    /* second_pitch is the second argument of the \augmentumduplex macro,
+     * that's what this function is all about. */
     char second_pitch = 0;
-    // this variable will be set to 1 if we are on the note before the last
-    // note
-    // of a podatus or a porrectus or a torculus resupinus
+    /* this variable will be set to 1 if we are on the note before the last
+     * note of a podatus or a porrectus or a torculus resupinus */
     unsigned char special_punctum = 0;
     if (current_note->previous) {
         if (current_note->previous->u.note.pitch - current_note->u.note.pitch ==
@@ -1298,14 +1297,14 @@ static void gregoriotex_write_auctum_duplex(FILE *f,
             second_pitch = pitch + 1;
         }
     }
-    // the first argument should always be the lowest one, that's what we do
-    // here:
+    /* the first argument should always be the lowest one, that's what we do
+     * here: */
     if (pitch > second_pitch) {
         previous_pitch = pitch;
         pitch = second_pitch;
         second_pitch = previous_pitch;
     }
-    // maybe the third argument should be changed
+    /* maybe the third argument should be changed */
     fprintf(f, "\\GreAugmentumDuplex{%d}{%d}{%d}%%\n", pitch_value(pitch),
             pitch_value(second_pitch), special_punctum);
 }
@@ -1319,24 +1318,24 @@ static void gregoriotex_write_auctum_duplex(FILE *f,
 static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
         gregorio_note *current_note)
 {
-    // in this if we consider that the puncta are only on the last two notes
-    // (maybe it would be useful to consider it more entirely, but it would be
-    // really weird...)
-    // the variable that will be set to true if we have to shift the punctum
-    // inclinatum before the last note
+    /* in this if we consider that the puncta are only on the last two notes
+     * (maybe it would be useful to consider it more entirely, but it would be
+     * really weird...) */
+    /* the variable that will be set to true if we have to shift the punctum
+     * inclinatum before the last note */
     bool shift_before = false;
-    // this variable will be set to 1 if we are on the note before the last
-    // note of a podatus or a porrectus or a torculus resupinus
+    /* this variable will be set to 1 if we are on the note before the last
+     * note of a podatus or a porrectus or a torculus resupinus */
     unsigned char special_punctum = 0;
-    // 0 if space is normal, 1 if there should be no space after a punctum
+    /* 0 if space is normal, 1 if there should be no space after a punctum */
     unsigned char no_space = 0;
-    // the pitch where to set the punctum
+    /* the pitch where to set the punctum */
     char pitch = current_note->u.note.pitch;
-    // a variable to know if we are on a punctum inclinatum or not
+    /* a variable to know if we are on a punctum inclinatum or not */
     unsigned char punctum_inclinatum = 0;
-    // a temp variable
+    /* a temp variable */
     gregorio_note *tmpnote;
-    // we go into this switch only if it is the note before the last note
+    /* we go into this switch only if it is the note before the last note */
     if (current_note->next) {
         switch (glyph->u.notes.glyph_type) {
         case G_FLEXA:
@@ -1363,7 +1362,7 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
                     || glyph->u.notes.liquescentia ==
                     L_AUCTUS_DESCENDENS_INITIO_DEBILIS) {
                 shift_before = true;
-                // fine tuning
+                /* fine tuning */
                 if (current_note->next->u.note.pitch -
                         current_note->u.note.pitch == 1) {
                     if (is_on_a_line(current_note->u.note.pitch)) {
@@ -1373,7 +1372,7 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
                     }
                 }
             } else {
-                // case for f.g
+                /* case for f.g */
                 if (current_note->next->u.note.pitch -
                         current_note->u.note.pitch == 1) {
                     special_punctum = 1;
@@ -1393,7 +1392,7 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
             break;
         case G_PORRECTUS:
         case G_TORCULUS_RESUPINUS:
-            // this case is only for the note before the previous note
+            /* this case is only for the note before the previous note */
             if ((current_note->next->u.note.pitch -
                             current_note->u.note.pitch == -1
                             || current_note->next->u.note.pitch -
@@ -1405,7 +1404,7 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
             break;
         }
     }
-    // we enter here in any case
+    /* we enter here in any case */
     switch (glyph->u.notes.glyph_type) {
     case G_TRIGONUS:
     case G_PUNCTA_INCLINATA:
@@ -1427,9 +1426,9 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
     if (current_note->u.note.shape == S_PUNCTUM_INCLINATUM_DEMINUTUS) {
         punctum_inclinatum = 1;
     }
-    // when the punctum mora is on a note on a line, and the prior note is on
-    // the space immediately above, the dot is placed on the space below the
-    // line instead
+    /* when the punctum mora is on a note on a line, and the prior note is on
+     * the space immediately above, the dot is placed on the space below the
+     * line instead */
     if (current_note->previous
             && (current_note->previous->u.note.pitch -
                     current_note->u.note.pitch == 1)
@@ -1456,14 +1455,14 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
         }
         return;
     }
-    // There are two special cases. The first: if the next glyph is a
-    // ZERO_WIDTH_SPACE, and the current glyph is a PES, and the punctum mora
-    // is
-    // on the first note, and the first note of the next glyph is at least two
-    // (or three depending on something) pitches higher than the current note.
-    // You'll all have understood, this case is quite rare... but when it
-    // appears, we pass 1 as a second argument of \punctummora so that it
-    // removes the space introduced by the punctummora.
+    /* There are two special cases. The first: if the next glyph is a
+     * ZERO_WIDTH_SPACE, and the current glyph is a PES, and the punctum mora
+     * is on the first note, and the first note of the next glyph is at least
+     * two (or three depending on something) pitches higher than the current
+     * note.
+     * You'll all have understood, this case is quite rare... but when it
+     * appears, we pass 1 as a second argument of \punctummora so that it
+     * removes the space introduced by the punctummora. */
     if (glyph->u.notes.glyph_type == G_PODATUS && glyph->next
             && glyph->next->type == GRE_SPACE
             && current_note->next && glyph->next->next
@@ -1475,8 +1474,8 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
                 special_punctum, punctum_inclinatum);
         return;
     }
-    // if there is a punctum or a auctum dumplex on a note after, we put a
-    // zero-width punctum
+    /* if there is a punctum or a auctum dumplex on a note after, we put a
+     * zero-width punctum */
     tmpnote = current_note->next;
     while (tmpnote) {
         if (tmpnote->signs == _PUNCTUM_MORA || tmpnote->signs == _AUCTUM_DUPLEX
@@ -1489,12 +1488,12 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
         tmpnote = tmpnote->next;
     }
 
-    // the normal operation
+    /* the normal operation */
     fprintf(f, "\\GrePunctumMora{%d}{%d}{%d}{%d}%%\n", pitch_value(pitch),
             no_space, special_punctum, punctum_inclinatum);
 }
 
-static inline int get_punctum_inclinatum_space_case(
+static __inline int get_punctum_inclinatum_space_case(
         const gregorio_note *const note)
 {
     char temp;
@@ -1503,12 +1502,14 @@ static inline int get_punctum_inclinatum_space_case(
     case S_PUNCTUM_INCLINATUM:
     case S_PUNCTUM_CAVUM_INCLINATUM:
         if (note->previous) {
-            // means that it is the first note of the puncta inclinata sequence
+            /* means that it is the first note of the puncta inclinata
+             * sequence */
             temp = note->previous->u.note.pitch - note->u.note.pitch;
-            // if (temp < -1 || temp > 1)
+            /* if (temp < -1 || temp > 1) */
             switch (temp) {
-                // we switch on the range of the inclinata this will look
-                // somewhat strange if temp is negative... to be aligned then,
+                /* we switch on the range of the inclinata this will look
+                 * somewhat strange if temp is negative... to be aligned
+                 * then, */
             case -2:
             case 2:
                 return 10;
@@ -1517,7 +1518,7 @@ static inline int get_punctum_inclinatum_space_case(
                 return 11;
             case -4:
             case 4:
-                // not sure we ever need to consider a larger ambitus here
+                /* not sure we ever need to consider a larger ambitus here */
                 return 11;
             default:
                 return 3;
@@ -1527,7 +1528,8 @@ static inline int get_punctum_inclinatum_space_case(
         break;
     case S_PUNCTUM_INCLINATUM_DEMINUTUS:
         if (note->previous) {
-            // means that it is the first note of the puncta inclinata sequence
+            /* means that it is the first note of the puncta inclinata
+             * sequence */
             temp = note->previous->u.note.pitch - note->u.note.pitch;
             if (temp < -2 || temp > 2) {
                 return 11;
@@ -1536,13 +1538,14 @@ static inline int get_punctum_inclinatum_space_case(
                         && note->previous->u.note.shape ==
                         S_PUNCTUM_INCLINATUM_DEMINUTUS) {
                     if (temp < -1 || temp > 1) {
-                        // really if the ambitus = 3rd at this point
+                        /* really if the ambitus = 3rd at this point */
                         return 10;
                     } else {
                         return 8;
                     }
                 } else {
-                    // puncta inclinatum followed by puncta inclinatum debilis
+                    /* puncta inclinatum followed by puncta inclinatum
+                     * debilis */
                     return 7;
                 }
             }
@@ -1551,12 +1554,13 @@ static inline int get_punctum_inclinatum_space_case(
     case S_PUNCTUM_INCLINATUM_AUCTUS:
     case S_PUNCTUM_CAVUM_INCLINATUM_AUCTUS:
         if (note->previous) {
-            // means that it is the first note of the puncta inclinata sequence
+            /* means that it is the first note of the puncta inclinata
+             * sequence */
             temp = note->previous->u.note.pitch - note->u.note.pitch;
             if (temp < -1 || temp > 1) {
                 return 1;
             } else {
-                // we approximate that it is the same space
+                /* we approximate that it is the same space */
                 return 3;
             }
         }
@@ -1568,7 +1572,7 @@ static inline int get_punctum_inclinatum_space_case(
     return -1;
 }
 
-static inline void write_single_hepisemus(FILE *const f, int hepisemus_case,
+static __inline void write_single_hepisemus(FILE *const f, int hepisemus_case,
         const gregorio_note *const note, bool connect, char height,
         const grehepisemus_size size, const int i,
         const gregorio_glyph *const glyph,
@@ -1608,7 +1612,7 @@ static inline void write_single_hepisemus(FILE *const f, int hepisemus_case,
                             || glyph->next->type != GRE_SPACE
                             || glyph->next->u.misc.unpitched.info.space
                             != SP_ZERO_WIDTH)) {
-                    // not followed by a zero-width space
+                    /* not followed by a zero-width space */
                     fprintf(f, "\\GreHEpisemusBridge{%d}{%d}{-1}%%\n",
                             pitch_value(height), hepisemus_case);
                 } else if (note->next
@@ -1617,7 +1621,7 @@ static inline void write_single_hepisemus(FILE *const f, int hepisemus_case,
                             == S_PUNCTUM_INCLINATUM_DEMINUTUS
                             || note->next->u.note.shape
                             == S_PUNCTUM_INCLINATUM_AUCTUS)) {
-                    // is a punctum inclinatum of some sort
+                    /* is a punctum inclinatum of some sort */
                     fprintf(f, "\\GreHEpisemusBridge{%d}{%d}{%d}%%\n",
                             pitch_value(height), hepisemus_case,
                             get_punctum_inclinatum_space_case(note->next));
@@ -1654,7 +1658,7 @@ static void gregoriotex_write_hepisemus(FILE *const f,
         porrectus_long_episemus_index = 2;
         break;
     default:
-        // do nothing
+        /* do nothing */
         break;
     }
 
@@ -1666,7 +1670,7 @@ static void gregoriotex_write_hepisemus(FILE *const f,
             porrectus_long_episemus_index, &gtex_is_h_episemus_above_shown);
 }
 
-// a macro to write an additional line
+/* a macro to write an additional line */
 
 static void gregoriotex_write_additional_line(FILE *f,
         int i, gtex_type type, bool bottom,
@@ -1678,8 +1682,8 @@ static void gregoriotex_write_additional_line(FILE *f,
                 "gregoriotex_write_additional_line", VERBOSITY_ERROR, 0);
         return;
     }
-    // patch to get a line under the full glyph in the case of dbc (for
-    // example)
+    /* patch to get a line under the full glyph in the case of dbc (for
+     * example) */
     switch (type) {
     case T_PORRECTUS:
     case T_PORRECTUS_FLEXUS:
@@ -1691,7 +1695,7 @@ static void gregoriotex_write_additional_line(FILE *f,
                     && current_note->previous->u.note.pitch
                     <= PITCH_ABOVE_STAFF) {
                 i = HEPISEMUS_FIRST_TWO;
-                // HEPISEMUS_FIRST_TWO works only for first note
+                /* HEPISEMUS_FIRST_TWO works only for first note */
                 current_note = current_note->previous;
             } else {
                 return;
@@ -1700,7 +1704,7 @@ static void gregoriotex_write_additional_line(FILE *f,
         if (i == 3) {
             if (bottom || current_note->previous->u.note.pitch
                     > PITCH_ABOVE_STAFF) {
-                // we don't need to add twice the same line
+                /* we don't need to add twice the same line */
                 return;
             }
         }
@@ -1715,7 +1719,7 @@ static void gregoriotex_write_additional_line(FILE *f,
                     && current_note->previous->u.note.pitch
                     <= PITCH_ABOVE_STAFF) {
                 i = HEPISEMUS_FIRST_TWO;
-                // HEPISEMUS_FIRST_TWO works only for first note
+                /* HEPISEMUS_FIRST_TWO works only for first note */
                 current_note = current_note->previous;
             } else {
                 return;
@@ -1724,7 +1728,7 @@ static void gregoriotex_write_additional_line(FILE *f,
         if (i == 4) {
             if (bottom || current_note->previous->u.note.pitch
                     > PITCH_ABOVE_STAFF) {
-                // we don't need to add twice the same line
+                /* we don't need to add twice the same line */
                 return;
             }
         }
@@ -1734,8 +1738,8 @@ static void gregoriotex_write_additional_line(FILE *f,
     }
 
     if (i == HEPISEMUS_FIRST_TWO) {
-        // here we must compare the first note of the big bar with the second
-        // one, but it may be tricky sometimes, because of the previous patch
+        /* here we must compare the first note of the big bar with the second
+         * one, but it may be tricky sometimes, because of the previous patch */
         if (current_note->previous &&
                 current_note->previous->u.note.pitch >
                 current_note->u.note.pitch) {
@@ -1796,7 +1800,8 @@ static void gregoriotex_write_rare(FILE *f, gregorio_note *current_note,
                 pitch_value(current_note->u.note.pitch),
                 current_note->gtex_offset_case);
         break;
-        // the cases of the bar signs are dealt in another function (write_bar)
+        /* the cases of the bar signs are dealt in another function
+         * (write_bar) */
     default:
         break;
     }
@@ -1812,7 +1817,7 @@ static void gregoriotex_write_note(FILE *f, gregorio_note *note,
     unsigned int initial_shape = note->u.note.shape;
     const char *shape;
     int space_case;
-    // type in the sense of GregorioTeX alignment type
+    /* type in the sense of GregorioTeX alignment type */
     gtex_alignment type = AT_ONE_NOTE;
     if (!note) {
         gregorio_message(_
@@ -1839,7 +1844,7 @@ static void gregoriotex_write_note(FILE *f, gregorio_note *note,
     }
     shape = gregoriotex_determine_note_glyph_name(note, glyph, element, &type);
     note->u.note.shape = initial_shape;
-    // special things for puncta inclinata
+    /* special things for puncta inclinata */
     space_case = get_punctum_inclinatum_space_case(note);
     if (space_case >= 0) {
         fprintf(f, "\\GreEndOfGlyph{%d}%%\n", space_case);
@@ -1883,8 +1888,8 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
     int result = 0;
     gtex_alignment type = AT_ONE_NOTE;
     gtex_type gtype = T_ONE_NOTE;
-    // alteration says if there is a flat or a natural first in the next
-    // syllable, see gregoriotex.tex for more details
+    /* alteration says if there is a flat or a natural first in the next
+     * syllable, see gregoriotex.tex for more details */
     int alteration = 0;
     gregorio_glyph *glyph;
     gregorio_element *element;
@@ -1935,7 +1940,7 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
                         alteration = 60;
                         break;
                     default:
-                        // do nothing
+                        /* do nothing */
                         break;
                     }
                 }
@@ -1981,7 +1986,7 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
     return 0;
 }
 
-static inline void write_low_choral_sign(FILE *const f,
+static __inline void write_low_choral_sign(FILE *const f,
         const gregorio_note *const note, int special)
 {
     fprintf(f, "\\GreLowChoralSign{%d}{%s%s%s}{%d}%%\n",
@@ -1990,7 +1995,7 @@ static inline void write_low_choral_sign(FILE *const f,
             note->choral_sign, note->choral_sign_is_nabc? "}" : "", special);
 }
 
-static inline void write_high_choral_sign(FILE *const f,
+static __inline void write_high_choral_sign(FILE *const f,
         const gregorio_note *const note, int pitch_offset)
 {
     fprintf(f, "\\GreHighChoralSign{%d}{%s%s%s}{\\GreOCase%s}%%\n",
@@ -2004,19 +2009,19 @@ static void gregoriotex_write_choral_sign(FILE *f, gregorio_glyph *glyph,
         gregorio_note *current_note, bool low)
 {
     bool kind_of_pes;
-    // false in the normal case (sign above the note), true in the case of it's
-    // next to the note (same height as a punctum)
+    /* false in the normal case (sign above the note), true in the case of it's
+     * next to the note (same height as a punctum) */
     bool low_sign = choral_sign_here_is_low(glyph, current_note, &kind_of_pes);
 
-    // the low choral signs must be typeset after the punctum, whereas the high
-    // must be typeset before the h episemus
+    /* the low choral signs must be typeset after the punctum, whereas the high
+     * must be typeset before the h episemus */
     if ((low_sign && !low) || (!low_sign && low)) {
         return;
     }
 
     if (low_sign) {
-        // very approximative heuristic, some things may have to be adapted
-        // here...
+        /* very approximative heuristic, some things may have to be adapted
+         * here... */
         if (is_on_a_line(current_note->u.note.pitch)) {
             if (kind_of_pes && current_note->u.note.pitch -
                     current_note->next->u.note.pitch == -1) {
@@ -2034,7 +2039,7 @@ static void gregoriotex_write_choral_sign(FILE *f, gregorio_glyph *glyph,
 
         write_low_choral_sign(f, current_note, 0);
     } else {
-        // let's cheat a little
+        /* let's cheat a little */
         if (is_on_a_line(current_note->u.note.pitch)) {
             write_high_choral_sign(f, current_note, 0);
         } else {
@@ -2054,8 +2059,8 @@ static void gregoriotex_write_choral_sign(FILE *f, gregorio_glyph *glyph,
  * 
  */
 
-// small helper
-static inline bool _found(FILE *const f, const bool found)
+/* small helper */
+static __inline bool _found(FILE *const f, const bool found)
 {
     if (!found) {
         fprintf (f, "%%\n");\
@@ -2069,7 +2074,7 @@ static void compute_height_extrema(const gregorio_glyph *const glyph,
         signed char *const bottom_height)
 {
     char height;
-    // get the minima/maxima pitches
+    /* get the minima/maxima pitches */
     for (; note; note = note->next) {
         if (note->h_episemus_above) {
             height = note->h_episemus_above;
@@ -2104,14 +2109,14 @@ static void compute_height_extrema(const gregorio_glyph *const glyph,
     }
 }
 
-static inline void fixup_height_extrema(signed char *const top_height,
+static __inline void fixup_height_extrema(signed char *const top_height,
         signed char *const bottom_height)
 {
     if (*top_height == UNDETERMINED_HEIGHT) {
-        *top_height = 9; // 'g'
+        *top_height = 9; /* 'g' */
     }
     if (*bottom_height == UNDETERMINED_HEIGHT) {
-        *bottom_height = 9; // 'g'
+        *bottom_height = 9; /* 'g' */
     }
 }
 
@@ -2119,20 +2124,21 @@ static void gregoriotex_write_signs(FILE *f, gtex_type type,
         gregorio_glyph *glyph, gregorio_note *note,
         gregoriotex_status *const status)
 {
-    // i is the number of the note for which we are typesetting the sign.
+    /* i is the number of the note for which we are typesetting the sign. */
     int i;
     gregorio_note *current_note;
-    // a dumb char
+    /* a dumb char */
     char block_hepisemus = 0;
     signed char high_pitch = UNDETERMINED_HEIGHT;
     signed char low_pitch = UNDETERMINED_HEIGHT;
+    bool found = false;
     compute_height_extrema(glyph, note, &high_pitch, &low_pitch);
     fixup_height_extrema(&high_pitch, &low_pitch);
     fprintf(f, "%%\n{%%\n\\GreGlyphHeights{%d}{%d}%%\n",
             pitch_value(high_pitch), pitch_value(low_pitch));
     for (current_note = note, i = 1; current_note;
             current_note = current_note->next, ++i) {
-        // we start by the additional lines
+        /* we start by the additional lines */
         if (current_note->u.note.pitch < PITCH_BELOW_STAFF) {
             gregoriotex_write_additional_line(f, i, type, true, current_note);
             status->bottom_line = 1;
@@ -2149,9 +2155,8 @@ static void gregoriotex_write_signs(FILE *f, gtex_type type,
         }
     }
     fprintf(f, "}{");
-    bool found = false;
-    // now a first loop for the choral signs, because high signs must be taken
-    // into account before any hepisemus
+    /* now a first loop for the choral signs, because high signs must be taken
+     * into account before any hepisemus */
     for (current_note = note, i = 1; current_note;
             current_note = current_note->next, ++i) {
         if (current_note->choral_sign) {
@@ -2162,15 +2167,15 @@ static void gregoriotex_write_signs(FILE *f, gtex_type type,
             break;
         }
     }
-    // a loop for rare signs, vertical episemus, and horizontal episemus
+    /* a loop for rare signs, vertical episemus, and horizontal episemus */
     for (current_note = note, i = 1; current_note;
             current_note = current_note->next, ++i) {
-        // we continue with the hepisemus
+        /* we continue with the hepisemus */
         if (current_note->h_episemus_above || current_note->h_episemus_below) {
             found = _found(f, found);
             gregoriotex_write_hepisemus(f, current_note, i, type, glyph);
         }
-        // write_rare also writes the vepisemus
+        /* write_rare also writes the vepisemus */
         if (current_note->special_sign) {
             found = _found(f, found);
             gregoriotex_write_rare(f, current_note, current_note->special_sign);
@@ -2185,10 +2190,10 @@ static void gregoriotex_write_signs(FILE *f, gtex_type type,
             gregoriotex_write_vepisemus(f, current_note);
             break;
         default:
-            // do nothing
+            /* do nothing */
             break;
         }
-        // why is this if there?...
+        /* why is this if there?... */
         if (!current_note->special_sign) {
             if (block_hepisemus == 2) {
                 block_hepisemus = 0;
@@ -2201,7 +2206,7 @@ static void gregoriotex_write_signs(FILE *f, gtex_type type,
             break;
         }
     }
-    // final loop for choral signs and punctum mora
+    /* final loop for choral signs and punctum mora */
     for (current_note = note, i = 1; current_note;
             current_note = current_note->next, ++i) {
         switch (current_note->signs) {
@@ -2273,13 +2278,13 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
         gregorio_element *element, gregorio_glyph *glyph,
         gregoriotex_status *const status)
 {
-    // glyph number is the number of the glyph in the fonte, it is discussed in
-    // later comments
-    // type is the type of the glyph. Understand the type of the glyph for
-    // gregoriotex, for the alignement between text and notes. (AT_ONE_NOTE,
-    // etc.)
+    /* glyph number is the number of the glyph in the fonte, it is discussed in
+     * later comments
+     * type is the type of the glyph. Understand the type of the glyph for
+     * gregoriotex, for the alignement between text and notes. (AT_ONE_NOTE,
+     * etc.) */
     gtex_alignment type = 0;
-    // the type of the glyph, in the sense of the shape (T_PES, etc.)
+    /* the type of the glyph, in the sense of the shape (T_PES, etc.) */
     gtex_type gtype = 0;
     char next_note_pitch = 0;
     gregorio_note *current_note;
@@ -2296,10 +2301,10 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
     }
     next_note_pitch = gregorio_determine_next_pitch(syllable, element, glyph);
     current_note = glyph->u.notes.first_note;
-    // first we check if it is really a unique glyph in gregoriotex... the
-    // glyphs that are not a unique glyph are : trigonus and pucta inclinata
-    // in general, and torculus resupinus and torculus resupinus flexus, so
-    // we first divide the glyph into real gregoriotex glyphs
+    /* first we check if it is really a unique glyph in gregoriotex... the
+     * glyphs that are not a unique glyph are : trigonus and pucta inclinata
+     * in general, and torculus resupinus and torculus resupinus flexus, so
+     * we first divide the glyph into real gregoriotex glyphs */
     switch (glyph->u.notes.glyph_type) {
     case G_TRIGONUS:
     case G_PUNCTA_INCLINATA:
@@ -2361,7 +2366,7 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
         break;
     case G_TORCULUS_RESUPINUS_FLEXUS:
         leading_shape = determine_leading_shape(glyph);
-        // trick to have the good position for these glyphs
+        /* trick to have the good position for these glyphs */
         glyph->u.notes.glyph_type = G_PORRECTUS_FLEXUS_NO_BAR;
         glyph->u.notes.first_note = current_note->next;
         shape = gregoriotex_determine_glyph_name(glyph, element, &type, &gtype);
@@ -2424,7 +2429,7 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
                 break;
             }
         }
-        // else fall into the next case
+        /* else fall into the next case */
     case G_PUNCTUM_INCLINATUM:
     case G_VIRGA:
     case G_VIRGA_REVERSA:
@@ -2435,13 +2440,13 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
         gregoriotex_write_signs(f, T_ONE_NOTE, glyph, current_note, status);
         break;
     default:
-        // special case of the torculus resupinus which first note is not a
-        // punctum
+        /* special case of the torculus resupinus which first note is not a
+         * punctum */
         if (glyph->u.notes.glyph_type == G_TORCULUS_RESUPINUS
                 && current_note->u.note.shape != S_PUNCTUM
                 && current_note->u.note.shape != S_QUILISMA) {
             leading_shape = determine_leading_shape(glyph);
-            // trick to have the good position for these glyphs
+            /* trick to have the good position for these glyphs */
             glyph->u.notes.glyph_type = G_PORRECTUS_NO_BAR;
             glyph->u.notes.first_note = current_note->next;
             shape = gregoriotex_determine_glyph_name(glyph, element, &type,
@@ -2468,19 +2473,19 @@ static void gregoriotex_write_glyph(FILE *f, gregorio_syllable *syllable,
     }
 }
 
-// here we absolutely need to pass the syllable as an argument, because we
-// will need the next note, that may be contained in the next syllable
+/* here we absolutely need to pass the syllable as an argument, because we
+ * will need the next note, that may be contained in the next syllable */
 
 static void gregoriotex_write_element(FILE *f, gregorio_syllable *syllable,
         gregorio_element *element, gregoriotex_status *status)
 {
     if (element->type == GRE_ELEMENT) {
-        for (gregorio_glyph *glyph = element->u.first_glyph; glyph;
-                glyph = glyph->next) {
+        gregorio_glyph *glyph;
+        for (glyph = element->u.first_glyph; glyph; glyph = glyph->next) {
             switch (glyph->type) {
             case GRE_SPACE:
-                // we assume here that it is a SP_ZERO_WIDTH, the only one a
-                // glyph can be
+                /* we assume here that it is a SP_ZERO_WIDTH, the only one a
+                 * glyph can be */
                 fprintf(f, "\\GreEndOfGlyph{1}%%\n");
                 break;
 
@@ -2512,7 +2517,7 @@ static void gregoriotex_write_element(FILE *f, gregorio_syllable *syllable,
                 break;
 
             default:
-                // at this point glyph->type is GRE_GLYPH
+                /* at this point glyph->type is GRE_GLYPH */
                 assert(glyph->type == GRE_GLYPH);
                 gregoriotex_write_glyph(f, syllable, element, glyph, status);
                 if (glyph->next && glyph->next->type == GRE_GLYPH) {
@@ -2593,8 +2598,8 @@ static void gregoriotex_print_change_line_clef(FILE *f,
     }
     if (current_element->type == GRE_F_KEY_CHANGE) {
         if (current_element->u.misc.pitched.flatted_key) {
-            // the third argument is 0 or 1 according to the need for a
-            // space before the clef
+            /* the third argument is 0 or 1 according to the need for a
+             * space before the clef */
             fprintf(f, "\\GreSetLinesClef{f}{%d}{1}{%d}%%\n",
                     current_element->u.misc.pitched.pitch - '0',
                     gregoriotex_clef_flat_height('f',
@@ -2608,10 +2613,12 @@ static void gregoriotex_print_change_line_clef(FILE *f,
 
 static void handle_final_bar(FILE *f, const char *type, gregorio_syllable *syllable)
 {
+    gregorio_element *element;
     fprintf(f, "\\GreFinal%s{%%\n", type);
-    // first element will be the bar, which we just handled, so skip it
-    for (gregorio_element *element = (*syllable->elements)->next; element;
+    /* first element will be the bar, which we just handled, so skip it */
+    for (element = (*syllable->elements)->next; element;
             element = element->next) {
+        gregorio_glyph *glyph;
         switch (element->type) {
         case GRE_TEXVERB_ELEMENT:
             if (element->texverb) {
@@ -2621,7 +2628,7 @@ static void handle_final_bar(FILE *f, const char *type, gregorio_syllable *sylla
             break;
 
         case GRE_ELEMENT:
-            for (gregorio_glyph *glyph = element->u.first_glyph; glyph;
+            for (glyph = element->u.first_glyph; glyph;
                     glyph = glyph->next) {
                 if (glyph->type == GRE_MANUAL_CUSTOS) {
                     fprintf(f, "\\GreManualCusto{%d}%%\n",
@@ -2631,21 +2638,21 @@ static void handle_final_bar(FILE *f, const char *type, gregorio_syllable *sylla
             break;
 
         default:
-            // do nothing
+            /* do nothing */
             break;
         }
     }
     fprintf(f, "}%%\n");
 }
 
-static inline bool is_manual_custos(const gregorio_element *element)
+static __inline bool is_manual_custos(const gregorio_element *element)
 {
     return element->type == GRE_ELEMENT
             && element->u.first_glyph
             && element->u.first_glyph->type == GRE_MANUAL_CUSTOS;
 }
 
-static inline bool next_is_bar(const gregorio_syllable *syllable,
+static __inline bool next_is_bar(const gregorio_syllable *syllable,
         const gregorio_element *element)
 {
     bool got_custos = false;
@@ -2658,13 +2665,13 @@ static inline bool next_is_bar(const gregorio_syllable *syllable,
             if (element->type == GRE_BAR) {
                 return true;
             }
-            // allow no more than one manual custos before a bar
+            /* allow no more than one manual custos before a bar */
             if (got_custos || !is_manual_custos(element)) {
                 return false;
             }
             got_custos = true;
             if (element->next) {
-                // look at the next element
+                /* look at the next element */
                 element = element->next;
                 continue;
             }
@@ -2681,15 +2688,15 @@ static inline bool next_is_bar(const gregorio_syllable *syllable,
             return false;
         }
 
-        // the next syllable is a GRE_SYLLABLE; so look at the element
+        /* the next syllable is a GRE_SYLLABLE; so look at the element */
         element = syllable->elements[0];
     }
 
-    assert(false); // should never reach here
-    return false; // avoid gcc 5.1 warning
+    assert(false); /* should never reach here */
+    return false; /* avoid gcc 5.1 warning */
 }
 
-static inline void write_syllable_point_and_click(FILE *const f,
+static __inline void write_syllable_point_and_click(FILE *const f,
         const gregorio_syllable *const syllable,
         const gregoriotex_status *const status)
 {
@@ -2716,12 +2723,12 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
         bool * first_syllable, unsigned char *line_number,
         unsigned char first_of_disc, gregoriotex_status *const status)
 {
-    gregorio_element *clef_change_element = NULL;
+    gregorio_element *clef_change_element = NULL, *element;
     if (!syllable) {
         return;
     }
-    // Very first: before anything, if the syllable is the beginning of a
-    // no-linebreak area:
+    /* Very first: before anything, if the syllable is the beginning of a
+     * no-linebreak area: */
     if (syllable->no_linebreak_area == NLBA_BEGINNING) {
         fprintf(f, "\\GreBeginNLBArea{1}{0}%%\n");
     }
@@ -2843,7 +2850,7 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
     }
     fprintf(f, "}{%%\n");
 
-    for (gregorio_element *element = *syllable->elements; element;
+    for (element = *syllable->elements; element;
             element = element->next) {
         if (element->nabc_lines && element->nabc) {
             size_t i;
@@ -2909,8 +2916,8 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                  */
                 if (element->previous && element->previous->type == GRE_BAR) {
                     if (element->u.misc.pitched.flatted_key) {
-                        // the third argument is 0 or 1 according to the need for a
-                        // space before the clef
+                        /* the third argument is 0 or 1 according to the need
+                         * for a space before the clef */
                         fprintf(f, "\\GreChangeClef{c}{%d}{0}{%d}%%\n",
                                 element->u.misc.pitched.pitch - '0',
                                 gregoriotex_clef_flat_height('c',
@@ -2922,8 +2929,8 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                     }
                 } else {
                     if (element->u.misc.pitched.flatted_key) {
-                        // the third argument is 0 or 1 according to the need for a
-                        // space before the clef
+                        /* the third argument is 0 or 1 according to the need
+                         * for a space before the clef */
                         fprintf(f, "\\GreChangeClef{c}{%d}{1}{%d}%%\n",
                                 element->u.misc.pitched.pitch - '0',
                                 gregoriotex_clef_flat_height('c',
@@ -2944,8 +2951,8 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                  */
                 if (element->previous && element->previous->type == GRE_BAR) {
                     if (element->u.misc.pitched.flatted_key) {
-                        // the third argument is 0 or 1 according to the need for a
-                        // space before the clef
+                        /* the third argument is 0 or 1 according to the need
+                         * for a space before the clef */
                         fprintf(f, "\\GreChangeClef{f}{%d}{0}{%d}%%\n",
                                 element->u.misc.pitched.pitch - '0',
                                 gregoriotex_clef_flat_height('f',
@@ -2957,8 +2964,8 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                     }
                 } else {
                     if (element->u.misc.pitched.flatted_key) {
-                        // the third argument is 0 or 1 according to the need for a
-                        // space before the clef
+                        /* the third argument is 0 or 1 according to the need
+                         * for a space before the clef */
                         fprintf(f, "\\GreChangeClef{f}{%d}{1}{%d}%%\n",
                                 element->u.misc.pitched.pitch - '0',
                                 gregoriotex_clef_flat_height('f',
@@ -2977,7 +2984,7 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                 /*
                  * We don't print custos before a bar at the end of a line 
                  */
-                // we also print an unbreakable larger space before the custo
+                /* we also print an unbreakable larger space before the custo */
                 fprintf(f, "\\GreEndOfElement{1}{1}%%\n\\GreCusto{%d}%%\n",
                         pitch_value(element->u.misc.pitched.pitch));
             }
@@ -2991,8 +2998,8 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
             break;
 
         case GRE_END_OF_LINE:
-            // here we suppose we don't have two linebreaks in the same
-            // syllable
+            /* here we suppose we don't have two linebreaks in the same
+             * syllable */
             if (element->u.misc.unpitched.info.sub_type != GRE_END_OF_PAR) {
                 fprintf(f, "%%\n%%\n\\GreNewLine %%\n%%\n%%\n");
             } else {
@@ -3005,7 +3012,7 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
             break;
 
         default:
-            // there current_element->type is GRE_ELEMENT
+            /* there current_element->type is GRE_ELEMENT */
             assert(element->type == GRE_ELEMENT);
             gregoriotex_write_element(f, syllable, element, status);
             if (element->next && (element->next->type == GRE_ELEMENT
@@ -3023,7 +3030,7 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
             || syllable->position == WORD_ONE_SYLLABLE || !syllable->text) {
         fprintf(f, "%%\n");
     }
-    // Very last, if the syllable is the end of a no-linebreak area:
+    /* Very last, if the syllable is the end of a no-linebreak area: */
     if (syllable->no_linebreak_area == NLBA_END) {
         fprintf(f, "\\GreEndNLBArea{%d}{0}%%\n",
                 next_is_bar(syllable, NULL)? 3 : 1);
@@ -3042,7 +3049,8 @@ static char *digest_to_hex(const unsigned char digest[SHA1_DIGEST_SIZE])
     char *p = result;
     unsigned char byte;
 
-    for (int i = 0; i < SHA1_DIGEST_SIZE; ++i) {
+    int i;
+    for (i = 0; i < SHA1_DIGEST_SIZE; ++i) {
         byte = digest[i];
 
         *(p++) = hex[(byte >> 4) & 0x0FU];
@@ -3057,12 +3065,16 @@ static char *digest_to_hex(const unsigned char digest[SHA1_DIGEST_SIZE])
 static void initialize_score(gregoriotex_status *const status,
         gregorio_score *score, const bool point_and_click)
 {
+    gregorio_syllable *syllable;
+
     status->bottom_line = false;
     status->top_height = status->bottom_height = UNDETERMINED_HEIGHT;
     status->abovelinestext = status->translation = false;
 
-    for (gregorio_syllable *syllable = score->first_syllable; syllable;
+    for (syllable = score->first_syllable; syllable;
             syllable = syllable->next_syllable) {
+        int voice;
+
         if (syllable->translation) {
             status->translation = true;
         }
@@ -3071,17 +3083,21 @@ static void initialize_score(gregoriotex_status *const status,
             status->abovelinestext = true;
         }
 
-        for (int voice = 0; voice < score->number_of_voices; ++voice) {
+        for (voice = 0; voice < score->number_of_voices; ++voice) {
+            gregorio_element *element;
+
             gregoriotex_compute_positioning(syllable->elements[voice]);
-            for (gregorio_element *element = syllable->elements[voice]; element;
+            for (element = syllable->elements[voice]; element;
                     element = element->next) {
+                gregorio_glyph *glyph;
+
                 switch (element->type) {
                 case GRE_ALT:
                     status->abovelinestext = true;
                     break;
 
                 case GRE_ELEMENT:
-                    for (gregorio_glyph *glyph = element->u.first_glyph; glyph;
+                    for (glyph = element->u.first_glyph; glyph;
                             glyph = glyph->next) {
                         if (glyph->type == GRE_GLYPH) {
                             compute_height_extrema(glyph,
@@ -3093,7 +3109,7 @@ static void initialize_score(gregoriotex_status *const status,
                     break;
 
                 default:
-                    // to eliminate the warning
+                    /* to eliminate the warning */
                     break;
                 }
             }
@@ -3109,15 +3125,15 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
         const char *const point_and_click_filename)
 {
     gregorio_character *first_text;
-    // true if it is the first syllable and false if not.
-    // It is for the initial.
+    /* true if it is the first syllable and false if not.
+     * It is for the initial. */
     bool first_syllable = false;
     char clef_letter;
     int clef_line;
     char clef_flat = NO_KEY_FLAT;
     gregorio_syllable *current_syllable;
-    // the current line (as far as we know), it is always 0, it can be 1 in the
-    // case of the first line of a score with a two lines initial
+    /* the current line (as far as we know), it is always 0, it can be 1 in the
+     * case of the first line of a score with a two lines initial */
     unsigned char line = 0;
     int annotation_num;
     gregoriotex_status status;
@@ -3166,13 +3182,13 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
         fprintf(f, "\\defaultcentering%%\n");
         break;
     default:
-        // don't set any centering
+        /* don't set any centering */
         break;
     }
     if (score->nabc_lines) {
         fprintf(f, "\\scorenabclines{%d}", (int)score->nabc_lines);
     }
-    // we select the good font -- Deprecated (remove in next release)
+    /* we select the good font -- Deprecated (remove in next release) */
     if (score->gregoriotex_font) {
         if (!strcmp(score->gregoriotex_font, "gregorio")) {
             fprintf(f, "\\gresetgregoriofont{gregorio}%%\n");
@@ -3184,7 +3200,7 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
             fprintf(f, "\\gresetgregoriofont{greciliae}%%\n");
         }
     }
-    // end Deprecated section
+    /* end Deprecated section */
     if (score->annotation[0]) {
         fprintf(f, "\\GreAnnotationLines");
         for (annotation_num = 0; annotation_num < MAX_ANNOTATIONS;
@@ -3202,7 +3218,7 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
     if (score->mode != 0) {
         fprintf(f, "\\GreMode{%d}%%\n", score->mode);
     }
-    // first we draw the initial (first letter) and the initial key
+    /* first we draw the initial (first letter) and the initial key */
     if (score->initial_style == NO_INITIAL) {
         fprintf(f, "\\GreNoInitial %%\n");
     } else {

--- a/src/gregoriotex/gregoriotex.h
+++ b/src/gregoriotex/gregoriotex.h
@@ -20,7 +20,7 @@
 #ifndef GREGORIOTEX_H
 #define GREGORIOTEX_H
 
-#include <stdbool.h>
+#include "bool.h"
 
 #define OFFSET_CASE(name) static const char *const name = #name
 

--- a/src/gregoriotex/gregoriotex.h
+++ b/src/gregoriotex/gregoriotex.h
@@ -30,7 +30,7 @@
 
 typedef enum gtex_type {
     T_ONE_NOTE = 1,
-    // two note neumes
+    /* two note neumes */
     T_PES,
     T_PESQUADRATUM,
     T_PESQUADRATUM_LONGQUEUE,
@@ -45,24 +45,24 @@ typedef enum gtex_type {
     T_FLEXUS_ORISCUS_SCAPUS,
     T_FLEXUS_ORISCUS_SCAPUS_LONGQUEUE,
     T_VIRGA_STRATA,
-    // three note neumes
+    /* three note neumes */
     T_PORRECTUS,
     T_TORCULUS,
     T_TORCULUS_QUILISMA,
-    T_SCANDICUS, // only deminutus
-    T_ANCUS, // only deminutus
-    T_ANCUS_LONGQUEUE, // only deminutus
+    T_SCANDICUS, /* only deminutus */
+    T_ANCUS, /* only deminutus */
+    T_ANCUS_LONGQUEUE, /* only deminutus */
     T_SALICUS,
     T_SALICUS_LONGQUEUE,
-    // four note neumes
+    /* four note neumes */
     T_PORRECTUS_FLEXUS,
     T_TORCULUS_RESUPINUS,
     T_TORCULUS_LIQUESCENS,
-    T_TORCULUS_RESUPINUS_FLEXUS,
+    T_TORCULUS_RESUPINUS_FLEXUS
 } gtex_type;
 
-// the different types for the alignment of the notes in GregorioTeX
-// these values are numbers coded into GregorioTeX
+/* the different types for the alignment of the notes in GregorioTeX
+ * these values are numbers coded into GregorioTeX */
 typedef enum gtex_alignment {
     AT_ONE_NOTE = 0,
     AT_FLEXUS = 1,
@@ -73,36 +73,37 @@ typedef enum gtex_alignment {
     AT_PUNCTUM_INCLINATUM = 6,
     AT_STROPHA = 7,
     AT_FLEXUS_1 = 8,
-    AT_FLEXUS_DEMINUTUS = 9,
+    AT_FLEXUS_DEMINUTUS = 9
 } gtex_alignment;
 
-// Here we define a function that will determine the number of the
-// liquescentia that we will add to the glyph number. There are several types
-// as all glyphs can't have all liquescentiae. Let's first define the
-// different types:
+/* Here we define a function that will determine the number of the
+ * liquescentia that we will add to the glyph number. There are several types
+ * as all glyphs can't have all liquescentiae. Let's first define the
+ * different types: */
 
 typedef enum gtex_glyph_liquescentia {
-    // for glyphs that accept all liquecentiae
+    /* for glyphs that accept all liquecentiae */
     LG_ALL = 0,
-    // for glyphs that don't accept initio debilis
+    /* for glyphs that don't accept initio debilis */
     LG_NO_INITIO,
-    // for glyphs for which we don't know if the auctus is ascendens or descendens
+    /* for glyphs for which we don't know if the auctus is ascendens or
+     * descendens */
     LG_UNDET_AUCTUS,
-    // for glyphs that don't accept liquescentia
+    /* for glyphs that don't accept liquescentia */
     LG_NONE,
     LG_ONLY_DEMINUTUS,
     LG_NO_DEMINUTUS,
-    LG_ONLY_AUCTUS,
+    LG_ONLY_AUCTUS
 } gtex_glyph_liquescentia;
 
 typedef enum gtex_sign_type {
     ST_H_EPISEMUS = 0,
-    ST_V_EPISEMUS = 1,
+    ST_V_EPISEMUS = 1
 } gtex_sign_type;
 
 #define HEPISEMUS_FIRST_TWO 12
 
-static inline bool choral_sign_here_is_low(const gregorio_glyph *const glyph,
+static __inline bool choral_sign_here_is_low(const gregorio_glyph *const glyph,
         const gregorio_note *const note, bool *const kind_of_pes)
 {
     if (kind_of_pes) {
@@ -141,12 +142,12 @@ static inline bool choral_sign_here_is_low(const gregorio_glyph *const glyph,
     return false;
 }
 
-static inline bool is_on_a_line(const char pitch)
+static __inline bool is_on_a_line(const char pitch)
 {
     return pitch % 2 == 0;
 }
 
-static inline bool is_between_lines(const char pitch)
+static __inline bool is_between_lines(const char pitch)
 {
     return pitch % 2 == 1;
 }

--- a/src/messages.c
+++ b/src/messages.c
@@ -74,7 +74,7 @@ static const char *verbosity_to_str(const gregorio_verbosity verbosity)
         str = _("fatal error:");
         break;
     default:
-        // INFO, for example
+        /* INFO, for example */
         str = " ";
         break;
     }
@@ -117,7 +117,7 @@ void gregorio_messagef(const char *function_name,
                         function_name, verbosity_str);
             }
         } else {
-            // no function_name specified
+            /* no function_name specified */
             if (!file_name) {
                 fprintf(error_out, "line %d: %s", line_number, verbosity_str);
             } else {
@@ -135,9 +135,9 @@ void gregorio_messagef(const char *function_name,
              */
             fprintf(error_out, "in function `%s': %s", function_name,
                     verbosity_str);
-            // }
+            /* } */
         } else {
-            // no function_name specified
+            /* no function_name specified */
             /*
              * if (!file_name) {
              *     fprintf (error_out, "%s", verbosity_str);
@@ -145,7 +145,7 @@ void gregorio_messagef(const char *function_name,
              * } else {
              */
             fprintf(error_out, "%s", verbosity_str);
-            // }
+            /* } */
         }
     }
     va_start(args, format);

--- a/src/messages.c
+++ b/src/messages.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>             /* for exit() */
 #include <stdarg.h>             /* for exit() */
-#include <stdbool.h>
+#include "bool.h"
 #include "messages.h"
 
 static FILE *error_out;

--- a/src/messages.h
+++ b/src/messages.h
@@ -39,7 +39,7 @@ typedef enum gregorio_verbosity {
     VERBOSITY_WARNING,
     VERBOSITY_DEPRECATION,
     VERBOSITY_ERROR,
-    VERBOSITY_FATAL,
+    VERBOSITY_FATAL
 } gregorio_verbosity;
 
 void gregorio_message(const char *string, const char *function_name,

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -39,6 +39,9 @@
 
 #ifdef HAVE_STDALIGN_H
 #include <stdalign.h>
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wc11-extensions"
+#endif
 #else
 #define alignof(x) sizeof(x)
 #endif

--- a/src/struct.c
+++ b/src/struct.c
@@ -259,7 +259,7 @@ void gregorio_add_cs_to_note(gregorio_note *const*const current_note,
 void gregorio_add_special_sign(gregorio_note *note, gregorio_sign sign)
 {
     if (!note) {
-        // error
+        /* error */
         return;
     }
     note->special_sign = sign;
@@ -295,7 +295,7 @@ void gregorio_change_shape(gregorio_note *note, gregorio_shape shape)
             fix_punctum_cavum_inclinatum_liquescentia(note);
             break;
         }
-        // else fall through
+        /* else fall through */
 
     default:
         note->u.note.shape = shape;
@@ -363,7 +363,7 @@ void gregorio_add_liquescentia(gregorio_note *note, gregorio_liquescentia liq)
             note->u.note.liquescentia = L_AUCTA_INITIO_DEBILIS;
             break;
         default:
-            // do nothing
+            /* do nothing */
             break;
         }
     } else {
@@ -418,18 +418,18 @@ static void apply_auto_h_episemus(gregorio_note *const note,
 {
     if (note->h_episemus_above == HEPISEMUS_NONE
             && note->h_episemus_below == HEPISEMUS_NONE) {
-        // if both are unset, set both to auto
+        /* if both are unset, set both to auto */
         set_h_episemus_above(note, HEPISEMUS_AUTO, size, !disable_bridge);
         set_h_episemus_below(note, HEPISEMUS_AUTO, size, !disable_bridge);
     } else if (note->h_episemus_above == HEPISEMUS_AUTO
             && note->h_episemus_below == HEPISEMUS_AUTO) {
-        // if both are auto, then force both
-        // the upper episemus keeps its settings
+        /* if both are auto, then force both */
+        /* the upper episemus keeps its settings */
         note->h_episemus_above = HEPISEMUS_FORCED;
 
         set_h_episemus_below(note, HEPISEMUS_FORCED, size, !disable_bridge);
     } else {
-        // force whichever is not already forced
+        /* force whichever is not already forced */
         if (note->h_episemus_above != HEPISEMUS_FORCED) {
             set_h_episemus_above(note, HEPISEMUS_FORCED, size, !disable_bridge);
         }
@@ -511,7 +511,7 @@ void gregorio_add_h_episemus(gregorio_note *note,
             set_h_episemus_below(note, HEPISEMUS_FORCED, size, !disable_bridge);
             break;
 
-        default: // VPOS_AUTO
+        default: /* VPOS_AUTO */
             apply_auto_h_episemus(note, size, disable_bridge);
             *nbof_isolated_episemus = 1;
             break;
@@ -526,7 +526,7 @@ void gregorio_add_sign(gregorio_note *note, gregorio_sign sign,
         gregorio_vposition vposition)
 {
     if (!note) {
-        // error
+        /* error */
         return;
     }
     switch (sign) {
@@ -589,7 +589,7 @@ void gregorio_go_to_first_note(gregorio_note **note)
     *note = tmp;
 }
 
-static inline void free_one_note(gregorio_note *note)
+static __inline void free_one_note(gregorio_note *note)
 {
     free(note->texverb);
     free(note->choral_sign);
@@ -702,7 +702,7 @@ void gregorio_go_to_first_glyph(gregorio_glyph **glyph)
     *glyph = tmp;
 }
 
-static inline void free_one_glyph(gregorio_glyph *glyph)
+static __inline void free_one_glyph(gregorio_glyph *glyph)
 {
     free(glyph->texverb);
     if (glyph->type == GRE_GLYPH) {
@@ -782,7 +782,7 @@ void gregorio_add_misc_element(gregorio_element **current_element,
     }
 }
 
-static inline void free_one_element(gregorio_element *element)
+static __inline void free_one_element(gregorio_element *element)
 {
     size_t i;
     free(element->texverb);
@@ -1279,7 +1279,7 @@ void gregorio_set_score_annotation(gregorio_score *score, char *annotation)
                 "gregorio_set_annotation", VERBOSITY_WARNING, 0);
         return;
     }
-    // save the annotation in the first spare place.
+    /* save the annotation in the first spare place. */
     for (annotation_num = 0; annotation_num < MAX_ANNOTATIONS; ++annotation_num) {
         if (score->annotation[annotation_num] == NULL) {
             score->annotation[annotation_num] = annotation;
@@ -1529,7 +1529,7 @@ signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
                 "gregorio_determine_next_pitch", VERBOSITY_ERROR, 0);
         return DUMMY_PITCH;
     }
-    // we first explore the next glyphs to find a note, if there is one
+    /* we first explore the next glyphs to find a note, if there is one */
     if (glyph) {
         glyph = glyph->next;
         while (glyph) {
@@ -1543,7 +1543,7 @@ signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
             glyph = glyph->next;
         }
     }
-    // then we do the same with the elements
+    /* then we do the same with the elements */
     element = element->next;
     while (element) {
         if (element->type == GRE_ELEMENT && element->u.first_glyph) {
@@ -1562,19 +1562,19 @@ signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
         element = element->next;
     }
 
-    // then we do the same with the syllables
+    /* then we do the same with the syllables */
     syllable = syllable->next_syllable;
     while (syllable) {
-        // we call another function that will return the pitch of the first
-        // note if syllable has a note, and 0 else
+        /* we call another function that will return the pitch of the first
+         * note if syllable has a note, and 0 else */
         temp = gregorio_syllable_first_note(syllable);
         if (temp) {
             return temp;
         }
         syllable = syllable->next_syllable;
     }
-    // here it means that there is no next note, so we return a stupid value,
-    // but it won' t be used
+    /* here it means that there is no next note, so we return a stupid value,
+     * but it won' t be used */
     return DUMMY_PITCH;
 }
 
@@ -1668,8 +1668,8 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
         voice_info = voice_info->next_voice_info;
     }
 
-    // then we suppress syllables that contain nothing anymore : case of (c2)
-    // at beginning of files
+    /* then we suppress syllables that contain nothing anymore : case of (c2)
+     * at beginning of files */
 
     for (i = 0; i < score->number_of_voices; i++) {
         if (score->first_syllable->elements[i]) {
@@ -1682,8 +1682,8 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
         gregorio_free_one_syllable(&(score->first_syllable),
                                    score->number_of_voices);
     }
-    // finally we initialize voice infos that have no initial key to default
-    // key
+    /* finally we initialize voice infos that have no initial key to default
+     * key */
 
     voice_info = score->first_voice_info;
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -1627,7 +1627,6 @@ void gregorio_reinitialize_one_voice_alterations(char alterations[13])
 
 void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
 {
-    char *error;
     int clef = 0;
     gregorio_element *element;
     gregorio_voice_info *voice_info;
@@ -1639,7 +1638,6 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
                 "gregorio_fix_initial_keys", VERBOSITY_WARNING, 0);
         return;
     }
-    error = malloc(100 * sizeof(char));
     voice_info = score->first_voice_info;
     for (i = 0; i < score->number_of_voices; i++) {
         element = score->first_syllable->elements[i];
@@ -1653,11 +1651,9 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
             voice_info->initial_key = clef;
             voice_info->flatted_key = element->u.misc.pitched.flatted_key;
             gregorio_free_one_element(&(score->first_syllable->elements[i]));
-            snprintf(error, 80, _("in voice %d the first element is a key "
-                                  "definition, considered as initial key"),
-                     i + 1);
-            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSITY_INFO,
-                    0);
+            gregorio_messagef("gregorio_fix_initial_keys", VERBOSITY_INFO, 0,
+                    _("in voice %d the first element is a key definition, "
+                    "considered as initial key"), i + 1);
         } else if (element->type == GRE_F_KEY_CHANGE) {
             clef =
                 gregorio_calculate_new_key(F_KEY,
@@ -1665,11 +1661,9 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
             voice_info->initial_key = clef;
             voice_info->flatted_key = element->u.misc.pitched.flatted_key;
             gregorio_free_one_element(&(score->first_syllable->elements[i]));
-            snprintf(error, 80, _("in voice %d the first element is a key "
-                                  "definition, considered as initial key"),
-                     i + 1);
-            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSITY_INFO,
-                    0);
+            gregorio_messagef("gregorio_fix_initial_keys", VERBOSITY_INFO, 0,
+                    _("in voice %d the first element is a key definition, "
+                    "considered as initial key"), i + 1);
         }
         voice_info = voice_info->next_voice_info;
     }
@@ -1696,14 +1690,12 @@ void gregorio_fix_initial_keys(gregorio_score *score, int default_key)
     for (i = 0; i < score->number_of_voices; i++) {
         if (voice_info->initial_key == NO_KEY) {
             voice_info->initial_key = default_key;
-            snprintf(error, 75, _("no initial key definition in voice %d, "
-                        "default key definition applied"), i + 1);
-            gregorio_message(error, "gregorio_fix_initial_keys", VERBOSITY_INFO,
-                    0);
+            gregorio_messagef("gregorio_fix_initial_keys", VERBOSITY_INFO, 0,
+                    _("no initial key definition in voice %d, default key "
+                    "definition applied"), i + 1);
         }
         voice_info = voice_info->next_voice_info;
     }
-    free(error);
 }
 
 /**********************************

--- a/src/struct.h
+++ b/src/struct.h
@@ -40,14 +40,14 @@
 #define ENUM_BITFIELD(TYPE) unsigned int
 #endif
 
-// Lilypond-compatible location counters
+/* Lilypond-compatible location counters */
 typedef struct gregorio_scanner_location {
-    // - line is the 1-based line number
-    // - column is the 0-based* column number, tabs expanded to 8-column stops
-    // - offset is the 0-based number of characters from the start of the line
-
-    // * = column is calculated and stored as a 0-based number so the tabstop
-    // math is simpler; it should be printed 1-based
+    /* - line is the 1-based line number
+     * - column is the 0-based* column number, tabs expanded to 8-column stops
+     * - offset is the 0-based number of characters from the start of the line
+     *
+     * * = column is calculated and stored as a 0-based number so the tabstop
+     * math is simpler; it should be printed 1-based */
 
     unsigned short first_line;
     unsigned short first_column;
@@ -57,7 +57,7 @@ typedef struct gregorio_scanner_location {
     unsigned short last_offset;
 } gregorio_scanner_location;
 
-// all the different types of things a gregorio_* can be
+/* all the different types of things a gregorio_* can be */
 
 typedef enum gregorio_type {
     GRE_NOTE = 1,
@@ -76,19 +76,19 @@ typedef enum gregorio_type {
     GRE_BAR,
     GRE_END_OF_PAR,
     GRE_CUSTO,
-    // I don't really know how I could use the a TEXVERB_NOTE in gregoriotex,
-    // as we don't write note by note...
-    // GRE_TEXVERB_NOTE,
+    /* I don't really know how I could use the a TEXVERB_NOTE in gregoriotex,
+     * as we don't write note by note... */
+    /* GRE_TEXVERB_NOTE, */
     GRE_TEXVERB_GLYPH,
     GRE_TEXVERB_ELEMENT,
-    // above lines text, quite the same as GRE_TEXVERB_ELEMENT, but counted
-    // differently for the spaces above the lines
+    /* above lines text, quite the same as GRE_TEXVERB_ELEMENT, but counted
+     * differently for the spaces above the lines */
     GRE_ALT,
     GRE_NLBA,
-    GRE_MANUAL_CUSTOS,
+    GRE_MANUAL_CUSTOS
 } gregorio_type;
 
-// the different shapes, only for notes
+/* the different shapes, only for notes */
 
 typedef enum gregorio_shape {
     S_UNDETERMINED = 0,
@@ -117,20 +117,20 @@ typedef enum gregorio_shape {
     S_LINEA_PUNCTUM_CAVUM,
     S_PUNCTUM_CAVUM_INCLINATUM,
     S_PUNCTUM_CAVUM_INCLINATUM_AUCTUS,
-    // special shapes that must not appear in the final form of the score :
-    // quadratum is the shape of the first note of a punctum quadratum
-    // and quilisma quadratum is the shape of the first note of a pes
-    // quislisma quadratum
+    /* special shapes that must not appear in the final form of the score :
+     * quadratum is the shape of the first note of a punctum quadratum
+     * and quilisma quadratum is the shape of the first note of a pes
+     * quislisma quadratum */
     S_QUADRATUM,
-    // those shapes are for now used only in gregoriotex
+    /* those shapes are for now used only in gregoriotex */
     S_QUILISMA_QUADRATUM,
     S_PUNCTUM_AUCTUS_ASCENDENS,
     S_PUNCTUM_AUCTUS_DESCENDENS,
     S_PUNCTUM_DEMINUTUS,
-    S_LINEA,
+    S_LINEA
 } gregorio_shape;
 
-// the different kind of bars
+/* the different kind of bars */
 
 typedef enum gregorio_bar {
     B_NO_BAR = 0,
@@ -144,13 +144,13 @@ typedef enum gregorio_bar {
     B_DIVISIO_MINOR_D3,
     B_DIVISIO_MINOR_D4,
     B_DIVISIO_MINOR_D5,
-    B_DIVISIO_MINOR_D6,
+    B_DIVISIO_MINOR_D6
 } gregorio_bar;
 
-// definition of the signs. You can notice that the values are made so
-// that if you wan to add a vertical episemus to a note, you juste
-// make note->signs+=_V_EPISEMUS, so please don't change the value as
-// this tricky is used.
+/* definition of the signs. You can notice that the values are made so
+ * that if you wan to add a vertical episemus to a note, you juste
+ * make note->signs+=_V_EPISEMUS, so please don't change the value as
+ * this trick is used. */
 
 typedef enum gregorio_sign {
     _NO_SIGN = 0x00,
@@ -159,18 +159,18 @@ typedef enum gregorio_sign {
     _V_EPISEMUS = 0x10,
     _V_EPISEMUS_PUNCTUM_MORA = 0x11,
     _V_EPISEMUS_AUCTUM_DUPLEX = 0x12,
-    // more rare signs, for now they can't be used with the others
+    /* more rare signs, for now they can't be used with the others */
     _ACCENTUS = 0x03,
     _ACCENTUS_REVERSUS = 0x04,
     _CIRCULUS = 0x05,
     _SEMI_CIRCULUS = 0x06,
     _SEMI_CIRCULUS_REVERSUS = 0x07,
-    // signs of a bar
+    /* signs of a bar */
     _BAR_H_EPISEMUS = 0x08,
-    _V_EPISEMUS_BAR_H_EPISEMUS = 0x18,
+    _V_EPISEMUS_BAR_H_EPISEMUS = 0x18
 } gregorio_sign;
 
-// the different spaces
+/* the different spaces */
 
 typedef enum gregorio_space {
     SP_DEFAULT = 1,
@@ -181,13 +181,13 @@ typedef enum gregorio_space {
     SP_GLYPH_SPACE,
     SP_NEUMATIC_CUT_NB,
     SP_LARGER_SPACE_NB,
-    SP_GLYPH_SPACE_NB,
+    SP_GLYPH_SPACE_NB
 } gregorio_space;
 
-// the different liquescences, like for the signs, have special
-// values: to say that something is initio_debilis, just do
-// glyph->liquescentia+=L_INITIO_DEBILIS. So don't change the value,
-// the tricky is much used
+/* the different liquescences, like for the signs, have special
+ * values: to say that something is initio_debilis, just do
+ * glyph->liquescentia+=L_INITIO_DEBILIS. So don't change the value,
+ * the trick is much used */
 
 typedef enum gregorio_liquescentia {
     L_NO_LIQUESCENTIA = 0,
@@ -199,24 +199,24 @@ typedef enum gregorio_liquescentia {
     L_DEMINUTUS_INITIO_DEBILIS = 0x11,
     L_AUCTUS_ASCENDENS_INITIO_DEBILIS = 0x12,
     L_AUCTUS_DESCENDENS_INITIO_DEBILIS = 0x14,
-    L_AUCTA_INITIO_DEBILIS = 0x18,
+    L_AUCTA_INITIO_DEBILIS = 0x18
 } gregorio_liquescentia;
 
 typedef enum grehepisemus_size {
     H_NORMAL = 0,
     H_SMALL_LEFT,
     H_SMALL_CENTRE,
-    H_SMALL_RIGHT,
+    H_SMALL_RIGHT
 } grehepisemus_size;
 
-// values are chosen so BELOW/ABOVE can be added to a pitch
+/* values are chosen so BELOW/ABOVE can be added to a pitch */
 typedef enum gregorio_vposition {
     VPOS_AUTO = 0,
     VPOS_BELOW = -1,
-    VPOS_ABOVE = 1,
+    VPOS_ABOVE = 1
 } gregorio_vposition;
 
-// The different types of glyph
+/* The different types of glyph */
 
 typedef enum gregorio_glyph_type {
     G_PUNCTUM_INCLINATUM = 1,
@@ -230,7 +230,7 @@ typedef enum gregorio_glyph_type {
     G_5_PUNCTA_INCLINATA_ASCENDENS,
     G_TRIGONUS,
     G_PUNCTA_INCLINATA,
-    // !!! DO NOT CHANGE THE ENUM ORDERING BEFORE THIS LINE !!!
+    /* !!! DO NOT CHANGE THE ENUM ORDERING BEFORE THIS LINE !!! */
     G_UNDETERMINED,
     G_VIRGA,
     G_STROPHA,
@@ -261,10 +261,10 @@ typedef enum gregorio_glyph_type {
     G_SALICUS,
     G_VIRGA_STRATA,
     G_TORCULUS_LIQUESCENS,
-    // additional glyph types, necessary for determination
+    /* additional glyph types, necessary for determination */
     G_PORRECTUS_NO_BAR,
     G_PORRECTUS_FLEXUS_NO_BAR,
-    G_PES_QUILISMA,
+    G_PES_QUILISMA
 } gregorio_glyph_type;
 
 /*
@@ -278,19 +278,19 @@ typedef enum grestyle_style {
     ST_NO_STYLE = 0,
     ST_ITALIC,
     ST_CENTER,
-    // when the user types a {}, basically the same behaviour, except for
-    // the initial
+    /* when the user types a {}, basically the same behaviour, except for
+     * the initial */
     ST_FORCED_CENTER,
     ST_BOLD,
     ST_TT,
     ST_SMALL_CAPS,
     ST_SPECIAL_CHAR,
     ST_VERBATIM,
-    ST_INITIAL, // a style used to determine the initial
+    ST_INITIAL, /* a style used to determine the initial */
     ST_UNDERLINED,
     ST_COLORED,
     ST_FIRST_SYLLABLE,
-    ST_FIRST_SYLLABLE_INITIAL,
+    ST_FIRST_SYLLABLE_INITIAL
 } grestyle_style;
 
 /*
@@ -301,7 +301,7 @@ typedef enum grestyle_style {
 typedef enum grestyle_type {
     ST_T_NOTHING = 0,
     ST_T_BEGIN,
-    ST_T_END,
+    ST_T_END
 } grestyle_type;
 
 /*
@@ -311,7 +311,7 @@ typedef enum grestyle_type {
 typedef enum gregorio_tr_centering {
     TR_NORMAL = 0,
     TR_WITH_CENTER_BEGINNING,
-    TR_WITH_CENTER_END,
+    TR_WITH_CENTER_END
 } gregorio_tr_centering;
 
 /*
@@ -321,31 +321,31 @@ typedef enum gregorio_tr_centering {
 typedef enum gregorio_nlba {
     NLBA_NORMAL = 0,
     NLBA_BEGINNING,
-    NLBA_END,
+    NLBA_END
 } gregorio_nlba;
 
 typedef enum gregorio_euouae {
     EUOUAE_NORMAL = 0,
     EUOUAE_BEGINNING,
-    EUOUAE_END,
+    EUOUAE_END
 } gregorio_euouae;
 
 typedef enum gregorio_word_position {
     WORD_BEGINNING = 1,
     WORD_MIDDLE,
     WORD_END,
-    WORD_ONE_SYLLABLE,
+    WORD_ONE_SYLLABLE
 } gregorio_word_position;
 
-// the centering schemes for gabc:
+/* the centering schemes for gabc: */
 typedef enum gregorio_lyric_centering {
     SCHEME_DEFAULT = 0,
     SCHEME_VOWEL,
-    SCHEME_SYLLABLE,
+    SCHEME_SYLLABLE
 } gregorio_lyric_centering;
 
 typedef struct gregorio_extra_info {
-    // the sub-type of GRE_END_OF_LINE
+    /* the sub-type of GRE_END_OF_LINE */
     ENUM_BITFIELD(gregorio_type) sub_type:8;
     ENUM_BITFIELD(gregorio_bar) bar:8;
     ENUM_BITFIELD(gregorio_space) space:8;
@@ -353,21 +353,21 @@ typedef struct gregorio_extra_info {
 } gregorio_extra_info;
 
 typedef union gregorio_misc_element_info {
-    // pitched is used for GRE_CUSTO, GRE_FLAT, GRE_SHARP, GRE_NATURAL,
-    // GRE_C_KEY_CHANGE, GRE_F_KEY_CHANGE, GRE_C_KEY_CHANGE_FLATED, and
-    // GRE_F_KEY_CHANGE_FLATED
+    /* pitched is used for GRE_CUSTO, GRE_FLAT, GRE_SHARP, GRE_NATURAL,
+     * GRE_C_KEY_CHANGE, GRE_F_KEY_CHANGE, GRE_C_KEY_CHANGE_FLATED, and
+     * GRE_F_KEY_CHANGE_FLATED */
     struct {
-        // The pitch of the glyph for GRE_FLAT, GRE_NATURAL, GRE_SHARP.
-        // If a clef change, pitch will be a number indicating the line of
-        // the clef.
+        /* The pitch of the glyph for GRE_FLAT, GRE_NATURAL, GRE_SHARP.
+         * If a clef change, pitch will be a number indicating the line of
+         * the clef. */
         signed char pitch;
-        // boolean indicating a clef with a B-flat
+        /* boolean indicating a clef with a B-flat */
         bool flatted_key:1;
     } pitched;
-    // unpitched is used for everything else
+    /* unpitched is used for everything else */
     struct {
         struct gregorio_extra_info info;
-        // an element might carry a sign.
+        /* an element might carry a sign. */
         ENUM_BITFIELD(gregorio_sign) special_sign:8;
     } unpitched;
 } gregorio_misc_element_info;
@@ -378,57 +378,58 @@ typedef union gregorio_misc_element_info {
  * other things). 
  */
 typedef struct gregorio_note {
-    // then two pointer to other notes, to make a chained list.
+    /* then two pointer to other notes, to make a chained list. */
     struct gregorio_note *previous;
     struct gregorio_note *next;
-    // choral sign is a letter that appears next to a note in some choral
-    // scores we put it as char* because sometimes two letters appear
+    /* choral sign is a letter that appears next to a note in some choral
+     * scores we put it as char* because sometimes two letters appear */
     char *choral_sign;
-    // a string containing a possible TeX verbatim; necessary during
-    // structure generation.
+    /* a string containing a possible TeX verbatim; necessary during
+     * structure generation. */
     char *texverb;
     union {
-        // note is used for GRE_NOTE, GRE_FLAT, GRE_SHARP, GRE_NATURAL,
-        // GRE_C_KEY_CHANGE, GRE_F_KEY_CHANGE, GRE_C_KEY_CHANGE_FLATED, and
-        // GRE_F_KEY_CHANGE_FLATED
+        /* note is used for GRE_NOTE, GRE_FLAT, GRE_SHARP, GRE_NATURAL,
+         * GRE_C_KEY_CHANGE, GRE_F_KEY_CHANGE, GRE_C_KEY_CHANGE_FLATED, and
+         * GRE_F_KEY_CHANGE_FLATED */
         struct {
-            // the pitch is the height of the note on the score, that is to
-            // say the letter it is represented by in gabc.  If a clef
-            // change, pitch will be a number indicating the line of the clef.
+            /* the pitch is the height of the note on the score, that is to
+             * say the letter it is represented by in gabc.  If a clef
+             * change, pitch will be a number indicating the line of the
+             * clef. */
             signed char pitch;
-            // shape is the shape of the note... if you want to know the
-            // different possible shapes, see above.
+            /* shape is the shape of the note... if you want to know the
+             * different possible shapes, see above. */
             ENUM_BITFIELD(gregorio_shape) shape:8;
-            // liquescentia is the liquescence on the note, it is not really
-            // used in the final score, but it is, like type, used in the
-            // determination of glyphs.
+            /* liquescentia is the liquescence on the note, it is not really
+             * used in the final score, but it is, like type, used in the
+             * determination of glyphs. */
             ENUM_BITFIELD(gregorio_liquescentia) liquescentia:8;
         } note;
-        // other is used for everything else
+        /* other is used for everything else */
         struct gregorio_extra_info other;
     } u;
 
-    //// these go to the end for structure alignment
+    /* these go to the end for structure alignment */
     unsigned short src_line, src_column, src_offset;
 
-    // we have seen that notes are always real notes, that is to say
-    // GRE_NOTE. the type is always that in the final structure. But there
-    // is however this field in the structure because of the temporary
-    // states that can appear in the determination, where notes can be
-    // other things. This is the case for example in gabc reading.
+    /* we have seen that notes are always real notes, that is to say
+     * GRE_NOTE. the type is always that in the final structure. But there
+     * is however this field in the structure because of the temporary
+     * states that can appear in the determination, where notes can be
+     * other things. This is the case for example in gabc reading. */
     ENUM_BITFIELD(gregorio_type) type:8;
-    // signs is the signs on the notes, see above for all possible values
+    /* signs is the signs on the notes, see above for all possible values */
     ENUM_BITFIELD(gregorio_sign) signs:8;
-    // special_sign is the sign we sometimes encounter on punctum cavum, like
-    // accentus, semi-circulus, etc.
+    /* special_sign is the sign we sometimes encounter on punctum cavum, like
+     * accentus, semi-circulus, etc. */
     ENUM_BITFIELD(gregorio_sign) special_sign:8;
-    // h_episemus_type is the type of horizontal episemus, possible values
-    // are H_ALONE for an isolated horizontal episemus, H_MULTI_BEGINNING
-    // if the note is the first note of an episemus on several notes,
-    // H_MULTI_MIDDLE if it is inside an episemus on several notes. I let
-    // you guess what could be the use of H_MULTI_END. Other values are
-    // temporary values used in determination, they must not appear in the
-    // final structure.
+    /* h_episemus_type is the type of horizontal episemus, possible values
+     * are H_ALONE for an isolated horizontal episemus, H_MULTI_BEGINNING
+     * if the note is the first note of an episemus on several notes,
+     * H_MULTI_MIDDLE if it is inside an episemus on several notes. I let
+     * you guess what could be the use of H_MULTI_END. Other values are
+     * temporary values used in determination, they must not appear in the
+     * final structure. */
 
     const char *gtex_offset_case;
     signed char v_episemus_height;
@@ -450,59 +451,60 @@ typedef struct gregorio_note {
  * \c GRE_FLAT, \c GRE_NATURAL or \c GRE_SPACE 
  */
 typedef struct gregorio_glyph {
-    // two pointer to make a chained list
+    /* two pointer to make a chained list */
     struct gregorio_glyph *previous;
     struct gregorio_glyph *next;
-    // a string containing a possible TeX verbatim; necessary during structure
-    // generation.
+    /* a string containing a possible TeX verbatim; necessary during structure
+     * generation. */
     char *texverb;
     union {
-        // glyph is used for GRE_GLYPH
+        /* glyph is used for GRE_GLYPH */
         struct {
-            // a pointer to a (chained list of) gregorio_notes, the first of
-            // the glyph.
+            /* a pointer to a (chained list of) gregorio_notes, the first of
+             * the glyph. */
             struct gregorio_note *first_note;
-            // The glyph type for a GRE_GLYPH (porrectus, pes, etc.).  They
-            // are all listed above.
+            /* The glyph type for a GRE_GLYPH (porrectus, pes, etc.).  They
+             * are all listed above. */
             ENUM_BITFIELD(gregorio_glyph_type) glyph_type:8;
-            // liquescentia is really used, because that will determine the
-            // shape we will have to use.
+            /* liquescentia is really used, because that will determine the
+             * shape we will have to use. */
             ENUM_BITFIELD(gregorio_liquescentia) liquescentia:8;
         } notes;
         union gregorio_misc_element_info misc;
     } u;
 
-    //// characters go to the end for structure alignment
+    /* characters go to the end for structure alignment */
 
-    // type can have the values explained in the comment just above.
+    /* type can have the values explained in the comment just above. */
     ENUM_BITFIELD(gregorio_type) type:8;
 
-    // There is no additional parameter for GRE_SPACE in a gregorio_glyph
-    // because gregorio_space in this case can have only one value:
-    // SP_ZERO_WIDTH, as other spaces would break the glyphs into
-    // different elements.
+    /* There is no additional parameter for GRE_SPACE in a gregorio_glyph
+     * because gregorio_space in this case can have only one value:
+     * SP_ZERO_WIDTH, as other spaces would break the glyphs into
+     * different elements. */
 } gregorio_glyph;
 
 typedef struct gregorio_element {
-    // pointers to the next and previous elements.
+    /* pointers to the next and previous elements. */
     struct gregorio_element *previous;
     struct gregorio_element *next;
-    // a string containing a possible TeX verbatim; necessary during structure
-    // generation.
+    /* a string containing a possible TeX verbatim; necessary during structure
+     * generation. */
     char *texverb;
-    // The nabc string
+    /* The nabc string */
     char **nabc;
-    size_t nabc_lines; // we put it here to get the length of the array here too
+    /* we put it here to get the length of the array here too */
+    size_t nabc_lines;
     union {
-        // first_glyph is used for GRE_ELEMENT
-        // a pointer to the first glyph of the element.
+        /* first_glyph is used for GRE_ELEMENT */
+        /* a pointer to the first glyph of the element. */
         struct gregorio_glyph *first_glyph;
         union gregorio_misc_element_info misc;
     } u;
 
-    // type can have the values GRE_ELEMENT, GRE_BAR, GRE_C_KEY_CHANGE,
-    // GRE_F_KEY_CHANGE, GRE_END_OF_LINE, GRE_SPACE, GRE_TEXVERB_ELEMENT
-    // or GRE_NLBA
+    /* type can have the values GRE_ELEMENT, GRE_BAR, GRE_C_KEY_CHANGE,
+     * GRE_F_KEY_CHANGE, GRE_END_OF_LINE, GRE_SPACE, GRE_TEXVERB_ELEMENT
+     * or GRE_NLBA */
     ENUM_BITFIELD(gregorio_type) type:8;
 } gregorio_element;
 
@@ -570,54 +572,54 @@ typedef struct gregorio_character {
 } gregorio_character;
 
 typedef struct gregorio_syllable {
-    // pointer to a gregorio_text structure corresponding to the text.
+    /* pointer to a gregorio_text structure corresponding to the text. */
     struct gregorio_character *text;
-    // pointer to a gregorio_text structure corresponding to the
-    // translation
+    /* pointer to a gregorio_text structure corresponding to the
+     * translation */
     struct gregorio_character *translation;
-    // a string representing the text above the lines (raw TeX)
+    /* a string representing the text above the lines (raw TeX) */
     char *abovelinestext;
-    // pointer to the next and previous syllable
+    /* pointer to the next and previous syllable */
     struct gregorio_syllable *next_syllable;
     struct gregorio_syllable *previous_syllable;
-    // and finally a pointer to the elements of the structure. Here we see
-    // that we point to an array of elements. In fact it is the array of
-    // the first elements of the different voices of the syllable, for the
-    // case of polyphonic score. In most scores (monophonic), the array
-    // has only one element.
+    /* and finally a pointer to the elements of the structure. Here we see
+     * that we point to an array of elements. In fact it is the array of
+     * the first elements of the different voices of the syllable, for the
+     * case of polyphonic score. In most scores (monophonic), the array
+     * has only one element. */
     struct gregorio_element **elements;
     unsigned short src_line, src_column, src_offset;
-    // a syllable can be a GRE_SYLLABLE, a GRE_*_KEY_CHANGE or a
-    // GRE_BAR. It is useful when there is only that in a syllable.
+    /* a syllable can be a GRE_SYLLABLE, a GRE_*_KEY_CHANGE or a
+     * GRE_BAR. It is useful when there is only that in a syllable. */
     char type;
-    // again, an additional field to put some signs or other things...
+    /* again, an additional field to put some signs or other things... */
     ENUM_BITFIELD(gregorio_sign) special_sign:8;
-    // type of translation (with center beginning or only center end)
+    /* type of translation (with center beginning or only center end) */
     ENUM_BITFIELD(gregorio_tr_centering) translation_type:2;
-    // beginning or end of area without linebreak?
+    /* beginning or end of area without linebreak? */
     ENUM_BITFIELD(gregorio_nlba) no_linebreak_area:2;
-    // beginning or end of euouae area
+    /* beginning or end of euouae area */
     ENUM_BITFIELD(gregorio_euouae) euouae:2;
-    // position is WORD_BEGINNING for the beginning of a multi-syllable
-    // word, WORD_ONE_SYLLABLE for syllable that are alone in their word,
-    // and i let you gess what are WORD_MIDDLE and WORD_END.
+    /* position is WORD_BEGINNING for the beginning of a multi-syllable
+     * word, WORD_ONE_SYLLABLE for syllable that are alone in their word,
+     * and i let you gess what are WORD_MIDDLE and WORD_END. */
     ENUM_BITFIELD(gregorio_word_position) position:3;
 } gregorio_syllable;
 
-// The items in source_info used to be -- well, most of them -- in
-// gregorio_voice_info.  This is because the different `voices' may
-// in future be used for different variants of a melody:
-// e.g. notated in square notation, notated in some early neumatic
-// form from manuscript A, and another in manuscript B.  In that
-// case the different voices would naturally have different source
-// info.  However, this enhancement to gregorio is not yet planned,
-// and so this structure is made part of gregorio_score.
+/* The items in source_info used to be -- well, most of them -- in
+ * gregorio_voice_info.  This is because the different `voices' may
+ * in future be used for different variants of a melody:
+ * e.g. notated in square notation, notated in some early neumatic
+ * form from manuscript A, and another in manuscript B.  In that
+ * case the different voices would naturally have different source
+ * info.  However, this enhancement to gregorio is not yet planned,
+ * and so this structure is made part of gregorio_score. */
 typedef struct source_info {
     char *author;
     char *date;
     char *manuscript;
-    char *manuscript_reference; // was reference
-    char *manuscript_storage_place; // was storage_place
+    char *manuscript_reference; /* was reference */
+    char *manuscript_storage_place; /* was storage_place */
     char *book;
     char *transcriber;
     char *transcription_date;
@@ -634,39 +636,39 @@ typedef struct source_info {
 
 typedef struct gregorio_score {
     unsigned char digest[SHA1_DIGEST_SIZE];
-    // the structure starts by a pointer to the first syllable of the
-    // score.
+    /* the structure starts by a pointer to the first syllable of the
+     * score. */
     struct gregorio_syllable *first_syllable;
-    // the number of voices is very important. In monophony it is one. If
-    // there are more voices thant number_of_voices, the additional voices
-    // won't be taken into consideration.
+    /* the number of voices is very important. In monophony it is one. If
+     * there are more voices thant number_of_voices, the additional voices
+     * won't be taken into consideration. */
     int number_of_voices;
-    // then start some metadata:
+    /* then start some metadata: */
     char *name;
     char *gabc_copyright;
     char *score_copyright;
     char *office_part;
     char *occasion;
-    // the meter, numbers of syllables per line, as e.g. 8.8.8.8
+    /* the meter, numbers of syllables per line, as e.g. 8.8.8.8 */
     char *meter;
     char *commentary;
     char *arranger;
     struct source_info si;
-    // the mode of a song is between 1 and 8
+    /* the mode of a song is between 1 and 8 */
     char mode;
-    // There is one annotation for each line above the initial letter
+    /* There is one annotation for each line above the initial letter */
     char *annotation[MAX_ANNOTATIONS];
-    // field giving informations on the initial (no initial, normal initial 
-    // or two lines initial)
+    /* field giving informations on the initial (no initial, normal initial 
+     * or two lines initial) */
     char initial_style;
-    // the font to use in gregoriotex
+    /* the font to use in gregoriotex */
     char *gregoriotex_font;
     size_t nabc_lines;
     char *user_notes;
-    // the determination method (maximal ambitus, etc.)
+    /* the determination method (maximal ambitus, etc.) */
     unsigned char det_method;
-    // then, as there are some metadata that are voice-specific, we add a
-    // pointer to the first voice_info. (see comments below)
+    /* then, as there are some metadata that are voice-specific, we add a
+     * pointer to the first voice_info. (see comments below) */
     struct gregorio_voice_info *first_voice_info;
     gregorio_lyric_centering centering;
 } gregorio_score;
@@ -682,19 +684,19 @@ typedef struct gregorio_score {
  */
 
 typedef struct gregorio_voice_info {
-    // the only thing that is worth a comment here is the key. We have a
-    // special representation for the key. See comments on
-    // src/struct-utils.c for further reading.
+    /* the only thing that is worth a comment here is the key. We have a
+     * special representation for the key. See comments on
+     * src/struct-utils.c for further reading. */
     int initial_key;
-    // See source_info above for comments about the move of author etc.
+    /* See source_info above for comments about the move of author etc. */
     char *style;
     char *virgula_position;
     struct gregorio_voice_info *next_voice_info;
     bool flatted_key;
 } gregorio_voice_info;
 
-// the maximum number of voices, more than this is total nonsense in
-// gregorian chant.
+/* the maximum number of voices, more than this is total nonsense in
+ * gregorian chant. */
 #define MAX_NUMBER_OF_VOICES 10
 
 #define MAX_TEXT_LENGTH 200
@@ -703,12 +705,10 @@ typedef struct gregorio_voice_info {
 #define F_KEY 'f'
 #define NO_KEY -5
 #define DEFAULT_KEY 5
-//#define FLAT_KEY 25
-//#define NO_FLAT_KEY 0
 
 #define MONOPHONY 0
 
-// the different initial styles
+/* the different initial styles */
 
 #define NO_INITIAL 0
 #define NORMAL_INITIAL 1
@@ -720,7 +720,7 @@ typedef struct gregorio_voice_info {
 
 #define USELESS_VALUE 0
 
-static inline bool is_puncta_inclinata(char glyph)
+static __inline bool is_puncta_inclinata(char glyph)
 {
     return glyph <= G_5_PUNCTA_INCLINATA_ASCENDENS;
 }
@@ -728,13 +728,13 @@ static inline bool is_puncta_inclinata(char glyph)
 #define IS_INITIO_DEBILIS 5
 #define NO_INITIO_DEBILIS 0
 
-static inline bool is_liquescentia(char liquescentia)
+static __inline bool is_liquescentia(char liquescentia)
 {
     return liquescentia == L_DEMINUTUS || liquescentia == L_AUCTUS_ASCENDENS
         || liquescentia == L_AUCTUS_DESCENDENS || liquescentia == L_AUCTA;
 }
 
-static inline bool is_initio_debilis(char liquescentia)
+static __inline bool is_initio_debilis(char liquescentia)
 {
     return liquescentia >= L_INITIO_DEBILIS;
 }
@@ -743,7 +743,7 @@ static inline bool is_initio_debilis(char liquescentia)
 #define HEPISEMUS_AUTO -1
 #define HEPISEMUS_FORCED -2
 
-// The first pitch MUST be an odd number
+/* The first pitch MUST be an odd number */
 #define LOWEST_PITCH 3
 #define HIGHEST_PITCH (LOWEST_PITCH + 12)
 #define DUMMY_PITCH (LOWEST_PITCH + 6)

--- a/src/struct.h
+++ b/src/struct.h
@@ -29,7 +29,7 @@
 #ifndef STRUCT_H
 #define STRUCT_H
 
-#include <stdbool.h>
+#include "bool.h"
 #include "sha1.h"
 
 #ifdef __cplusplus

--- a/src/support.c
+++ b/src/support.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
+ * 
+ * This file is part of Gregorio.
+ *
+ * Gregorio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gregorio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include "support.h"
+
+/* Our version of snprintf; this is NOT semantically the same as C99's
+ * snprintf; rather, it's a "lowest common denominator" implementation
+ * blending C99 and MS-C */
+void gregorio_snprintf(char *s, size_t size, const char *format, ...)
+{
+    va_list args;
+
+#ifdef _MSC_VER
+    memset(s, 0, size * sizeof(char));
+#endif
+
+    va_start(args, format);
+#ifdef _MSC_VER
+    _vsnprintf_s(s, size, _TRUNCATE, format, args);
+#else
+    vsnprintf(s, size, format, args);
+#endif
+    va_end(args);
+}

--- a/src/support.h
+++ b/src/support.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
+ * 
+ * This file is part of Gregorio.
+ *
+ * Gregorio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gregorio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SUPPORT_H
+#define SUPPORT_H
+
+#include <stdlib.h>
+
+void gregorio_snprintf(char *s, size_t size, const char *format, ...)
+        __attribute__ ((__format__ (__printf__, 3, 4)));
+
+#endif

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -19,7 +19,7 @@
 
 #include "config.h"
 #include <stdio.h>
-#include <string.h>             // for strlen
+#include <string.h> /* for strlen */
 #include <stdlib.h>
 #include "struct.h"
 #include "unicode.h"
@@ -35,41 +35,41 @@
  * 
  */
 
-// an utf8 version of mbstowcs
+/* an utf8 version of mbstowcs */
 
 static size_t gregorio_mbstowcs(grewchar *dest, const char *src, int n)
 {
     unsigned char bytes_to_come;
     grewchar result = 0;
     unsigned char c;
-    size_t res = 0;             // number of bytes we've done so far
+    size_t res = 0; /* number of bytes we've done so far */
     if (!src) {
         gregorio_message(_("call with a NULL argument"), "gregorio_mbstowcs",
                 VERBOSITY_ERROR, 0);
     }
     while (*src && ((int) res <= n || !dest)) {
         c = (unsigned char) (*src);
-        if (c < 128) {          // 0100xxxx
-            // one-byte symbol
+        if (c < 128) { /* 0100xxxx */
+            /* one-byte symbol */
             bytes_to_come = 0;
             result = c;
-        } else if (c >= 240) {  // 1111xxxx
-            // start of a four-byte symbol
-            // printf("%d\n", c);
+        } else if (c >= 240) { /* 1111xxxx */
+            /* start of a four-byte symbol */
+            /* printf("%d\n", c); */
             bytes_to_come = 3;
             result = (result << 3) | (c & 7);
-        } else if (c >= 224) {  // 1110xxxx
-            // start of a three-byte symbol
-            // printf("%d\n", c);
+        } else if (c >= 224) { /* 1110xxxx */
+            /* start of a three-byte symbol */
+            /* printf("%d\n", c); */
             bytes_to_come = 2;
             result = (result << 4) | (c & 15);
-        } else if (c >= 192) {  // 1100xxxx
-            // start of a two-byte symbol
-            // printf("%d\n", c);
+        } else if (c >= 192) { /* 1100xxxx */
+            /* start of a two-byte symbol */
+            /* printf("%d\n", c); */
             bytes_to_come = 1;
             result = (result << 5) | (c & 31);
         } else {
-            // printf("%s %d %d\n", src, res, c);
+            /* printf("%s %d %d\n", src, res, c); */
             gregorio_message(_("malformed UTF-8 sequence1"),
                     "gregorio_mbstowcs", VERBOSITY_ERROR, 0);
             return -1;
@@ -78,7 +78,7 @@ static size_t gregorio_mbstowcs(grewchar *dest, const char *src, int n)
             bytes_to_come--;
             src++;
             c = (unsigned char) (*src);
-            if (c < 192 && c >= 128)    // 1000xxxx
+            if (c < 192 && c >= 128) /* 1000xxxx */
             {
                 result = (result << 6) | (c & 63);
             } else {
@@ -100,7 +100,7 @@ static size_t gregorio_mbstowcs(grewchar *dest, const char *src, int n)
     return res;
 }
 
-// the value returned by this function must be freed!
+/* the value returned by this function must be freed! */
 grewchar *gregorio_build_grewchar_string_from_buf(const char *const buf)
 {
     size_t len;
@@ -108,13 +108,13 @@ grewchar *gregorio_build_grewchar_string_from_buf(const char *const buf)
     if (buf == NULL) {
         return NULL;
     }
-    len = strlen(buf);          // to get the length of the syllable in ASCII
+    len = strlen(buf); /* to get the length of the syllable in ASCII */
     gwstring = (grewchar *) malloc((len + 1) * sizeof(grewchar));
-    gregorio_mbstowcs(gwstring, buf, len);  // converting into wchar_t
+    gregorio_mbstowcs(gwstring, buf, len); /* converting into wchar_t */
     return gwstring;
 }
 
-// the function to build a gregorio_character list from a buffer.
+/* the function to build a gregorio_character list from a buffer. */
 
 gregorio_character *gregorio_build_char_list_from_buf(const char *const buf)
 {
@@ -125,7 +125,7 @@ gregorio_character *gregorio_build_char_list_from_buf(const char *const buf)
         return NULL;
     }
     gwstring = gregorio_build_grewchar_string_from_buf(buf);
-    // we add the corresponding characters in the list of gregorio_characters
+    /* we add the corresponding characters in the list of gregorio_characters */
     while (gwstring[i]) {
         gregorio_add_character(&current_character, gwstring[i]);
         i++;
@@ -135,8 +135,8 @@ gregorio_character *gregorio_build_char_list_from_buf(const char *const buf)
     return current_character;
 }
 
-// the function to compare a grewchar * and a buf. Returns 1 if different, 0
-// if not.
+/* the function to compare a grewchar * and a buf. Returns 1 if different, 0
+ * if not. */
 
 unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf)
 {
@@ -146,10 +146,10 @@ unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf)
     if (!buf || !wstr) {
         return 1;
     }
-    len = strlen(buf);          // to get the length of the syllable in ASCII
+    len = strlen(buf); /* to get the length of the syllable in ASCII */
     gwbuf = (grewchar *) malloc((len + 1) * sizeof(grewchar));
-    gregorio_mbstowcs(gwbuf, buf, len); // converting into wchar_t
-    // we add the corresponding characters in the list of gregorio_characters
+    gregorio_mbstowcs(gwbuf, buf, len); /* converting into wchar_t */
+    /* we add the corresponding characters in the list of gregorio_characters */
     while (gwbuf[i] && wstr[i]) {
         if (gwbuf[i] != wstr[i]) {
             free(gwbuf);
@@ -157,7 +157,7 @@ unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf)
         }
         i = i + 1;
     }
-    // we finished the two strings
+    /* we finished the two strings */
     if (gwbuf[i] == 0 && wstr[i] == 0) {
         free(gwbuf);
         return 0;

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -35,7 +35,7 @@ void gregorio_print_unistring(FILE *f, grewchar *first_char);
 unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf);
 grewchar *gregorio_build_grewchar_string_from_buf(const char *buf);
 
-static inline size_t gregorio_wcstrlen(const grewchar *wstr)
+static __inline size_t gregorio_wcstrlen(const grewchar *wstr)
 {
     size_t length = 0;
 
@@ -46,14 +46,14 @@ static inline size_t gregorio_wcstrlen(const grewchar *wstr)
     return length;
 }
 
-// this macro is for portability under windows, where L'x' is only two-bytes
-// long, and thus needs to be cast to a 4-bytes integer.
+/* this macro is for portability under windows, where L'x' is only two-bytes
+ * long, and thus needs to be cast to a 4-bytes integer. */
 #define GL(wc) ((const grewchar) L'wc')
 
 #endif
 
-// we enter the second part only if struct.h has already been included, because
-// we need gregorio_character
+/* we enter the second part only if struct.h has already been included, because
+ * we need gregorio_character */
 
 #ifdef STRUCT_H
 

--- a/src/utf8strings.h.in
+++ b/src/utf8strings.h.in
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
+ *
+ * This file is part of Gregorio.
+ *
+ * Gregorio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Gregorio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UTF8STRINGS_H
+#define UTF8STRINGS_H
+
+#define ACCENTED_AE "'æ"
+#define ACCENTED_OE "'œ"
+
+/* This is a superset of Latin vowels which includes some French, Vietnamese,
+ * Slavic, Hungarian, and Norwegian vowels which don't interfere with Latin
+ * itself.  For something more accurate, the user should consider the use of
+ * custom centering rules. */
+#define DEFAULT_VOWELS "aàáâăąåAÀÁÂĂĄÅeèéêëěęEÈÉÊËĚĘiìíîIÌÍÎ" \
+    "oòóôơőøOÒÓÔƠŐØuùúûưůűUÙÚÛƯŮŰyỳýYỲÝæǽÆǼœŒ"
+
+#endif

--- a/src/vowel/vowel-rules.l
+++ b/src/vowel/vowel-rules.l
@@ -32,7 +32,7 @@
 
 #define YY_NO_INPUT
 
-static inline void save_lval(void)
+static __inline void save_lval(void)
 {
     gregorio_vowel_rulefile_lval =
             malloc((gregorio_vowel_rulefile_leng + 1) * sizeof(char));
@@ -41,7 +41,7 @@ static inline void save_lval(void)
     gregorio_vowel_rulefile_lval[gregorio_vowel_rulefile_leng] = '\0';
 }
 
-static inline void invalid(void)
+static __inline void invalid(void)
 {
     gregorio_messagef("gregorio_vowel_rulefile_lex", VERBOSITY_WARNING, 0,
             _("invalid character in vowel file: %c"),

--- a/src/vowel/vowel-rules.y
+++ b/src/vowel/vowel-rules.y
@@ -36,14 +36,14 @@
 # define IGNORE(e) /* empty */
 #endif
 
-// NOTE: This parser might allocate a new value for language; this value MUST
-//       BE FREED after the parser returns (if the value of the language pointer
-//       changes, then free the pointer).  This parser DOES free the language
-//       pointer before changing it, if status points to RFPS_ALIASED.
+/* NOTE: This parser might allocate a new value for language; this value MUST
+ *       BE FREED after the parser returns (if the value of the language pointer
+ *       changes, then free the pointer).  This parser DOES free the language
+ *       pointer before changing it, if status points to RFPS_ALIASED. */
 
-// uncomment it if you want to have an interactive shell to understand the
-// details on how bison works for a certain input
-//int gregorio_vowel_rulefile_debug=1;
+/* uncomment it if you want to have an interactive shell to understand the
+ * details on how bison works for a certain input */
+/*int gregorio_vowel_rulefile_debug=1;*/
 
 static void gregorio_vowel_rulefile_error(const char *const filename,
         char **const language, rulefile_parse_status *const status,
@@ -55,8 +55,8 @@ static void gregorio_vowel_rulefile_error(const char *const filename,
             _("%s: %s"), filename, error_str);
 }
 
-// this returns false until the language *after* the desired language
-static inline bool match_language(char **language,
+/* this returns false until the language *after* the desired language */
+static __inline bool match_language(char **language,
         rulefile_parse_status *status, char *const name)
 {
     if (*status == RFPS_FOUND) {
@@ -72,7 +72,7 @@ static inline bool match_language(char **language,
     return false;
 }
 
-static inline void alias(char **const language,
+static __inline void alias(char **const language,
         rulefile_parse_status *const status, char *const name,
         char *const target)
 {
@@ -90,7 +90,7 @@ static inline void alias(char **const language,
     free(name);
 }
 
-static inline void add(const rulefile_parse_status *const status,
+static __inline void add(const rulefile_parse_status *const status,
         void (*const fn)(const char *), char *const value)
 {
     if (*status == RFPS_FOUND) {

--- a/src/vowel/vowel-rules.y
+++ b/src/vowel/vowel-rules.y
@@ -19,8 +19,8 @@
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <assert.h>
+#include "bool.h"
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -20,13 +20,13 @@
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
 #ifdef USE_KPSE
     #include <kpathsea/kpathsea.h>
 #endif
+#include "bool.h"
 #include "vowel.h"
 #include "unicode.h"
 #include "messages.h"

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -63,10 +63,11 @@ static character_set *character_set_new(const bool alloc_next)
 
 static void character_set_free(character_set *const set);
 
-static inline void character_set_next_elements_free(character_set *const set)
+static __inline void character_set_next_elements_free(character_set *const set)
 {
+    unsigned int i;
     assert(set && set->next);
-    for (unsigned int i = 0; i < set->bins; ++i) {
+    for (i = 0; i < set->bins; ++i) {
         if (set->next[i]) {
             character_set_free(set->next[i]);
         }
@@ -88,13 +89,14 @@ static void character_set_free(character_set *const set)
 static bool character_set_contains(character_set *const set,
         const grewchar vowel, character_set **const next)
 {
+    unsigned int index;
     assert(set);
 
     if (next) {
         *next = NULL;
     }
-    for (unsigned int index = ((unsigned long)vowel) & set->mask;
-            set->table[index]; index = (index + 1) & set->mask) {
+    for (index = ((unsigned long)vowel) & set->mask; set->table[index];
+            index = (index + 1) & set->mask) {
         if (set->table[index] == vowel) {
             if (next && set->next) {
                 *next = set->next[index];
@@ -105,7 +107,7 @@ static bool character_set_contains(character_set *const set,
     return false;
 }
 
-static inline void character_set_put(character_set *const set,
+static __inline void character_set_put(character_set *const set,
         const grewchar vowel, character_set *next)
 {
     unsigned int index;
@@ -123,10 +125,10 @@ static inline void character_set_put(character_set *const set,
     }
 }
 
-static inline void character_set_grow(character_set *const set) {
+static __inline void character_set_grow(character_set *const set) {
     static grewchar *old_table;
     static character_set **old_next;
-    unsigned int old_bins;
+    unsigned int old_bins, i;
 
     assert(set);
 
@@ -146,7 +148,7 @@ static inline void character_set_grow(character_set *const set) {
     if (old_next) {
         set->table = calloc(set->bins, sizeof(character_set *));
     }
-    for (unsigned int i = 0; i < old_bins; ++i) {
+    for (i = 0; i < old_bins; ++i) {
         if (old_table[i]) {
             character_set_put(set, old_table[i], old_next ? old_next[i] : NULL);
         } else {
@@ -180,7 +182,7 @@ static character_set *character_set_add(character_set *const set,
     return next;
 }
 
-static inline void character_set_clear(character_set *const set)
+static __inline void character_set_clear(character_set *const set)
 {
     if (set) {
         memset(set->table, 0, set->bins * sizeof(grewchar));
@@ -288,8 +290,8 @@ void gregorio_vowel_tables_free(void)
 void gregorio_vowel_table_add(const char *vowels)
 {
     if (vowels) {
-        grewchar *str = gregorio_build_grewchar_string_from_buf(vowels);
-        for (grewchar *p = str; *p; ++p) {
+        grewchar *str = gregorio_build_grewchar_string_from_buf(vowels), *p;
+        for (p = str; *p; ++p) {
             character_set_add(vowel_table, *p);
         }
         free(str);
@@ -301,7 +303,7 @@ void gregorio_prefix_table_add(const char *prefix)
     character_set *set = prefix_table;
     grewchar *str, *p;
 
-    // store prefixes backwards
+    /* store prefixes backwards */
     if (prefix && *prefix) {
         str = gregorio_build_grewchar_string_from_buf(prefix);
         p = str;
@@ -357,10 +359,10 @@ void gregorio_secondary_table_add(const char *secondary)
 typedef enum {
     VWL_BEFORE = 0,
     VWL_WITHIN,
-    VWL_SUFFIX,
+    VWL_SUFFIX
 } vowel_group_state;
 
-static inline bool is_in_prefix(size_t bufpos) {
+static __inline bool is_in_prefix(size_t bufpos) {
     character_set *previous = prefix_table, *prefix;
 
     while (character_set_contains(previous, prefix_buffer[bufpos], &prefix)) {
@@ -376,11 +378,11 @@ bool gregorio_find_vowel_group(const grewchar *const string, int *const start,
 {
     size_t bufpos = 0;
     vowel_group_state state = VWL_BEFORE;
-    character_set *cset;
+    character_set *cset = NULL;
     const grewchar *subject;
     int i;
 
-    // stick the 0 in here to avoid overruns from is_in_prefix
+    /* stick the 0 in here to avoid overruns from is_in_prefix */
     prefix_buffer[0] = 0;
 
     for (i = 0, subject = string; true; ++i, ++subject) {
@@ -389,10 +391,10 @@ bool gregorio_find_vowel_group(const grewchar *const string, int *const start,
             bufpos = (bufpos + 1) & prefix_buffer_mask;
             prefix_buffer[bufpos] = *subject;
             if (character_set_contains(vowel_table, *subject, NULL)) {
-                // we found a vowel
+                /* we found a vowel */
                 if (!character_set_contains(vowel_table, *(subject + 1), NULL)
                         || !is_in_prefix(bufpos)) {
-                    // no vowel after or not in prefix, so this is the start
+                    /* no vowel after or not in prefix, so this is the start */
                     *start = i;
                     state = VWL_WITHIN;
                 }
@@ -401,13 +403,13 @@ bool gregorio_find_vowel_group(const grewchar *const string, int *const start,
 
         case VWL_WITHIN:
             if (!character_set_contains(vowel_table, *subject, NULL)) {
-                // not a vowel; is it a suffix?
+                /* not a vowel; is it a suffix? */
                 *end = i;
                 if (character_set_contains(suffix_table, *subject, &cset)) {
-                    // it's the start of a suffix
+                    /* it's the start of a suffix */
                     state = VWL_SUFFIX;
                 } else {
-                    // neither a vowel nor a suffix, so this is the end
+                    /* neither a vowel nor a suffix, so this is the end */
                     return true;
                 }
             }
@@ -415,11 +417,11 @@ bool gregorio_find_vowel_group(const grewchar *const string, int *const start,
 
         case VWL_SUFFIX:
             if (cset->is_final) {
-                // remember the last final position
+                /* remember the last final position */
                 *end = i;
             }
             if (!character_set_contains(cset, *subject, &cset)) {
-                // no longer in valid suffix
+                /* no longer in valid suffix */
                 return true;
             }
             break;
@@ -433,13 +435,13 @@ bool gregorio_find_vowel_group(const grewchar *const string, int *const start,
         }
     }
 
-    // no vowel found; look for a secondary
+    /* no vowel found; look for a secondary */
     *end = -1;
     for (*start = 0; *(subject = string + *start); ++ *start) {
         for (cset = secondary_table, i = *start;
                 character_set_contains(cset, *subject, &cset); ++i, ++subject) {
             if (cset->is_final) {
-                // remember the last final position
+                /* remember the last final position */
                 *end = i + 1;
             }
         }
@@ -448,7 +450,7 @@ bool gregorio_find_vowel_group(const grewchar *const string, int *const start,
         }
     }
 
-    // no center found
+    /* no center found */
     *start = -1;
     return false;
 }

--- a/src/vowel/vowel.h
+++ b/src/vowel/vowel.h
@@ -21,7 +21,7 @@
 #define _VOWEL_H
 
 #include <stdio.h>
-#include <stdbool.h>
+#include "bool.h"
 #include "unicode.h"
 
 typedef enum rulefile_parse_status {

--- a/src/vowel/vowel.h
+++ b/src/vowel/vowel.h
@@ -27,7 +27,7 @@
 typedef enum rulefile_parse_status {
     RFPS_NOT_FOUND = 0,
     RFPS_FOUND,
-    RFPS_ALIASED,
+    RFPS_ALIASED
 } rulefile_parse_status;
 
 int gregorio_vowel_rulefile_parse(const char *filename, char **language,


### PR DESCRIPTION
More fixes for #551 as per recent messages posted to gregorio-devel, with contributions from Akira Kakuto and Peter Breitenlohner.

I broke these out into individual commits.

Peter's explanation of Akira's changes map as follows:
1. e1e4459cf580920c7b7b462577cd5ad8aa1e37a2
2. already done
3. 501eef9c07e33960bfa7a976107c33f402ad0276
4. already done
5. c0ece89a664928f5ac46d5535959d0b7ff65b9d3
6. 802764f5a616b2f84756c5e914ffcb3384416e2a
7. 50663290032ccd2f616995e2180514b6d90b72a6
8. ad131d989bd8397f74b23bd4ec27e4c32cc0ed90
9. c0ece89a664928f5ac46d5535959d0b7ff65b9d3
10. 9579a37899f419b151f3782ccfd4dc1b13bb8f52

This compiles without warnings under both gcc and clang, and all tests pass.

Please let me know if I've missed anything or if you'd rather I do something differently.

This is ready for review and merge if there are no issues.