### PR TITLE
add type argument to GreDiscretionary (for #603)

### DIFF
--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -168,8 +168,8 @@ Typesets a custos.
 \macroname{\textbackslash GreDagger}{}{gregoriotex-symbols.tex}
 Macro to typeset a dagger (\GreDagger).
 
-\macroname{\textbackslash GreDiscretionary}{\#1\#2}{gregoriotex-signs.tex}
-A GregorioTeX specific discretionary used to avoid clef change at beginning or end of line, or even with more complex data (z0::c3 for instance).  We require a special function because in the normal discretionary function you cannot use \verb=\hskip= (but you can use \verb=\kern=) and you cannot use \verb=\penalty= (which is useless indeed).  This macro corrects for these two limitations.
+\macroname{\textbackslash GreDiscretionary}{\#1\#2\#3}{gregoriotex-signs.tex}
+A GregorioTeX specific discretionary. Currently only used to avoid clef change at beginning or end of line, or even with more complex data (z0::c3 for instance).  We require a special function because in the normal discretionary function you cannot use \verb=\hskip= (but you can use \verb=\kern=) and you cannot use \verb=\penalty= (which is useless indeed).  This macro corrects for these two limitations. The first argument allows to select the penalty assigned to the discretionary by recent version of LuaTeX.
 
 \macroname{\textbackslash GreDivisioFinalis}{\#1}{gregoriotex-signs.tex}
 Macro to typeset a divisio finalis.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -171,6 +171,12 @@ Macro to typeset a dagger (\GreDagger).
 \macroname{\textbackslash GreDiscretionary}{\#1\#2\#3}{gregoriotex-signs.tex}
 A GregorioTeX specific discretionary. Currently only used to avoid clef change at beginning or end of line, or even with more complex data (z0::c3 for instance).  We require a special function because in the normal discretionary function you cannot use \verb=\hskip= (but you can use \verb=\kern=) and you cannot use \verb=\penalty= (which is useless indeed).  This macro corrects for these two limitations. The first argument allows to select the penalty assigned to the discretionary by recent version of LuaTeX.
 
+\begin{argtable}
+  \#1 & integer & Type of discretionary (for penalty assignment). Currently possible value is 0 for clef change discretionaries.\\
+  \#2 & \TeX\ code & First argument of resulting \verb=\discretionary=.\\
+  \#3 & \TeX\ code & Third argument of resulting \verb=\discretionary=.\\
+\end{argtable}
+
 \macroname{\textbackslash GreDivisioFinalis}{\#1}{gregoriotex-signs.tex}
 Macro to typeset a divisio finalis.
 

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2776,7 +2776,7 @@ static void gregoriotex_write_syllable(FILE *f, gregorio_syllable *syllable,
                  * In this case, the first thing to do is to change the line clef 
                  */
                 gregoriotex_print_change_line_clef(f, clef_change_element);
-                fprintf(f, "\\GreDiscretionary{%%\n");
+                fprintf(f, "\\GreDiscretionary{0}{%%\n");
                 gregoriotex_write_syllable(f, syllable, first_syllable,
                         line_number, 1, status);
                 fprintf(f, "}{%%\n");

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -54,17 +54,19 @@
 \let\gre@penalty\gre@truepenalty%
 \xdef\gre@insidediscretionary{\number 0}%
 
-\def\GreDiscretionary#1#2{%
+% #1 is the type of discretionary, for penalty assignment. Recognized types:
+%   - 0: clef change
+\def\GreDiscretionary#1#2#3{%
   \global\let\gre@hskip\kern %
   \global\let\gre@penalty\gre@falsepenalty %
   \global\xdef\gre@insidediscretionary{\number 1}%
   \discretionary{%
     \global\gre@lastoflinecount=1\relax % (a good magic trick)
-    #1%
+    #2%
     }{%
     \global\gre@lastoflinecount=2\relax % (a good magic trick)
     }{%
-    #2%
+    #3%
     }%
   \global\xdef\gre@insidediscretionary{\number 0}%
   \global\let\gre@hskip\hskip %


### PR DESCRIPTION
This adds the argument to `\GreDiscretionary` as explained in #603. It is not taken into account yet, as the code is not merged yet in LuaTeX and the LuaTeX developers just told me that they might use `\hyphenpenalty` instead of adding `\discpenalty`... But the handling of the argument can wait a future release...