### PR TITLE
Added "firstletter" lyric centering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.
 - The first word of the score is now passed to a macro that allow it to be styled from TeX.  The first word is passed to `\GreFirstWord#1` and is styled by changing the `firstword` style.
+- A new type of lyric centering, enabled with `\gresetlyriccentering{firstletter}`, which aligns the neume with the first letter of each syllable.
 
 
 ## [4.0.0-beta2] - 2015-08-26

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -686,14 +686,15 @@ Macro to set how the text of the lyrics aligns with the alignment point of its r
 
 \begin{argtable}
   \#1 & vowel & The center of the vowel in the syllable will align with the alignment point of the neumes\\
-  & syllable & The center of the syllable will align with the alignment point of the neumes
+  & syllable & The center of the syllable will align with the alignment point of the neumes\\
+  & firstletter & The center of the first letter/character of the syllable will align with the alignment point of the neumes\\
 \end{argtable}
 
 \textbf{Nota Bene:} What constitutes the ``vowel'' of the syllable is determined by the language the lyric text is written in, as specified by the use of the \texttt{language} header in the gabc file.  Out of the box, Gregorio\TeX\ explicitly supports only Latin and English, but the rules for Latin have a high degree of overlap with many Romance languages, allowing them to fall back on the Latin rules with acceptable results.
 
 You can also define your own languages in \texttt{gregorio-vowels.dat}.  If you do define a language, please consider sharing your work by submitting it to the project (see CONTRIBUTING.md for instructions).
 
-Finally, in cases where you want some sort of exceptional alignment, you can force Gregorio to consider a particular part of the syllable to be the ``vowel'' by enclosing it in curly braces (``\{'' and ``\}'') in your gabc file.
+Finally, in cases where you want some sort of exceptional alignment, you can force Gregorio to consider a particular part of the syllable to be the ``vowel'' by enclosing it in curly braces (``\{'' and ``\}'') in your gabc file.  Curly braces only affect alignment when using vowel centering.  Syllable centering will always use the entire syllable, and firstletter centering will always use the first character of the syllable --- regardless of curly braces in the gabc file.
 
 \macroname{\textbackslash gresettranslationcentering}{\{\#1\}}{gregoriotex-main.tex}
 Macro to specify how the translation text should be aligned with it respective syllable text.

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -830,6 +830,9 @@ Macro to hold the version number of Gregorio\TeX\ so that it can be checked for 
 \macroname{\textbackslash gre@leftfill}{}{gregoriotex-main.tex}
 Macro set to \verb=\hfil= or \verb=\relax= depending on alignment choices.
 
+\macroname{\textbackslash gre@lyriccentering}{}{gregoriotex-syllable.tex}
+Macro set to \verb=0= for full-syllable centering, \verb=1= for vowel centering (the default), or \verb=2= for first-letter centering.
+
 \macroname{\textbackslash gre@rightfill}{}{gregoriotex-main.tex}
 Macro set to \verb=\hfil= or \verb=\relax= depending on alignment choices.
 
@@ -1088,9 +1091,6 @@ Boolean used in \verb=\gre@changeonedimenfactor= as we test for the presence of 
 
 \macroname{\textbackslash ifgre@shrink}{}{gregoriotex-spaces.tex}
 Boolean used in \verb=\gre@changeonedimenfactor= as we test for the presence of a shrink.
-
-\macroname{\textbackslash ifgre@vowelcentering}{}{gregoriotex-syllable.tex}
-Boolean used to specify whether the center of the vowel or the center of the syllable is used to align the lyrics with their neumes.
 
 \macroname{\textbackslash ifgre@translationcentering}{}{gregoriotex-main.tex}
 Boolean used to specify whether the translation text should be centered below its respective syllable.

--- a/src/characters.h
+++ b/src/characters.h
@@ -47,7 +47,7 @@ typedef enum gregorio_center_determination {
 /* this is a temporary structure that will be used for style determination */
 
 typedef struct det_style {
-    unsigned char style;
+    grestyle_style style;
     struct det_style *previous_style;
     struct det_style *next_style;
 } det_style;
@@ -55,6 +55,14 @@ typedef struct det_style {
 gregorio_character *gregorio_first_text(gregorio_score *score);
 
 void gregorio_write_text(bool skip_initial,
+        gregorio_character *current_character,
+        FILE *f, void (*printverb) (FILE *, grewchar *),
+        void (*printchar) (FILE *, grewchar),
+        void (*begin) (FILE *, grestyle_style),
+        void (*end) (FILE *, grestyle_style),
+        void (*printspchar) (FILE *, grewchar *));
+
+void gregorio_write_first_letter_alignment_text(bool skip_initial,
         gregorio_character *current_character,
         FILE *f, void (*printverb) (FILE *, grewchar *),
         void (*printchar) (FILE *, grewchar),
@@ -79,6 +87,6 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
 void gregorio_rebuild_first_syllable(gregorio_character **param_character,
         bool separate_initial);
 
-void gregorio_set_first_word(gregorio_character **const character);
+void gregorio_set_first_word(gregorio_character **character);
 
 #endif

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -93,8 +93,9 @@ static const char *dump_style_to_string(grestyle_style style)
         return "ST_FIRST_SYLLABLE";
     case ST_FIRST_SYLLABLE_INITIAL:
         return "ST_FIRST_SYLLABLE_INITIAL";
+    default:
+        return unknown(style);
     }
-    return unknown(style);
 }
 
 static void dump_write_characters(FILE *const f,

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -883,6 +883,7 @@ static void gtex_write_end(FILE *f, grestyle_style style)
     switch (style) {
     case ST_FORCED_CENTER:
     case ST_CENTER:
+    case ST_SYLLABLE_INITIAL:
         fprintf(f, "}{");
         break;
     case ST_INITIAL:
@@ -2568,11 +2569,16 @@ static void gregoriotex_write_text(FILE *f, gregorio_character *text,
         bool *first_syllable)
 {
     if (text == NULL) {
-        fprintf(f, "{}{}{}");
+        fprintf(f, "{}{}{}{}{}");
         return;
     }
     fprintf(f, "{");
     gregorio_write_text(first_syllable && *first_syllable, text, f,
+            (&gtex_write_verb), (&gtex_print_char), (&gtex_write_begin),
+            (&gtex_write_end), (&gtex_write_special_char));
+    fprintf(f, "}{");
+    gregorio_write_first_letter_alignment_text(
+            first_syllable && *first_syllable, text, f,
             (&gtex_write_verb), (&gtex_print_char), (&gtex_write_begin),
             (&gtex_write_end), (&gtex_write_special_char));
     if (first_syllable) {
@@ -2825,7 +2831,7 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
         fprintf(f, "}{%d}{",
                 gregoriotex_syllable_first_type(syllable->next_syllable));
     } else {
-        fprintf(f, "{\\GreSetNextSyllable{}{}{}}{");
+        fprintf(f, "{\\GreSetNextSyllable{}{}{}{}{}}{");
         write_syllable_point_and_click(f, syllable, status);
         fprintf(f, "}{0}{");
     }

--- a/src/struct.h
+++ b/src/struct.h
@@ -291,7 +291,8 @@ typedef enum grestyle_style {
     ST_COLORED,
     ST_FIRST_WORD,
     ST_FIRST_SYLLABLE,
-    ST_FIRST_SYLLABLE_INITIAL
+    ST_FIRST_SYLLABLE_INITIAL,
+    ST_SYLLABLE_INITIAL
 } grestyle_style;
 
 /*

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1000,8 +1000,6 @@
 
 % gre@attr@dash (see its definition in gregorio-syllable) is 0 when we are in a score, and unset when we are not
 
-\newif\ifgre@save@englishcentering% DEPRECATED
-
 %macro called at the beginning of a score
 % #1 is the gabc score id
 % #2 is the high height
@@ -1012,7 +1010,7 @@
 \def\GreBeginScore#1#2#3#4#5#6{%
   \global\setluatexattribute\gre@attr@glyph@id{0}%
   \xdef\gre@gabcname{#6}%
-  \global\let\ifgre@save@englishcentering\ifgre@vowelcentering\relax % DEPRECATED
+  \global\let\gre@save@englishcentering\gre@lyriccentering\relax % DEPRECATED
   \ifgre@justifylastline%
     \xdef\gre@save@parfillskip{\the\parfillskip}
     \parfillskip=0pt plus 0pt minus 0pt\relax%
@@ -1087,7 +1085,7 @@
   \ifgre@justifylastline%
     \parfillskip=\gre@save@parfillskip\relax%
   \fi %
-  \global\let\ifgre@vowelcentering\ifgre@save@englishcentering\relax % DEPRECATED
+  \global\let\gre@lyriccentering\gre@save@englishcentering\relax % DEPRECATED
   \global\setluatexattribute\gre@attr@glyph@id{0}%
   \relax%
 }%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1537,7 +1537,7 @@
   \gre@skip@temp@four = \gre@skip@spacebeforefinalfinalis%
   \gre@hskip\gre@skip@temp@four %
   \GreNoBreak %
-  \GreBarSyllable{\GreSetThisSyllable{}{}{}}{}{}{1}{}{}{0}{\GreLastOfLine}{%
+  \GreBarSyllable{\GreSetThisSyllable{}{}{}{}{}}{}{}{1}{}{}{0}{\GreLastOfLine}{%
     \GreNoBreak %
     \GreDivisioFinalis{}%
     #1%
@@ -1549,7 +1549,7 @@
 \def\GreFinalDivisioMaior#1{%
   \gre@localrightbox{}%
   \gre@localleftbox{}%
-    \GreBarSyllable{\GreSetThisSyllable{}{}{}}{}{}{1}{}{}{0}{}{%
+    \GreBarSyllable{\GreSetThisSyllable{}{}{}{}{}}{}{}{1}{}{}{0}{}{%
     \GreNoBreak %
     \GreDivisioMaior{}%
     #1%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -234,7 +234,7 @@
         \else%
           \global\setbox\gre@box@temp@width=\hbox{#1}%
         \fi%
-      \else%
+      \else% vowel or first-letter centering
         \ifcase#3%
           \gre@widthof{\gre@endsyllablepart}%
         \else%
@@ -430,15 +430,15 @@
 % #4 : the very first letter
 % #5 : all the letters after the first letter
 \def\GreSetThisSyllable#1#2#3#4#5{%
-  \ifcase\gre@lyriccentering% 0
+  \ifcase\gre@lyriccentering% 0 - syllable centering
     \gdef\gre@firstsyllablepart{}%
     \gdef\gre@middlesyllablepart{#1#2#3}%
     \gdef\gre@endsyllablepart{}%
-  \or % 1
+  \or % 1 - vowel centering
     \gdef\gre@firstsyllablepart{#1}%
     \gdef\gre@middlesyllablepart{#2}%
     \gdef\gre@endsyllablepart{#3}%
-  \or % 2
+  \or % 2 - first-letter centering
     \gdef\gre@firstsyllablepart{}%
     \gdef\gre@middlesyllablepart{#4}%
     \gdef\gre@endsyllablepart{#5}%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -209,10 +209,10 @@
 % Conditionals can be summed up this way:
 % if wd(#1/2) > \gre@dimen@textaligncenter then #2
 % else
-%   \ifgre@vowelcentering :
-%     if wd(\gre@endsyllablepart) > \gre@dimen@clivisalignmentmin -> #2 else #1
+%   if lyrics are centered on syllables :
+%     if (\gre@dimen@textaligncenter) > \gre@dimen@clivisalignmentmin -> #2 else #1
 %   else:
-%      if (\gre@dimen@textaligncenter) > \gre@dimen@clivisalignmentmin -> #2 else #1
+%     if wd(\gre@endsyllablepart) > \gre@dimen@clivisalignmentmin -> #2 else #1
 %
 % #3 is the same as #2 of previous function
 \def\gre@handleclivisspecialalignment#1#2#3{%
@@ -227,7 +227,14 @@
     \ifdim\gre@dimen@temp@three >\gre@dimen@textaligncenter %
       \global\setbox\gre@box@temp@width=\hbox{#2}%
     \else%
-      \ifgre@vowelcentering%
+      \ifcase\gre@lyriccentering% 0 == syllable centering
+        \gre@debugmsg{ifdim}{ textaligncenter > clivisalignmentmin}%
+        \ifdim\gre@dimen@textaligncenter >\gre@dimen@clivisalignmentmin %
+          \global\setbox\gre@box@temp@width=\hbox{#2}%
+        \else%
+          \global\setbox\gre@box@temp@width=\hbox{#1}%
+        \fi%
+      \else%
         \ifcase#3%
           \gre@widthof{\gre@endsyllablepart}%
         \else%
@@ -235,13 +242,6 @@
         \fi%
         \gre@debugmsg{ifdim}{ temp@three > clivisalignmentmin}%
         \ifdim\gre@dimen@temp@three >\gre@dimen@clivisalignmentmin %
-          \global\setbox\gre@box@temp@width=\hbox{#2}%
-        \else%
-          \global\setbox\gre@box@temp@width=\hbox{#1}%
-        \fi%
-      \else%
-        \gre@debugmsg{ifdim}{ textaligncenter > clivisalignmentmin}%
-        \ifdim\gre@dimen@textaligncenter >\gre@dimen@clivisalignmentmin %
           \global\setbox\gre@box@temp@width=\hbox{#2}%
         \else%
           \global\setbox\gre@box@temp@width=\hbox{#1}%
@@ -427,19 +427,25 @@
 % #1 : the first letters of the syllable, that don't count for the alignment
 % #2 : the middle letters of the syllable, we must align in the middle of them
 % #3 : the end letters, they don't count
-\def\GreSetThisSyllable#1#2#3{%
-  \ifgre@vowelcentering %
-    \gdef\gre@firstsyllablepart{#1}%
-    \gdef\gre@middlesyllablepart{#2}%
-    \gdef\gre@endsyllablepart{#3}%
-  \else %
+% #4 : the very first letter
+% #5 : all the letters after the first letter
+\def\GreSetThisSyllable#1#2#3#4#5{%
+  \ifcase\gre@lyriccentering% 0
     \gdef\gre@firstsyllablepart{}%
     \gdef\gre@middlesyllablepart{#1#2#3}%
     \gdef\gre@endsyllablepart{}%
+  \or % 1
+    \gdef\gre@firstsyllablepart{#1}%
+    \gdef\gre@middlesyllablepart{#2}%
+    \gdef\gre@endsyllablepart{#3}%
+  \or % 2
+    \gdef\gre@firstsyllablepart{}%
+    \gdef\gre@middlesyllablepart{#4}%
+    \gdef\gre@endsyllablepart{#5}%
   \fi %
 }%
 
-\def\GreSetNextSyllable#1#2#3{%
+\def\GreSetNextSyllable#1#2#3#4#5{%
   \gdef\gre@nextfirstsyllablepart{#1}%
   \gdef\gre@nextmiddlesyllablepart{#2}%
   \gdef\gre@nextendsyllablepart{#3}%
@@ -451,15 +457,17 @@
 
 \def\gresetlyriccentering#1{%
   \IfStrEq{#1}{vowel}%
-    {\gre@vowelcenteringtrue}%
+    {\xdef\gre@lyriccentering{1}}%
     {\IfStrEq{#1}{syllable}%
-      {\gre@vowelcenteringfalse}%
-      {\gre@error{Unrecognized option for \protect\gresetlyriccentering}}%
+      {\xdef\gre@lyriccentering{0}}%
+      {\IfStrEq{#1}{firstletter}%
+        {\xdef\gre@lyriccentering{2}}%
+        {\gre@error{Unrecognized option for \protect\gresetlyriccentering}}%
+      }%
     }%
 }%
 
-
-\newif\ifgre@vowelcentering\gre@vowelcenteringtrue %
+\xdef\gre@lyriccentering{1}%
 
 \def\englishcentering{%
   \gre@deprecated{\protect\englishcentering}{\protect\gresetlyriccentering{syllable}}%


### PR DESCRIPTION
As discussed on the gregorio-devel mailing list.  Gregorio will produce five-argument calls to the syllable-setting macros in order to provide the extra break-down of the lyric after the first character.

Please review and merge if satisfactory.