### PR TITLE
Fixed unbalanced styles around the center.

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -1041,7 +1041,7 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
             for (current_style = first_style; current_style
                     && current_style->style != current_character->cos.s.style;
                     current_style = current_style->next_style) {
-                // just loop
+                /* just loop */
             }
             if (current_style) {
                 suppress_char_and_end_c();
@@ -1110,7 +1110,7 @@ void gregorio_rebuild_characters(gregorio_character **param_character,
                         && current_style->next_style->style !=
                         current_character->cos.s.style;
                         current_style = current_style->next_style) {
-                    // just loop
+                    /* just loop */
                 }
                 if (current_style->next_style) {
                     for (current_style = first_style; current_style;

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -238,7 +238,7 @@ static void initialize_variables(void)
     translation_type = TR_NORMAL;
     no_linebreak_area = NLBA_NORMAL;
     euouae = EUOUAE_NORMAL;
-    center_is_determined = 0;
+    center_is_determined = CENTER_NOT_DETERMINED;
     for (i = 0; i < 10; i++) {
         macros[i] = NULL;
     }
@@ -412,10 +412,10 @@ static void gregorio_set_translation_center_beginning(
     current_syllable->translation_type = TR_NORMAL;
 }
 
-static void rebuild_characters(gregorio_character **param_character,
-        gregorio_center_determination center_is_determined)
+static void rebuild_characters()
 {
     bool has_initial = score->initial_style != NO_INITIAL;
+
     /* we rebuild the first syllable text if it is the first syllable, or if
      * it is the second when the first has no text.
      * it is a patch for cases like (c4) Al(ab)le(ab) */
@@ -427,7 +427,7 @@ static void rebuild_characters(gregorio_character **param_character,
         started_first_word = true;
     }
 
-    gregorio_rebuild_characters(param_character, center_is_determined,
+    gregorio_rebuild_characters(&current_character, center_is_determined,
             has_initial);
 
     if (started_first_word) {
@@ -482,7 +482,7 @@ static void close_syllable(YYLTYPE *loc)
  * the translation pointer instead of the text pointer */
 static void start_translation(unsigned char asked_translation_type)
 {
-    rebuild_characters(&current_character, center_is_determined);
+    rebuild_characters();
     first_text_character = current_character;
     /* the middle letters of the translation have no sense */
     center_is_determined = CENTER_FULLY_DETERMINED;
@@ -492,7 +492,7 @@ static void start_translation(unsigned char asked_translation_type)
 
 static void end_translation(void)
 {
-    rebuild_characters(&current_character, center_is_determined);
+    rebuild_characters();
     first_translation_character = current_character;
 }
 
@@ -1188,7 +1188,7 @@ above_line_text:
 
 syllable_with_notes:
     text OPENING_BRACKET notes {
-        rebuild_characters (&current_character, center_is_determined);
+        rebuild_characters();
         first_text_character = current_character;
         close_syllable(&@1);
     }


### PR DESCRIPTION
Fixes #601

This was due to the accidental loss of the current_style pointer, used in line 1057 of 2cd6aeca53f4f4f0b69bb433dabbdf087e3d497b.  I rejigged it so that current_style is used for looping only.

Additionally, in order to help my debugging, I removed the `gregorio_` prefix from non-exported functions in characters.c.

This is a pre-existing bug (as in, prior to 4.0), but the user will not see it there because, although the wrong styles get closed, they still get closed, and the curly braces balance.  However, there are first syllable/word styles in 4.0 which break the balance of curly braces.  Therefore, I am not adding anything to the changelog since this is a "newly visible" bug.

All current tests pass.  Upon merge, I will add new tests specifically for this bug.

Please review and merge if satisfactory.