### PR TITLE
Add `\gre@obsolete`

### DIFF
--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -60,6 +60,12 @@
   \relax%
 }%
 
+\def\gre@obsolete#1#2{%
+  \greerror{#1\space is obsolete.\MessageBreak Use #2\space instead}%
+  \relax%
+}%
+
+
 \def\gre@nothing{}
 
 \AtBeginDocument{\IfStrEq{\gre@debug}{}{}{\typeout{GregorioTeX is in debug mode}\typeout{\gre@debug\space messages will be printed to the log.}}}%
@@ -1458,19 +1464,19 @@
 }%
 
 \def\includetexscore#1{%
-  \gre@warning{\protect\includetexscore\space is obsolete. \MessageBreak Use \protect\gregorioscore[n]\space instead}%
+  \gre@obsolete{\protect\includetexscore}{\protect\gregorioscore[n]}%
 }%
 
 \def\greincludetexscore#1{%
-  \gre@warning{\protect\greincludetexscore\space is obsolete.\MessageBreak Use \protect\gregorioscore[n]\space instead}%
+  \gre@obsolete{\protect\greincludetexscore}{\protect\gregorioscore[n]}%
 }%
 
 \def\includegabcscore#1{%
-  \gre@warning{\protect\includegabcscore\space is obsolete.\MessageBreak Use \protect\gregorioscore[c]\space instead}%
+  \gre@obsolete{\protect\includegabcscore}{\protect\gregorioscore[c]}%
 }%
 
 \def\greincludegabcscore#1{%
-  \gre@warning{\protect\greincludegabcscore\space is obsolete.\MessageBreak Use \protect\gregorioscore[c]\space instead}%
+  \gre@obsolete{\protect\greincludegabcscore}{\protect\gregorioscore[c]}%
 }%
 
 % The internal macro called when \gregorioscore is called with the optional argument.  Behavior is determined by the value of the argument:

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -208,7 +208,7 @@
 }%
 
 \def\gresetstafflinefactor#1{%
-  \greerror{\protect\gresetstafflinefactor\space is obsolete.\MessageBreak Use \protect\grechangestafflinethickness\space instead.}%
+  \gre@obsolete{\protect\gresetstafflinefactor}{\protect\grechangestafflinethickness}%
 }%
 
 %constantglyphraise is the space between the 0 of the gragorian fonts and the effective 0 of the TeX score
@@ -1288,7 +1288,7 @@
 }%
 
 \def\GreSetAboveInitialSeparation#1{%
-  \greerror{\protect\GreSetAboveInitialSeparation\space is obsolete.\MessageBreak Use \protect\grechangedim\{annotationseparation\}\space instead.}%
+  \gre@obsolete{\protect\GreSetAboveInitialSeparation}{\protect\grechangedim\{annotationseparation\}}%
 }%
 
 %To change the space after the initial


### PR DESCRIPTION
Similar to `\gre@deprecated` this function makes the obsolescence messages consistent and makes sure they always raise an error.  It also makes moving down the removal path easier as a function which is moved from deprecated to obsolete now simply needs `\gre@deprecated` to be replaced by `\gre@obsolete` (and a removal of the bypass code, if necessary).
All functions which currently had individual obsolescence messages have been adapted to use the new function.