### PR TITLE
Used VersionManager.py to control the squarize.py version string.

### DIFF
--- a/VersionManager.py
+++ b/VersionManager.py
@@ -55,6 +55,7 @@ GREGORIO_FILES = ["configure.ac",
                   "tex/gregoriotex-symbols.tex",
                   "tex/gregoriotex-syllable.tex",
                   "tex/gregoriotex-main.tex",
+                  "fonts/squarize.py",
                  ]
 
 def get_parser():

--- a/fonts/Makefile.am
+++ b/fonts/Makefile.am
@@ -29,10 +29,10 @@ EXTRA_DIST = $(TTFFILES) $(SOURCEFILES) squarize.py convertsfdtottf.py README.md
 FONTFORGE = fontforge
 RM = rm
 
-%.ttf: squarize.py %-base.sfd ../.gregorio-version
+%.ttf: squarize.py %-base.sfd
 	$(FONTFORGE) -script $< $*
 
-%-op.ttf: squarize.py %-base.sfd ../.gregorio-version
+%-op.ttf: squarize.py %-base.sfd
 	$(FONTFORGE) -script $< $* op
 
 %.ttf: convertsfdtottf.py %.sfd

--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -79,6 +79,8 @@ AMBITUS = {
     5: 'Five',
 }
 
+GREGORIO_VERSION = '4.0.0-beta2'
+
 # The unicode character at which we start our numbering:
 # U+E000 is the start of the BMP Private Use Area
 glyphnumber = 0xe000 - 1
@@ -105,9 +107,6 @@ Usage:
 def main():
     "Main function"
     global oldfont, newfont, font_name, subspecies
-    version_script_file = os.path.join(sys.path[0], '../VersionManager.py')
-    proc = subprocess.Popen([version_script_file, '-c'], stdout=subprocess.PIPE, universal_newlines=True)
-    version = proc.stdout.read().strip('\n')
     try:
         opts, args = getopt.gnu_getopt(sys.argv[1:], "o:h", ["outfile","help"])
     except getopt.GetoptError:
@@ -139,7 +138,7 @@ def main():
     newfont.fontname = "%s" % font_name
     newfont.fullname = "%s" % font_name
     newfont.familyname = "%s" % font_name
-    newfont.version = version
+    newfont.version = GREGORIO_VERSION
     if font_base == "greciliae":
         newfont.copyright = """Greciliae font
 Copyright (C) 2007 Matthew Spencer with Reserved Font Name "Caeciliae",


### PR DESCRIPTION
This eliminates the need for python2 when building the fonts (the built-in fontforge python interpreter is still necessary).

All tests pass on the resulting fonts.