### PR TITLE
Allowed the first word to be styled from TeX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+### Added
+- The first word of the score is now passed to a macro that allow it to be styled from TeX.  The first word is passed to `\GreFirstWord#1` and is styled by changing the `firstword` style.
 
 
 ## [4.0.0-beta2] - 2015-08-26

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -594,7 +594,8 @@ Different elements of an include score have different styles applied.  These ele
   \stylename{lowchoralsign} & low choral signs & none\\
   \stylename{highchoralsign} & high choral signs & none\\
   \stylename{firstsyllableinitial} & the first letter of the first syllable of a score which is not the score initial & none\\
-  \stylename{firstsyllable} & the balance of the first syllable of the score & none\\
+  \stylename{firstsyllable} & the first syllable of the score excluding the score initial & none\\
+  \stylename{firstword} & the first word of the first score excluding the score initial & none\\
   \stylename{modeline} & the rendered annotation from the \texttt{mode: ;} header in the gabc file & \parbox[t]{2.2cm}{\raggedleft\textsc{\textbf{Bold Small Capitals}}}\\
   \stylename{nabc} & ancient notation & {\color{gregoriocolor}gregoriocolor} (\LaTeX)\\
   && none (Plain\TeX)\\

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -275,7 +275,7 @@ Macro to end a score with a divisio maior.
       & 1 & Something needs to be placed after the divisio maior.\\
 \end{argtable}
 
-\macroname{\textbackslash GreFirstSyllable}{\{\#1\}}{gregoriotex-syllble.tex}
+\macroname{\textbackslash GreFirstSyllable}{\{\#1\}}{gregoriotex-syllable.tex}
 A macro which is called with the text of the first syllable, excluding the
 initial of the score.  This macro may be redefined to style the first syllable
 appropriately.  This macro may be called up to three times: for the letters
@@ -286,7 +286,7 @@ after the centered letters.
   \#1 & string & Text from the first syllable.
 \end{argtable}
 
-\macroname{\textbackslash GreFirstSyllableInitial}{\{\#1\}}{gregoriotex-syllble.tex}
+\macroname{\textbackslash GreFirstSyllableInitial}{\{\#1\}}{gregoriotex-syllable.tex}
 A macro which is called with the first letter of the first syllable which is
 not the initial of the score.  If the \texttt{initial-style} is \texttt{0}, the
 first letter of the syllable will be passed.  If the \texttt{initial-style} is
@@ -298,7 +298,7 @@ may be redefined to style the first letter appropriately.
                  initial of the score.
 \end{argtable}
 
-\macroname{\textbackslash GreFirstWord}{\{\#1\}}{gregoriotex-syllble.tex}
+\macroname{\textbackslash GreFirstWord}{\{\#1\}}{gregoriotex-syllable.tex}
 A macro which is called with the text of the first word, excluding the
 initial of the score.  This macro may be redefined to style the first word
 appropriately.  This macro may be called multiple times, depending on how

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -298,6 +298,16 @@ may be redefined to style the first letter appropriately.
                  initial of the score.
 \end{argtable}
 
+\macroname{\textbackslash GreFirstWord}{\{\#1\}}{gregoriotex-syllble.tex}
+A macro which is called with the text of the first word, excluding the
+initial of the score.  This macro may be redefined to style the first word
+appropriately.  This macro may be called multiple times, depending on how
+many syllables are in the word.
+
+\begin{argtable}
+  \#1 & string & Text from the first syllable.
+\end{argtable}
+
 \macroname{\textbackslash GreFlat}{\#1\#2}{gregoriotex-signs.tex}
 Macro to typeset a flat.
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -704,6 +704,15 @@ Macro to place argument above the lines and empty
   \#1 & string & Text to be placed above the lines.\\
 \end{argtable}
 
+\macroname{\textbackslash GreSetThisSyllable}{\#1\#2\#3}{gregoriotex-syllable.tex}
+Macro to set the text of the current syllable.
+
+\begin{argtable}
+  \#1 & string & the first letters of the syllable, that don't count for the alignment\\
+  \#2 & string & the middle letters of the syllable, we must align in the middle of them\\
+  \#3 & string & the end letters, they don't count for alignment\\
+\end{argtable}
+
 \macroname{\textbackslash GreSharp}{\#1\#2}{gregoriotex-signs.tex}
 Macro to typeset a sharp.
 
@@ -729,12 +738,12 @@ Macro to typeset an asterisk (\GreStar).
 Macro to typeset the syllable.
 
 \begin{argtable}
-  \#1 & string & the first letters of the syllable, that don't count for the alignment\\
-  \#2 & string & the middle letters of the syllable, we must align in the middle of them\\
-  \#3 & string & the end letters, they don't count for alignment\\
+  \#1 & \TeX\ code & macro setting syllable letters for the current syllable\\
+  \#2 & empty & reserved for future use\\
+  \#3 & \TeX\ control sequence & the control sequence to use for styling the hyphen\\
   \#4 & 0 & this syllable is not the end of a word\\
   & 1 & this syllable is the end of a word\\
-  \#5 & \TeX\ code & macros setting next syllable letters of the next syllable\\
+  \#5 & \TeX\ code & macros setting syllable letters for the next syllable\\
   \#6 & string & the line, byte offset, and column address for textedit links when point-and-click is enabled\\
   \#7 & & alignment type of the first next glyph\\
   \#8 &\TeX\ code & other macros (translation, double text, etc.) that don't fit in the limitation of the number of arguments\\
@@ -772,6 +781,13 @@ nothing in Plain\TeX.
 
 \begin{argtable}
   \#1 & string & Text to typeset underlined.\\
+\end{argtable}
+
+\macroname{\textbackslash GreUnstyled}{\#1}{gregoriotex-syllable.tex}
+Returns its argument as-is.
+
+\begin{argtable}
+  \#1 & string & Text to typeset without any extra styling.\\
 \end{argtable}
 
 \macroname{\textbackslash GreVarBraceLength}{\#1}{gregoriotex-signs.tex}

--- a/src/characters.c
+++ b/src/characters.c
@@ -1240,3 +1240,38 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
     gregorio_go_to_first_character(&current_character);
     (*param_character) = current_character;
 }
+
+void gregorio_set_first_word(gregorio_character **const character)
+{
+    gregorio_character *ch = *character;
+    if (gregorio_go_to_end_initial(&ch)) {
+        ch = ch->next_character;
+    }
+    if (ch) {
+        bool started_style = false;
+        while (ch) {
+            if (!ch->is_character
+                    && (ch->cos.s.style == ST_CENTER
+                        || ch->cos.s.style == ST_FORCED_CENTER)) {
+                if (started_style) {
+                    started_style = false;
+                    gregorio_insert_style_before(ST_T_END, ST_FIRST_WORD, ch);
+                }
+            } else if (!started_style) {
+                started_style = true;
+                gregorio_insert_style_before(ST_T_BEGIN, ST_FIRST_WORD, ch);
+            }
+
+            if (!ch->next_character && started_style) {
+                gregorio_insert_style_after(ST_T_END, ST_FIRST_WORD, &ch);
+            }
+
+            ch = ch->next_character;
+        }
+    }
+    /* else there are no more characters here */
+    
+    if (*character) {
+        gregorio_go_to_first_character(character);
+    }
+}

--- a/src/characters.h
+++ b/src/characters.h
@@ -79,4 +79,6 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
 void gregorio_rebuild_first_syllable(gregorio_character **param_character,
         bool separate_initial);
 
+void gregorio_set_first_word(gregorio_character **const character);
+
 #endif

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -87,6 +87,8 @@ static const char *dump_style_to_string(grestyle_style style)
         return " ST_SPECIAL_CHAR";
     case ST_VERBATIM:
         return "     ST_VERBATIM";
+    case ST_FIRST_WORD:
+        return "   ST_FIRST_WORD";
     case ST_FIRST_SYLLABLE:
         return "ST_FIRST_SYLLABLE";
     case ST_FIRST_SYLLABLE_INITIAL:

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -444,7 +444,8 @@ static void close_syllable(YYLTYPE *loc)
     int i;
     gregorio_add_syllable(&current_syllable, number_of_voices, elements,
             first_text_character, first_translation_character, position,
-            abovelinestext, translation_type, no_linebreak_area, euouae, loc);
+            abovelinestext, translation_type, no_linebreak_area, euouae, loc,
+            started_first_word);
     if (!score->first_syllable) {
         /* we rebuild the first syllable if we have to */
         score->first_syllable = current_syllable;

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -92,6 +92,7 @@ static gregorio_center_determination center_is_determined;
  * (for key changes) */
 static int current_key = DEFAULT_KEY;
 static bool got_language = false;
+static bool started_first_word = false;
 static struct sha1_ctx digester;
 
 static __inline void check_multiple(const char *name, bool exists) {
@@ -241,6 +242,7 @@ static void initialize_variables(void)
     for (i = 0; i < 10; i++) {
         macros[i] = NULL;
     }
+    started_first_word = false;
 }
 
 /*
@@ -420,10 +422,16 @@ static void rebuild_characters(gregorio_character **param_character,
             || (current_syllable && !current_syllable->previous_syllable
             && !current_syllable->text && current_character)) {
         gregorio_rebuild_first_syllable(&current_character, has_initial);
+
+        started_first_word = true;
     }
 
     gregorio_rebuild_characters(param_character, center_is_determined,
             has_initial);
+
+    if (started_first_word) {
+        gregorio_set_first_word(&current_character);
+    }
 }
 
 /*
@@ -449,6 +457,10 @@ static void close_syllable(YYLTYPE *loc)
     }
     if (position == WORD_ONE_SYLLABLE || position == WORD_END) {
         position = WORD_BEGINNING;
+
+        if (started_first_word) {
+            started_first_word = false;
+        }
     }
     center_is_determined = CENTER_NOT_DETERMINED;
     current_character = NULL;

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -858,6 +858,9 @@ static void gtex_write_begin(FILE *f, grestyle_style style)
     case ST_COLORED:
         fprintf(f, "\\GreColored{");
         break;
+    case ST_FIRST_WORD:
+        fprintf(f, "\\GreFirstWord{");
+        break;
     case ST_FIRST_SYLLABLE:
         fprintf(f, "\\GreFirstSyllable{");
         break;
@@ -1066,6 +1069,9 @@ static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
                 return 0;
             if (current_char->cos.s.style != ST_CENTER
                     && current_char->cos.s.style != ST_FORCED_CENTER
+                    && current_char->cos.s.style != ST_FIRST_WORD
+                    && current_char->cos.s.style != ST_FIRST_SYLLABLE
+                    && current_char->cos.s.style != ST_FIRST_SYLLABLE_INITIAL
                     && current_char->cos.s.style != ST_SPECIAL_CHAR
                     && current_char->cos.s.style != ST_VERBATIM
                     && current_char->cos.s.style != ST_INITIAL) {
@@ -1078,6 +1084,9 @@ static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
                 if (!current_char->is_character
                         && current_char->cos.s.style != ST_CENTER
                         && current_char->cos.s.style != ST_FORCED_CENTER
+                        && current_char->cos.s.style != ST_FIRST_WORD
+                        && current_char->cos.s.style != ST_FIRST_SYLLABLE
+                        && current_char->cos.s.style != ST_FIRST_SYLLABLE_INITIAL
                         && current_char->cos.s.style != ST_INITIAL) {
                     state = 2;
                 } else if (current_char->cos.s.style != possible_fixed_style
@@ -1091,6 +1100,9 @@ static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
                 return 0;
             if (current_char->cos.s.style != ST_CENTER
                     && current_char->cos.s.style != ST_FORCED_CENTER
+                    && current_char->cos.s.style != ST_FIRST_WORD
+                    && current_char->cos.s.style != ST_FIRST_SYLLABLE
+                    && current_char->cos.s.style != ST_FIRST_SYLLABLE_INITIAL
                     && current_char->cos.s.style != ST_SPECIAL_CHAR
                     && current_char->cos.s.style != ST_VERBATIM
                     && current_char->cos.s.style != ST_INITIAL) {

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2805,7 +2805,9 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                 syllable->next_syllable? syllable->next_syllable->text : NULL);
         fprintf(f, "\\GreSyllable");
     }
+    fprintf(f, "{\\GreSetThisSyllable");
     gregoriotex_write_text(f, syllable->text, first_syllable);
+    fprintf(f, "}{}{\\Gre%s}", syllable->first_word ? "FirstWord" : "Unstyled");
     if (syllable->position == WORD_END
             || syllable->position == WORD_ONE_SYLLABLE || !syllable->text
             || !syllable->next_syllable

--- a/src/struct.c
+++ b/src/struct.c
@@ -926,7 +926,8 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
         gregorio_character *first_translation_character,
         gregorio_word_position position, char *abovelinestext,
         gregorio_tr_centering translation_type, gregorio_nlba no_linebreak_area,
-        gregorio_euouae euouae, const gregorio_scanner_location *const loc)
+        gregorio_euouae euouae, const gregorio_scanner_location *const loc,
+        const bool first_word)
 {
     gregorio_syllable *next;
     gregorio_element **tab;
@@ -951,6 +952,7 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
     next->translation = first_translation_character;
     next->translation_type = translation_type;
     next->abovelinestext = abovelinestext;
+    next->first_word = first_word;
     if (loc) {
         next->src_line = loc->first_line;
         next->src_column = loc->first_column;

--- a/src/struct.h
+++ b/src/struct.h
@@ -289,6 +289,7 @@ typedef enum grestyle_style {
     ST_INITIAL, /* a style used to determine the initial */
     ST_UNDERLINED,
     ST_COLORED,
+    ST_FIRST_WORD,
     ST_FIRST_SYLLABLE,
     ST_FIRST_SYLLABLE_INITIAL
 } grestyle_style;

--- a/src/struct.h
+++ b/src/struct.h
@@ -606,6 +606,7 @@ typedef struct gregorio_syllable {
      * word, WORD_ONE_SYLLABLE for syllable that are alone in their word,
      * and i let you gess what are WORD_MIDDLE and WORD_END. */
     ENUM_BITFIELD(gregorio_word_position) position:3;
+    bool first_word:1;
 } gregorio_syllable;
 
 /* The items in source_info used to be -- well, most of them -- in
@@ -765,9 +766,9 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
         gregorio_character *first_character,
         gregorio_character *first_translation_character,
         gregorio_word_position position, char *abovelinestext,
-        gregorio_tr_centering translation_type,
-        gregorio_nlba no_linebreak_area,
-        gregorio_euouae euouae, const gregorio_scanner_location *loc);
+        gregorio_tr_centering translation_type, gregorio_nlba no_linebreak_area,
+        gregorio_euouae euouae, const gregorio_scanner_location *loc,
+        bool first_word);
 void gregorio_add_special_sign(gregorio_note *current_note, gregorio_sign sign);
 void gregorio_change_shape(gregorio_note *note, gregorio_shape shape);
 void gregorio_position_h_episemus_above(gregorio_note *note, signed char height,

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1537,7 +1537,7 @@
   \gre@skip@temp@four = \gre@skip@spacebeforefinalfinalis%
   \gre@hskip\gre@skip@temp@four %
   \GreNoBreak %
-  \GreBarSyllable{}{}{}{1}{}{}{0}{\GreLastOfLine}{%
+  \GreBarSyllable{\GreSetThisSyllable{}{}{}}{}{}{1}{}{}{0}{\GreLastOfLine}{%
     \GreNoBreak %
     \GreDivisioFinalis{}%
     #1%
@@ -1549,7 +1549,7 @@
 \def\GreFinalDivisioMaior#1{%
   \gre@localrightbox{}%
   \gre@localleftbox{}%
-    \GreBarSyllable{}{}{}{1}{}{}{0}{}{%
+    \GreBarSyllable{\GreSetThisSyllable{}{}{}}{}{}{1}{}{}{0}{}{%
     \GreNoBreak %
     \GreDivisioMaior{}%
     #1%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -322,6 +322,7 @@
 %% macros for the typesetting of glyphs and notes together
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\def\GreFirstWord#1{\gre@style@firstword#1\endgre@style@firstword}%
 \def\GreFirstSyllable#1{\gre@style@firstsyllable#1\endgre@style@firstsyllable}%
 \def\GreFirstSyllableInitial#1{\gre@style@firstsyllableinitial#1\endgre@style@firstsyllableinitial}%
 

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -422,6 +422,23 @@
 
 \let\gre@fixednexttextformat\gre@textnormal %
 
+\def\GreUnstyled#1{#1}%
+
+% #1 : the first letters of the syllable, that don't count for the alignment
+% #2 : the middle letters of the syllable, we must align in the middle of them
+% #3 : the end letters, they don't count
+\def\GreSetThisSyllable#1#2#3{%
+  \ifgre@vowelcentering %
+    \gdef\gre@firstsyllablepart{#1}%
+    \gdef\gre@middlesyllablepart{#2}%
+    \gdef\gre@endsyllablepart{#3}%
+  \else %
+    \gdef\gre@firstsyllablepart{}%
+    \gdef\gre@middlesyllablepart{#1#2#3}%
+    \gdef\gre@endsyllablepart{}%
+  \fi %
+}%
+
 \def\GreSetNextSyllable#1#2#3{%
   \gdef\gre@nextfirstsyllablepart{#1}%
   \gdef\gre@nextmiddlesyllablepart{#2}%
@@ -494,9 +511,9 @@
 }%
 
 %% general macro : it will typeset the syllable : arguments are :
-% #1 : the first letters of the syllable, that don't count for the alignment
-% #2 : the middle letters of the syllable, we must align in the middle of them
-% #3 : the end letters, they don't count
+% #1 : macro setting the letters of this syllable
+% #2 : reserved (unused)
+% #3 : control sequence for styling the hyphen
 % #4 : end of word : if it is 0 it means it is not an end of word, if it is 1 it is
 % TODO: find another system for the end syllable
 % #9 : glyphs : all the notes
@@ -509,17 +526,9 @@
 %% at the end we wall \greendofword or \gre@endofsyllable with #7, to reduce the space in case of a flat or natural
 \def\GreSyllable#1#2#3#4#5#6#7#8#9{%
   \gre@debugmsg{general}{}%
-  \gre@debugmsg{general}{New syllable: \expandafter\unexpanded{#1}\expandafter\unexpanded{#2}\expandafter\unexpanded{#3}}%
+  \gre@debugmsg{general}{New syllable: \expandafter\unexpanded{#1}}%
   \gre@debugmsg{general}{}%
-  \ifgre@vowelcentering %
-    \gdef\gre@firstsyllablepart{#1}%
-    \gdef\gre@middlesyllablepart{#2}%
-    \gdef\gre@endsyllablepart{#3}%
-  \else %
-    \gdef\gre@firstsyllablepart{}%
-    \gdef\gre@middlesyllablepart{#1#2#3}%
-    \gdef\gre@endsyllablepart{}%
-  \fi %
+  #1%
   \gre@firstglyphtrue%
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}% we first get the width between the alignment point and the end of the syllable
   \gre@syllablenotes{#9}% we put the notes in a box, so that we have the width of it
@@ -580,9 +589,9 @@
     \ifdim\gre@skip@temp@one > \gre@dimen@maximumspacewithoutdash %
       % if it's the last syllable of line, the hyphen will be \GreHyph
       \ifnum\gre@lastoflinecount=1\relax %
-        \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart\GreHyph\relax}{#6}}}%
+        \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart#3{\GreHyph}\relax}{#6}}}%
       \else %
-        \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart-}{#6}}}%
+        \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart#3{-}}{#6}}}%
       \fi %
       % recomputing end difference and final skip with the final hyphen
       \gre@calculate@enddifference{\wd\gre@box@syllablenotes}{\wd\gre@box@syllabletext}{\gre@dimen@textaligncenter}{\gre@dimen@notesaligncenter}{0}%
@@ -712,15 +721,7 @@
   % the main goal is, when there is no text under the bar, to put the bar in the middle of the space between the last note of the previous syllable and the first note of the next syllable. But there are limits : a bar can't go very far above text. For example if there is "nuncncncncn" with a punctum on the u, the bar can't go above the fourth n, the most far position is the position where the end of the bar is above the end of the word. The same limitation applies for the syllable after the bar.
   % there are two different cases that have almost nothing in common : the case where there is something written under the bar, and the case where there is nothing.
   % first of all we need to calculate previousenddifference, begindifference, enddifference and nextbegindifference.
-  \ifgre@vowelcentering %
-    \gdef\gre@firstsyllablepart{#1}%
-    \gdef\gre@middlesyllablepart{#2}%
-    \gdef\gre@endsyllablepart{#3}%
-  \else %
-    \gdef\gre@firstsyllablepart{}%
-    \gdef\gre@middlesyllablepart{#1#2#3}%
-    \gdef\gre@endsyllablepart{}%
-  \fi %
+  #1%
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}%
   \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart}{#6}}}%
   \gre@debugmsg{spacing}{Width of bar text: \the\wd\gre@box@syllabletext}%

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -178,6 +178,10 @@
   {\begingroup}%
   {\endgroup}%
 
+\newenvironment{gre@style@firstword}%
+  {\begingroup}%
+  {\endgroup}%
+
 \newenvironment{gre@style@modeline}%
   {\begingroup\begin{scshape}\begin{bfseries}}%
   {\end{bfseries}\end{scshape}\endgroup}%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -222,6 +222,12 @@
 }%
 \def\endgre@style@firstsyllable{\endgroup}%
 
+\def\gre@style@firstword{%
+  \begingroup%
+  \relax%
+}%
+\def\endgre@style@firstword{\endgroup}%
+
 \def\gre@style@modeline{%
   \begingroup%
   \bf%


### PR DESCRIPTION
Similar to the styling of first syllable and first syllable initial, this allows styling of the whole first word.

All of the gabc->gtex and gabc->dump tests fail because of the new code, but that is expected.  All PDF tests pass.

Please review and merge if satisfactory.