### PR TITLE
Eliminated the use of stdbool.h.  Fixes #587.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,6 @@ AX_CHECK_LINK_FLAG([-pie], [LDFLAGS+=" -pie"])
 
 AC_HEADER_STDC
 
-AC_CHECK_HEADER_STDBOOL
-
 # linux has integer types in stdint.h, solaris, vms in inttypes.h
 AC_CHECK_HEADERS([stdint.h])
 AC_CHECK_HEADERS([stdalign.h])

--- a/src/bool.h
+++ b/src/bool.h
@@ -20,12 +20,8 @@
 #ifndef BOOL_H
 #define BOOL_H
 
-#ifdef HAVE__BOOL
-#include <stdbool.h>
-#else
 typedef unsigned int bool;
 #define true 1
 #define false 0
-#endif
 
 #endif


### PR DESCRIPTION
Using stdbool.h was a vestige of C99 support anyway.  Since we are dropping back to C89 in order to support MSVC, we might as well eliminate the use of stdbool.h altogether.

@rpspringuel Please try this out.

Ready for review/merge.