### PR TITLE
Emptied the annotation box at the end of the score.

### DIFF
--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1078,6 +1078,7 @@
   \gre@skip@temp@two=0pt%
   \gre@skip@temp@three=0pt%
   \gre@skip@temp@four=0pt%
+  \setbox\gre@box@annotation=\box\voidb@x%
   \directlua{gregoriotex.atScoreEnd()}%
   \unsetluatexattribute{\gre@attr@glyph@id}%
   \unsetluatexattribute{\gre@attr@glyph@top}%


### PR DESCRIPTION
Per @rpspringuel; fixes #592.

As this is a fix for a 4.0 feature, I did not add it to `CHANGELOG.md` since I am assuming all the -beta and -rc change logs will be sublimated into the 4.0.0 change log upon release.

I tested this and it works.  Ready for review/mege.  I will add the new test once this is merged.