### PR TITLE
Distinguishing end of line shifts from beginning of line shifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Fixed
 - Corrected the rendering of explicit automatic and manual custos at the end of lines when the clef change that follows it is pushed to the next line (see [#569](https://github.com/gregorio-project/gregorio/issues/569)).
+- Distinguished between `eolshift` and `bolshift` giving each their own flag and user commmand for turning them on and off.  `\seteolshift{enable}` allows the lyric text to stretch under the custos at the end of the line.  `\setbolshift{enable}` aligns the beginning of each line on the notes instead of the text.  Both are on by default, but can be turned off with `\seteolshift{disable}` and `\setbolshift{disable}`.
 
 ### Added
 - `\greillumination`: allows user to specify arbitrary content (usually an image) to be used as the initial.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -733,7 +733,15 @@ Macro to determine whether Gregorio\TeX\ should automatically place the custos a
 \textbf{Nota Bene:} This command only effects the custos that appears at the end of a line.  Custos which are placed at a key change are unaffected.  Further, if custos are specified in the gabc file manually and Gregorio\TeX\ is set to place custos automatically, you will get two custos at the line breaks.
 
 \macroname{\textbackslash greseteolshifts}{\{\#1\}}{gregoriotex-main.tex}
-Marco to determine whether Gregorio\TeX\ should apply the a small shift at the end of each line.
+Marco to determine whether Gregorio\TeX\ should apply a small shift at the end of each line, thus allowing lyrics to stretch under the final custos.
+
+\begin{argtable}
+  \#1 & enable & The shifts are applied (default)\\
+  & disable & The shifts are not applied.
+\end{argtable}
+
+\macroname{\textbackslash gresetbolshifts}{\{\#1\}}{gregoriotex-main.tex}
+Marco to determine whether Gregorio\TeX\ should apply a small shift at the beginning of each line so that lines are aligned on the notes rather than the syllable text.
 
 \begin{argtable}
   \#1 & enable & The shifts are applied (default)\\

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -733,7 +733,7 @@ Macro to determine whether Gregorio\TeX\ should automatically place the custos a
 \textbf{Nota Bene:} This command only effects the custos that appears at the end of a line.  Custos which are placed at a key change are unaffected.  Further, if custos are specified in the gabc file manually and Gregorio\TeX\ is set to place custos automatically, you will get two custos at the line breaks.
 
 \macroname{\textbackslash greseteolshifts}{\{\#1\}}{gregoriotex-main.tex}
-Marco to determine whether Gregorio\TeX\ should apply a small shift at the end of each line, thus allowing lyrics to stretch under the final custos.
+Macro to determine whether Gregorio\TeX\ should apply a small shift at the end of each line, thus allowing lyrics to stretch under the final custos.
 
 \begin{argtable}
   \#1 & enable & The shifts are applied (default)\\
@@ -741,7 +741,7 @@ Marco to determine whether Gregorio\TeX\ should apply a small shift at the end o
 \end{argtable}
 
 \macroname{\textbackslash gresetbolshifts}{\{\#1\}}{gregoriotex-main.tex}
-Marco to determine whether Gregorio\TeX\ should apply a small shift at the beginning of each line so that lines are aligned on the notes rather than the syllable text.
+Macro to determine whether Gregorio\TeX\ should apply a small shift at the beginning of each line so that lines are aligned on the notes rather than the syllable text.
 
 \begin{argtable}
   \#1 & enable & The shifts are applied (default)\\

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1186,8 +1186,11 @@ Boolean which indicates whether the custos at the end of the line should be bloc
 \macroname{\textbackslash ifgre@breakintranslation}{}{gregoriotex-main.tex}
 Boolean which indicates if line breaks are allowed inside a translation.
 
+\macroname{\textbackslash ifgre@bolshiftsenabled}{}{gregoriotex-main.tex}
+Boolean which indicates if the left shift for the first syllables of lines is enabled.
+
 \macroname{\textbackslash ifgre@eolshiftsenabled}{}{gregoriotex-main.tex}
-Boolean which indicates if the left shift for the first syllables of scores is enabled.
+Boolean which indicates if the left shift for the last syllables of lines is enabled.
 
 \macroname{\textbackslash ifgre@euouae@implies@nlba}{}{gregoriotex-main.tex}
 Boolean which indicates if line breaks are prohibited in an \texttt{euouae} area.

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1140,7 +1140,21 @@
   \relax%
 }%
 
-% a flag to disable (or reenable) the left shift for first syllables of scores
+% a flag to disable (or reenable) the left shift for first syllables of lines
+\newif\ifgre@bolshiftsenabled%
+% default state is for them to be enabled
+\gre@bolshiftsenabledtrue
+
+\def\gresetbolshifts#1{%
+  \IfStrEq{#1}{enable}%
+    {\gre@bolshiftsenabledtrue}%
+    {\IfStrEq{#1}{disable}%
+      {\gre@bolshiftsenabledfalse}%
+      {\gre@error{Unrecognized option in \protect\gresetbolshifts}}%
+    }%
+}%
+
+% a flag to disable (or reenable) the left shift for last syllables of lines
 \newif\ifgre@eolshiftsenabled%
 % default state is for them to be enabled
 \gre@eolshiftsenabledtrue

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -536,7 +536,7 @@
   % So, at beginning of lines, we will have shifted left, and in middle of lines
   % we will have shifted right and left, thus cancelling... Very easy trick, but
   % took me years to find it!
-  \ifgre@eolshiftsenabled%
+  \ifgre@bolshiftsenabled%
     \gre@compute@bolshift{\gre@dimen@begindifference}{1}%
     \ifnum\gre@lastoflinecount=2\else %
       \kern -\gre@dimen@bolshift %


### PR DESCRIPTION
End of line shifts (`eolshift`) are for allowing the lyric text to stretch under the custos
Beginning of line shifts (`bolshift`) are to align the lines on the notes rather than the text
The code previously conflated these two and used the same flag to determine whether to apply each one.  I've distinguished the two here, giving them each their own flag (both default to true) and user command for changing the behavior.