### PR TITLE
Updating `gregoriosyms.sty`

### DIFF
--- a/VersionManager.py
+++ b/VersionManager.py
@@ -55,6 +55,7 @@ GREGORIO_FILES = ["configure.ac",
                   "tex/gregoriotex-symbols.tex",
                   "tex/gregoriotex-syllable.tex",
                   "tex/gregoriotex-main.tex",
+                  "tex/gregoriosyms.sty",
                   "fonts/squarize.py",
                  ]
 

--- a/tex/gregoriosyms.sty
+++ b/tex/gregoriosyms.sty
@@ -19,11 +19,60 @@
 
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{gregoriosyms}
+    [2015/08/26 v4.0.0-beta2 GregorioTeX symbols only.]% PARSE_VERSION_DATE_LTX
 
+\RequirePackage{kvoptions}%
+\RequirePackage{ifluatex}%
+\RequirePackage{luatexbase}%
 \RequirePackage{luaotfload}
+\RequirePackage{luamplib}%
 
 \providecommand{\gre@declarefileversion}[2]{\relax}
+
+% The version of gregorio. All gregoriotex*.tex files must have the same.
+% All gtex files must also have the same version.
+\xdef\gre@gregorioversion{4.0.0-beta2}% GREGORIO_VERSION - VersionManager.py
+
+
+\def\gre@error#1{\PackageError{GregorioTeX}{#1}{}}%
+\def\gre@warning#1{\PackageWarning{GregorioTeX}{#1}}%
+\def\gre@bug#1{\PackageError{GregorioTeX}{#1 !! This is a bug in Gregorio.  Please report it at https://github.com/gregorio-project/gregorio/issues}{}}%
+\def\gre@typeout{\typeout}
+
+\SetupKeyvalOptions{prefix=gre@}
+\DeclareStringOption{debug}[all]
+
+% This option allows the user to transform all deprecation messages
+% into errors.  Allowing one to determine if the TeX file is compliant
+% with future versions of gregoriotex. To enable, use gregoriotex with
+% this option: deprecated=false
+\DeclareBoolOption[true]{deprecated}
+
+\ProcessKeyvalOptions*
+
+% Macro to handle deprecated macros.
+% #1 - the deprecated macro
+% #2 - the correct macro to use
+\def\gre@deprecated#1#2{%
+  \ifgre@deprecated%
+    \gre@warning{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+  \else%
+    \gre@error{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+  \fi%
+  \relax%
+}%
+
+\def\gre@obsolete#1#2{%
+  \gre@error{#1\space is obsolete.\MessageBreak Use #2\space instead}%
+  \relax%
+}%
+\AtBeginDocument{\IfStrEq{\gre@debug}{}{}{\typeout{GregorioTeX is in debug mode}\typeout{\gre@debug\space messages will be printed to the log.}}}%
 
 \long\def\gre@iflatex#1{#1}
 \input gregoriotex-symbols.tex
 
+\xdef\gre@gregoriotexluaversion{\directlua{tex.write(gregoriotex.get_gregorioversion())}}%
+
+% Test to make sure that gregoriotex.lua is of the same version.
+\IfStrEq*{\gre@gregoriotexluaversion}{\gre@gregorioversion}{}{%else
+    \gre@error{uncoherent file versions: gregoriosyms.sty is in version \number\gre@gregorioversion \space\space while gregoriotex.lua is in version \gre@gregoriotexluaversion}}%

--- a/tex/gregoriosyms.sty
+++ b/tex/gregoriosyms.sty
@@ -26,13 +26,18 @@
 \RequirePackage{luatexbase}%
 \RequirePackage{luaotfload}
 \RequirePackage{luamplib}%
+\RequirePackage{xstring}%
 
-\providecommand{\gre@declarefileversion}[2]{\relax}
+\newluatexcatcodetable\gre@atletter %
+\setluatexcatcodetable\gre@atletter{%
+  \catcode`\@=11 %
+}%
 
 % The version of gregorio. All gregoriotex*.tex files must have the same.
 % All gtex files must also have the same version.
 \xdef\gre@gregorioversion{4.0.0-beta2}% GREGORIO_VERSION - VersionManager.py
 
+\providecommand{\gre@declarefileversion}[2]{\relax}
 
 \def\gre@error#1{\PackageError{GregorioTeX}{#1}{}}%
 \def\gre@warning#1{\PackageWarning{GregorioTeX}{#1}}%


### PR DESCRIPTION
Changes for gregorio-project/gregorio-test#20

To ensure interoperability of code, `gregoriosyms.sty` needs the warning and error commands defined with in it.
Added the debug and deprecation options to the package (the only two options that make sense for it)
Added version number and version number checking.  Also added the package to VersionManager.py

I need some help with this one as I'm still getting an error I'm unable to resolve:

```
! LuaTeX error ...xlive/texmf-local/tex/luatex/gregoriotex/gregoriotex.lua:615: 
no string to print
stack traceback:
	[C]: in function 'print'
	...xlive/texmf-local/tex/luatex/gregoriotex/gregoriotex.lua:615: in function 'i
nit_variant_font'
	[\directlua]:1: in main chunk.
\gredefsizedsymbol ..._variant_font([[#2]],false)}
                                                  \directlua {gregoriotex.de...
l.53 \gredefsizedsymbol{greABar}{greextra}{ABar}
                                              
? 
! Emergency stop.
```
I'm thinking this means that there's some other line(s) from `gregoriotex-main.tex` that I need to copy into `gregoriosyms.sty` but I don't know which one(s).