### PR TITLE
Cleared the glyph id attribute at the end of the score to stop leakage.

### DIFF
--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1088,6 +1088,7 @@
     \parfillskip=\gre@save@parfillskip\relax%
   \fi %
   \global\let\ifgre@vowelcentering\ifgre@save@englishcentering\relax % DEPRECATED
+  \global\setluatexattribute\gre@attr@glyph@id{0}%
   \relax%
 }%
 


### PR DESCRIPTION
Fixes #595.

As this is a fix to a beta feature, I am not adding to the change log.

Ready for review and merge if satisfactory.