### PR TITLE
Refactoring old styles deprecation check

### DIFF
--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -330,8 +330,7 @@
   \gre@dimen@temp@five=-\gre@dimen@textlower %
   % if it is a big initial we print it on the second line
   \ifnum\grebiginitial=0\relax %
-    \protected@edef\gre@@arg{\greinitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@initialformat\greinitialformat% DEPRECATED
       \setbox\gre@box@initial=\hbox{\gre@style@initial#1\endgre@style@initial}% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\greinitialformat}{\protect\grechangestyle{initial}}%  DEPRECATED
@@ -341,38 +340,35 @@
     \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\gre@box@initial %
     \else%
-      \gre@style@initial%
-      \protected@edef\gre@@arg{\greinitialformat{#1}}%  DEPRECATED
-      \expandafter\ifx\gre@@arg\relax% DEPRECATED
+      \ifx\gre@deprecated@initialformat\greinitialformat% DEPRECATED
+        \gre@style@initial% keep this line
         \global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth% keep this line
+        \endgre@style@initial% keep this line
       \else%  DEPRECATED
         \gre@deprecated{\protect\greinitialformat}{\protect\grechangestyle{initial}}%  DEPRECATED
         \greinitialformat{\global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth}% DEPRECATED
       \fi%  DEPRECATED
-      \endgre@style@initial%
     \fi%
     \gre@debugmsg{ifdim}{ wd(gre@box@annotation) > initialwidth}%
     \ifdim\wd\gre@box@annotation>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\gre@box@annotation%
     \fi%
     \gre@debugmsg{annotation}{Width check completed.}%
-    \protected@edef\gre@@arg{\greinitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@initialformat\greinitialformat% DEPRECATED
       \setbox\gre@box@initial=\hbox to \gre@dimen@initialwidth {\hss\raise -\gre@dimen@temp@five\hbox{\gre@style@initial#1\endgre@style@initial}\hss}% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\greinitialformat}{\protect\grechangestyle{initial}}%  DEPRECATED
       \setbox\gre@box@initial=\hbox to \gre@dimen@initialwidth {\hss\raise -\gre@dimen@temp@five\hbox{\greinitialformat{#1}}\hss}% DEPRECATED
     \fi%  DEPRECATED
     \gre@debugmsg{annotation}{Initial set.}%
-    \gre@style@initial%
-    \protected@edef\gre@@arg{\greinitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@initialformat\greinitialformat% DEPRECATED
+      \gre@style@initial% keep this line
       \global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift% keep this line
+      \endgre@style@initial% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\greinitialformat}{\protect\grechangestyle{initial}}%  DEPRECATED
       \greinitialformat{\global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift}%  DEPRECATED
     \fi%  DEPRECATED
-    \endgre@style@initial%
   \else %
     \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace %
     \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext %
@@ -380,8 +376,7 @@
     \advance\gre@dimen@temp@five by 4\gre@dimen@interstafflinespace %
     \advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight %
     \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
-    \protected@edef\gre@@arg{\grebiginitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@biginitialformat\grebiginitialformat% DEPRECATED
     \setbox\gre@box@initial=\hbox{\gre@style@biginitial#1\endgre@style@biginitial}% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\grebiginitialformat}{\protect\grechangestyle{biginitial}}%  DEPRECATED
@@ -391,61 +386,56 @@
     \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\gre@box@initial %
     \else%
-      \gre@style@biginitial%
-      \protected@edef\gre@@arg{\grebiginitialformat{#1}}%  DEPRECATED
-      \expandafter\ifx\gre@@arg\relax% DEPRECATED
+      \ifx\gre@deprecated@biginitialformat\grebiginitialformat% DEPRECATED
+        \gre@style@biginitial% keep this line
         \global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth% keep this line
+        \endgre@style@biginitial% keep this line
       \else%  DEPRECATED
         \gre@deprecated{\protect\grebiginitialformat}{\protect\grechangestyle{biginitial}}%  DEPRECATED
         \grebiginitialformat{\global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth}%  DEPRECATED
       \fi%  DEPRECATED
-      \endgre@style@biginitial%
     \fi%
     \gre@debugmsg{ifdim}{ wd(GreAboveinitialfirstbox) > initialwidth}%
     \ifdim\wd\gre@box@annotation>\gre@dimen@initialwidth\relax%
       \global\gre@dimen@initialwidth=\wd\gre@box@annoation%
     \fi%
-    \protected@edef\gre@@arg{\grebiginitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@biginitialformat\grebiginitialformat% DEPRECATED
       \setbox\gre@box@initial=\hbox{\vbox to 0pt{\hbox to \gre@dimen@initialwidth {\hss\raise -\gre@dimen@temp@five\hbox{\gre@style@biginitial#1\endgre@style@biginitial}\hss}\vss}}% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\grebiginitialformat}{\protect\grechangestyle{biginitial}}%  DEPRECATED
       \setbox\gre@box@initial=\hbox{\vbox to 0pt{\hbox to \gre@dimen@initialwidth {\hss\raise -\gre@dimen@temp@five\hbox{\grebiginitialformat{#1}}\hss}\vss}}%%  DEPRECATED
     \fi%  DEPRECATED
-    \gre@style@biginitial%
-    \protected@edef\gre@@arg{\grebiginitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@biginitialformat\grebiginitialformat% DEPRECATED
+      \gre@style@biginitial% keep this line
       \global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift% keep this line
+      \endgre@style@biginitial% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\grebiginitialformat}{\protect\grechangestyle{biginitial}}%  DEPRECATED
       \grebiginitialformat{\global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift}%  DEPRECATED
     \fi%  DEPRECATED
-    \endgre@style@biginitial%
   \fi %
   \hskip\gre@dimen@temp@four %
   \global\advance\gre@dimen@initialwidth by \gre@dimen@temp@four %
   \gre@debugmsg{annotation}{Ready to place initial.}%
   \copy\gre@box@initial%
   \ifnum\grebiginitial=0\relax%
-    \gre@style@initial%
-    \protected@edef\gre@@arg{\greinitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@initialformat\greinitialformat% DEPRECATED
+      \gre@style@initial% keep this line
       \global\gre@dimen@temp@four = \gre@dimen@afterinitialshift% keep this line
+      \endgre@style@initial% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\greinitialformat}{\protect\grechangestyle{initial}}%  DEPRECATED
       \greinitialformat{\global\gre@dimen@temp@four = \gre@dimen@afterinitialshift}%  DEPRECATED
     \fi%  DEPRECATED
-    \endgre@style@initial%
   \else%
-    \gre@style@biginitial%
-    \protected@edef\gre@@arg{\grebiginitialformat{#1}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@biginitialformat\grebiginitialformat% DEPRECATED
+      \gre@style@biginitial% keep this line
       \global\gre@dimen@temp@four = \gre@dimen@afterinitialshift% keep this line
+      \endgre@style@biginitial% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\grebiginitialformat}{\protect\grechangestyle{biginitial}}%  DEPRECATED
       \grebiginitialformat{\global\gre@dimen@temp@four = \gre@dimen@afterinitialshift}%  DEPRECATED
     \fi%  DEPRECATED
-    \endgre@style@biginitial%
   \fi%
   \hskip\gre@dimen@temp@four %
   \global\advance\gre@dimen@initialwidth by \gre@dimen@temp@four%
@@ -629,11 +619,11 @@
 \def\greabovelinestextstyle#1{% DEPRECATED
   \relax %
 }%
+\let\gre@deprecated@abovelinestextstyle\greabovelinestextstyle%
 
 % set space above the text lines - almost the same as for the translation
 \def\greaddspaceabove{%
-  \protected@edef\gre@@arg{\greabovelinestextstyle{a}}%  DEPRECATED
-  \expandafter\ifx\gre@@arg\relax% DEPRECATED
+  \ifx\gre@deprecated@abovelinestextstyle\greabovelinestextstyle% DEPRECATED
     \gre@style@abovelinestext% keep this line
     \global\gre@dimen@currentabovelinestextheight=\gre@dimen@abovelinestextheight % keep this line
     \gregeneratelines % keep this line
@@ -671,8 +661,7 @@
 
 % typesets the text above the line
 \def\gretypesettextabovelines#1{%
-  \protected@edef\gre@@arg{\greabovelinestextstyle{a}}%  DEPRECATED
-  \expandafter\ifx\gre@@arg\relax% DEPRECATED
+  \ifx\gre@deprecated@abovelinestextstyle\greabovelinestextstyle% DEPRECATED
     \gre@style@abovelinestext% keep this line
     \gre@debugmsg{spacing}{Raise alt text: \gre@dimen@abovelinestextraise}% keep this line
     \global\gre@dimen@temp@five=\gre@dimen@abovelinestextraise\relax% keep this line
@@ -693,8 +682,7 @@
   \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace %
   \gre@mark@abovelinestext %
   \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
-  \protected@edef\gre@@arg{\greabovelinestextstyle{a}}%  DEPRECATED
-  \expandafter\ifx\gre@@arg\relax% DEPRECATED
+  \ifx\gre@deprecated@abovelinestextstyle\greabovelinestextstyle% DEPRECATED
     \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\gre@style@abovelinestext#1\endgre@style@abovelinestext\hss}% keep this line
   \else%  DEPRECATED
     \gre@deprecated{\protect\greabovelinestextstyle}{\protect\grechangestyle{abovelinestext}}%  DEPRECATED
@@ -737,12 +725,11 @@
   %\gre@dimen@initialwidth=0pt
   \hbox to 0pt{%
     \vbox{%
-      \gre@style@normalstafflines%
-      \grenormalstafflinesformat % DEPRECATED
-      \protected@edef\gre@@arg{\grenormalstafflinesformat}%  DEPRECATED
-      \expandafter\ifx\gre@@arg\relax% DEPRECATED
+      \ifx\gre@deprecated@normalstafflinesformat\grenormalstafflinesformat% DEPRECATED
+        \gre@style@normalstafflines% keep this line
       \else%  DEPRECATED
         \gre@deprecated{\protect\grenormalstafflinesformat}{\protect\grechangestyle{normalstafflines}}%  DEPRECATED
+        \grenormalstafflinesformat % DEPRECATED
       \fi%  DEPRECATED
       \vskip\gre@dimen@currentabovelinestextheight %
       \vskip\gre@dimen@additionaltopspace %
@@ -776,7 +763,9 @@
       \vskip\gre@dimen@spacebeneathtext %
       \vskip\gre@dimen@currenttranslationheight %
       \vskip\gre@dimen@additionalbottomspace %
-      \endgre@style@normalstafflines%
+      \ifx\gre@deprecated@normalstafflinesformat\grenormalstafflinesformat% DEPRECATED
+        \endgre@style@normalstafflines% keep this line
+      \fi% DEPRECATED
     }%
     \hss%
   }%
@@ -791,12 +780,11 @@
 \def\gregeneratelines{%
   \setbox\gre@box@lines=\hbox to 0pt{%
     \vbox{%
-      \gre@style@normalstafflines%
-      \grenormalstafflinesformat % DEPRECATED
-      \protected@edef\gre@@arg{\grenormalstafflinesformat}%  DEPRECATED
-      \expandafter\ifx\gre@@arg\relax% DEPRECATED
+      \ifx\gre@deprecated@normalstafflinesformat\grenormalstafflinesformat% DEPRECATED
+        \gre@style@normalstafflines% keep this line
       \else%  DEPRECATED
         \gre@deprecated{\protect\grenormalstafflinesformat}{\protect\grechangestyle{normalstafflines}}%  DEPRECATED
+        \grenormalstafflinesformat % DEPRECATED
       \fi%  DEPRECATED
       \vskip\gre@skip@spaceabovelines %
       \vskip\gre@dimen@currentabovelinestextheight %
@@ -830,7 +818,9 @@
       \vskip\gre@dimen@additionalbottomspace %
       \vskip\gre@dimen@spacebeneathtext %
       \vskip\gre@dimen@currenttranslationheight %
-      \endgre@style@normalstafflines %
+      \ifx\gre@deprecated@normalstafflinesformat\grenormalstafflinesformat% DEPRECATED
+        \endgre@style@normalstafflines % keep this line
+      \fi% DEPRECATED
     }%
     \hss%
   }%
@@ -941,8 +931,7 @@
     \divide\gre@dimen@temp@five by 2\relax %
     \gre@mark@translation %
     \kern\gre@dimen@temp@five %
-    \protected@edef\gre@@arg{\gretranslationformat{a}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@translationformat\gretranslationformat% DEPRECATED
       \raise\gre@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\gretranslationformat}{\protect\grechangestyle{translation}}%  DEPRECATED
@@ -951,8 +940,7 @@
     \kern-\gre@dimen@temp@five %
   \else %
     \gre@mark@translation %
-    \protected@edef\gre@@arg{\gretranslationformat{a}}%  DEPRECATED
-    \expandafter\ifx\gre@@arg\relax% DEPRECATED
+    \ifx\gre@deprecated@translationformat\gretranslationformat% DEPRECATED
       \raise\gre@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}% keep this line
     \else%  DEPRECATED
       \gre@deprecated{\protect\gretranslationformat}{\protect\grechangestyle{translation}}%  DEPRECATED
@@ -967,8 +955,7 @@
   \fi %
   \gregoriocenterattr=1\relax %
   \gre@mark@translation %
-  \protected@edef\gre@@arg{\gretranslationformat{a}}%  DEPRECATED
-  \expandafter\ifx\gre@@arg\relax% DEPRECATED
+  \ifx\gre@deprecated@translationformat\gretranslationformat% DEPRECATED
     \raise\gre@dimen@spacebeneathtext\hbox to 0pt{\kern 0pt\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}\kern 0pt}% keep this line
   \else%  DEPRECATED
     \gre@deprecated{\protect\gretranslationformat}{\protect\grechangestyle{translation}}%  DEPRECATED
@@ -1451,17 +1438,34 @@
   \relax%
 }%
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% The following style functions are defined for backwards compatibility.  They will eventually be removed.
+\def\greinitialformat#1{% DEPRECATED
+  \relax %
+}
+\let\gre@deprecated@initialformat\greinitialformat
+
+\def\grebiginitialformat#1{% DEPRECATED
+  \relax %
+}
+\let\gre@deprecated@biginitialformat\grebiginitialformat
+
 \def\gretranslationformat#1{% DEPRECATED
   \relax %
 }%
+\let\gre@deprecated@translationformat\gretranslationformat
 
 \def\grenormalstafflinesformat{% DEPRECATED
   \relax %
 }%
+\let\gre@deprecated@normalstafflinesformat\grenormalstafflinesformat
 
 \def\greadditionalstafflinesformat{% DEPRECATED
   \relax %
 }%
+\let\gre@deprecated@additionalstafflinesformat\greadditionalstafflinesformat
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \def\GreSetStaffLinesFormat#1{%
   \gre@deprecated{\protect\GreSetStaffLinesFormat}{\protect\grechangestyle{normalstafflines}}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -343,14 +343,21 @@
   \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
-    \gre@style@additionalstafflines %
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \gre@style@additionalstafflines % keep this line
+    \else % DEPRECATED
+      \gre@deprecated{\protect\greadditionalstafflines}{\protect\grechangestyle{additionalstafflines}}% DEPRECATED
+      \greadditionalstafflines% DEPRECATED
+    \fi% DEPRECATED
     \kern\gre@dimen@temp@three %
     \gre@dimen@temp@five=\wd\gre@box@temp@sign %
     \advance\gre@dimen@temp@five by \gre@dimen@additionalcustoslineswidth %
     \kern-\gre@dimen@temp@five %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight%
     \hss %
-    \endgre@style@additionalstafflines%
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \endgre@style@additionalstafflines% keep this line
+    \fi% DEPRECATED
   }%
   \relax %
 }%
@@ -364,14 +371,21 @@
   \advance\gre@dimen@temp@five by -\gre@dimen@stafflineheight %
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
-    \gre@style@additionalstafflines %
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \gre@style@additionalstafflines % keep this line
+    \else % DEPRECATED
+      \gre@deprecated{\protect\greadditionalstafflines}{\protect\grechangestyle{additionalstafflines}}% DEPRECATED
+      \greadditionalstafflines% DEPRECATED
+    \fi% DEPRECATED
     \kern\gre@dimen@temp@three %
     \gre@dimen@temp@five=\wd\gre@box@temp@sign %
     \advance\gre@dimen@temp@five by \gre@dimen@additionalcustoslineswidth %
     \kern-\gre@dimen@temp@five %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight%
     \hss %
-    \endgre@style@additionalstafflines %
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \endgre@style@additionalstafflines% keep this line
+    \fi% DEPRECATED
   }%
   \relax %
 }%
@@ -387,7 +401,12 @@
   \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight %
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
-    \gre@style@additionalstafflines %
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \gre@style@additionalstafflines % keep this line
+    \else % DEPRECATED
+      \gre@deprecated{\protect\greadditionalstafflines}{\protect\grechangestyle{additionalstafflines}}% DEPRECATED
+      \greadditionalstafflines% DEPRECATED
+    \fi% DEPRECATED
     \hss %
     \kern\gre@dimen@temp@three %
     \gre@dimen@temp@five=\gre@dimen@additionalcustoslineswidth %
@@ -395,7 +414,9 @@
     \advance\gre@dimen@temp@five by \wd\gre@box@temp@sign %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight%
     \hss %
-    \endgre@style@additionalstafflines%
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \endgre@style@additionalstafflines% keep this line
+    \fi% DEPRECATED
   }%
   \relax %
 }%
@@ -409,7 +430,12 @@
   \advance\gre@dimen@temp@five by -\gre@dimen@stafflineheight %
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
-    \gre@style@additionalstafflines %
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \gre@style@additionalstafflines % keep this line
+    \else % DEPRECATED
+      \gre@deprecated{\protect\greadditionalstafflines}{\protect\grechangestyle{additionalstafflines}}% DEPRECATED
+      \greadditionalstafflines% DEPRECATED
+    \fi% DEPRECATED
     \hss %
     \kern\gre@dimen@temp@three %
     \gre@dimen@temp@five=\gre@dimen@additionalcustoslineswidth %
@@ -417,7 +443,9 @@
     \advance\gre@dimen@temp@five by \wd\gre@box@temp@sign %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight%
     \hss %
-    \endgre@style@additionalstafflines%
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \endgre@style@additionalstafflines% keep this line
+    \fi% DEPRECATED
   }%
   \relax %
 }%
@@ -797,8 +825,10 @@
   \relax %
 }%
 
-\gdef\grelowchoralsignstyle#1{\relax}%
-\gdef\grehighchoralsignstyle#1{\relax}%
+\gdef\grelowchoralsignstyle#1{\relax}% DEPRECATED
+\let\gre@deprecated@lowchoralsignstyle\grelowchoralsignstyle%
+\gdef\grehighchoralsignstyle#1{\relax}% DEPRECATED
+\let\gre@deprecated@highchoralsignstyle\grehighchoralsignstyle%
 
 % quite simple function: #1 is the height, #2 is the string, #3 is #2 of punctum mora, #4 is #3 of punctum mora
 % #3 is 1 if it must be a bit higher
@@ -812,8 +842,7 @@
   \else %
     \gre@calculate@glyphraisevalue{#1}{10}%
   \fi %
-  \protected@edef\gre@@arg{\grelowchoralsignstyle{#2}}%  DEPRECATED
-  \expandafter\ifx\gre@@arg\relax% DEPRECATED
+  \ifx\gre@deprecated@lowchoralsignstyle\grelowchoralsignstyle% DEPRECATED
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@style@lowchoralsign#2\endgre@style@lowchoralsign}% keep this line
   \else%  DEPRECATED
     \gre@deprecated{\protect\grelowchoralsignstyle}{\protect\grechangestyle{lowchoralsign}}%  DEPRECATED
@@ -824,8 +853,7 @@
 
 \def\GreHighChoralSign#1#2#3{%
   \grenobreak %
-  \protected@edef\gre@@arg{\grehighchoralsignstyle{#2}}%  DEPRECATED
-  \expandafter\ifx\gre@@arg\relax%  DEPRECATED
+  \ifx\gre@deprecated@highchoralsignstyle\grehighchoralsignstyle%  DEPRECATED
     \grevepisemusorrare{#1}{#3}{}{3}{\gre@style@highchoralsign#2\endgre@style@highchoralsign}% keep this line
   \else%  DEPRECATED
     \gre@deprecated{\protect\grehighchoralsignstyle}{\protect\grechangestyle{highchoralsign}}%  DEPRECATED
@@ -1193,9 +1221,16 @@
 \def\GreAdditionalLine#1#2#3{%
   \ifgre@showlines %
     \xdef\gresavedglyphraise{\the\gre@dimen@glyphraisevalue}%
-    \gre@style@additionalstafflines %
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \gre@style@additionalstafflines % keep this line
+    \else % DEPRECATED
+      \gre@deprecated{\protect\greadditionalstafflines}{\protect\grechangestyle{additionalstafflines}}% DEPRECATED
+      \greadditionalstafflines% DEPRECATED
+    \fi% DEPRECATED
     \grehepisorline{\gre@pitch@a}{#1}{#2}{#3}{f}%
-    \endgre@style@additionalstafflines%
+    \ifx\gre@deprecated@additionalstafflines\greadditionalstafflines% DEPRECATED
+      \endgre@style@additionalstafflines% keep this line
+    \fi% DEPRECATED
     \gre@dimen@glyphraisevalue=\gresavedglyphraise %
   \fi %
   \relax %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -717,8 +717,7 @@
 
 % macro to tell gregorio to set space for the translation
 \def\gre@addtranslationspace{%
-  \protected@edef\gre@@arg{\gretranslationformat{a}}%  DEPRECATED
-  \expandafter\ifx\gre@@arg\relax% DEPRECATED
+  \ifx\gre@deprecated@translationformat\gretranslationformat% DEPRECATED
     \gre@style@translation% keep this line
     \global\gre@dimen@currenttranslationheight=\gre@dimen@translationheight % keep this line
     \global\gre@dimen@textlower=\gre@dimen@spacebeneathtext % keep this line

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -73,15 +73,6 @@
 \definecolor{grebackgroundcolor}{RGB}{255,255,255}%
 \definecolor{gregoriocolor}{RGB}{229,53,44}
 
-%% The following two functions are defined for backwards compatibility.  They will eventually be removed.
-\def\greinitialformat#1{% DEPRECATED
-  \relax %
-}
-
-\def\grebiginitialformat#1{% DEPRECATED
-  \relax %
-}
-
 %%%%%%%%%
 %% LaTeX specific definitions for fonts
 %%%%%%%%%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -58,16 +58,6 @@
 \message{#1}%
 \endgroup}%
 
-% we're borrowing \protected@edef from the LaTeX source, so we need to define it for PlainTeX ourselves
-\def\@unexpandable@protect{\noexpand\protect\noexpand}
-\def\restore@protect{\let\protect\@@protect}
-\let\@edef\edef
-\def\protected@edef{%
-   \let\@@protect\protect
-   \let\protect\@unexpandable@protect
-   \afterassignment\restore@protect
-   \@edef}
-
 \ifx\csname gre@debug\endcsname\relax%
 \else%
   \def\gre@debug{}%
@@ -158,16 +148,6 @@
 }
 
 \let\normallines\grenormallines
-
-
-%% The following two functions are defined for backwards compatibility.  They will eventually be removed.
-\def\greinitialformat#1{% DEPRECATED
-  \relax %
-}%
-
-\def\grebiginitialformat#1{% DEPRECATED
-  \relax %
-}
 
 %%%%%%%%%%%%%%%%%%%%
 %% Formatting environments


### PR DESCRIPTION
I've been shown a better way (which doesn't require the use of `\protected@edef`) to do the check for the use of the old style syntax (See [TeX StackExchange] (http://tex.stackexchange.com/questions/261830/testing-for-macro-change/261834#261834)).  I implement that here and remove the definition for `\protected@edef`.
I also pulled the definitions of `\greinitialformat` and `\grebiginitialformat` out of gregoriotex.tex and gregoriotex.sty and put them in gregoriotex-main.tex since they are identical.
Fixed some consistency problems with when styles were being applied relative to the checks (all styles which existed in the old system should now be applied within the checks)
Added checks for `additionalstafflines`, which was lacking the backwards compatibility code completely (despite being a legacy style)