### PR TITLE
Feature/distance flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - All of the keywords for `\grescaledim` were now work as described in the documentation.
 
 ### Changed
-- `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scaling` and `fixed`( instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
-- `\grescaledim` now accepts `scaling` as a keyword to turn on scaling (in keeping with the above change)
+- `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scalable` and `fixed`( instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
+- `\grescaledim` now accepts `scalable` as a keyword to turn on scalable (in keeping with the above change)
 
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Fixed
 - Deactivating the end of line shifts now prevents lyrics from stretching under the custos at the end of the line.
 
+### Changed
+- `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scaling` and `fixed`( instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
+
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.
 - The first word of the score is now passed to a macro that allow it to be styled from TeX.  The first word is passed to `\GreFirstWord#1` and is styled by changing the `firstword` style.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Fixed
 - Deactivating the end of line shifts now prevents lyrics from stretching under the custos at the end of the line.
+- All of the keywords for `\grescaledim` were now work as described in the documentation.
 
 ### Changed
 - `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scaling` and `fixed`( instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
+- `\grescaledim` now accepts `scaling` as a keyword to turn on scaling (in keeping with the above change)
 
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -158,6 +158,10 @@ Within a TeX document, you can switch back to MetaPost brace rendering by using:
 
 You can freely switch between the two behaviors within a TeX document.
 
+#### Keyword argument for `\grecreatedim` and `\grechangedim`
+
+In order to better match the new command naming conventions, the third argument of `\grecreatedim` and `\grechangedim` should now be `scaling` or `fixed` instead of `1` or `0`, respectively.
+
 ## 3.0
 ### TeX Live 2013
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -225,8 +225,8 @@ Macro to create one of Gregorio\TeX’s distances.  Used to initialize distances
 \begin{argtable}
   \#1 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
   \#2 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
-  \#3 & 0 & Distance will not scale when staff size is changed.\\
-  & 1 & Distance will scale when staff size is changed.
+  \#3 & fixed & Distance will not scale when staff size is changed.\\
+  & scaling & Distance will scale when staff size is changed.
 \end{argtable}
 
 \macroname{\textbackslash grechangedim}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-spaces.tex}
@@ -235,8 +235,8 @@ Macro to change one of Gregorio\TeX’s distances.  This function will check to 
 \begin{argtable}
   \#1 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
   \#2 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
-  \#3 & 0 & Distance will not scale when staff size is changed.\\
-  & 1 & Distance will scale when staff size is changed.
+  \#3 & fixed & Distance will not scale when staff size is changed.\\
+  & scaling & Distance will scale when staff size is changed.
 \end{argtable}
 
 \macroname{\textbackslash grescaledim}{\{\#1\}\{\#2\}}{gregoriotex-spaces.tex}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -244,7 +244,7 @@ Macro to turn on or off scaling with the staff size for a particular distance.
 
 \begin{argtable}
   \#1 & string & The name of the distance for which scaling it to changed.  See \nameref{distances} below.\\
-  \#2 & \texttt{yes}/\texttt{true}/\texttt{on} & Scale the distance when changing the size of the staff.\\
+  \#2 & \texttt{yes}/\texttt{true}/\texttt{on}/\texttt{scaling} & Scale the distance when changing the size of the staff.\\
   & \textit{other} & Do not scale the distance when changing the size of the staff.
 \end{argtable}
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -248,6 +248,8 @@ Macro to turn on or off scaling with the staff size for a particular distance.
   & \textit{other} & Do not scale the distance when changing the size of the staff.
 \end{argtable}
 
+\textbf{Nota bene:} This macro also can be used to change whether or not the staff line thickness scales with the staff size by specifying \texttt{stafflinefactor} for the first argument.
+
 \macroname{\textbackslash greloadspaceconf}{\{\#1\}}{gregoriotex-spaces.tex}
 Macro to load a space configuration file.  Space configuration file names have the format \verb=gsp-identifier.tex= and must be in the same directory as your project or in your texmf directory.  This function is \texttt{gre}-prefixed to highlight that it only loads distances for Gregorio\TeX.
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -226,7 +226,7 @@ Macro to create one of Gregorio\TeX’s distances.  Used to initialize distances
   \#1 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
   \#2 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
   \#3 & fixed & Distance will not scale when staff size is changed.\\
-  & scaling & Distance will scale when staff size is changed.
+  & scalable & Distance will scale when staff size is changed.
 \end{argtable}
 
 \macroname{\textbackslash grechangedim}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-spaces.tex}
@@ -236,15 +236,15 @@ Macro to change one of Gregorio\TeX’s distances.  This function will check to 
   \#1 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
   \#2 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
   \#3 & fixed & Distance will not scale when staff size is changed.\\
-  & scaling & Distance will scale when staff size is changed.
+  & scalable & Distance will scale when staff size is changed.
 \end{argtable}
 
 \macroname{\textbackslash grescaledim}{\{\#1\}\{\#2\}}{gregoriotex-spaces.tex}
 Macro to turn on or off scaling with the staff size for a particular distance.
 
 \begin{argtable}
-  \#1 & string & The name of the distance for which scaling it to changed.  See \nameref{distances} below.\\
-  \#2 & \texttt{yes}/\texttt{true}/\texttt{on}/\texttt{scaling} & Scale the distance when changing the size of the staff.\\
+  \#1 & string & The name of the distance for which scaling is to changed.  See \nameref{distances} below.\\
+  \#2 & \texttt{yes}/\texttt{true}/\texttt{on}/\texttt{scalable} & Scale the distance when changing the size of the staff.\\
   & \textit{other} & Do not scale the distance when changing the size of the staff.
 \end{argtable}
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -914,6 +914,9 @@ Alias for \verb=\luatexlocalrightbox=.
 \macroname{\textbackslash gre@resizebox}{}{gregoriotex-main.tex}
 Alias for \verb=\resizebox=.
 
+\macroname{\textbackslash gre@dimension}{}{gregoriotex-spaces.tex}
+Workhorse function behind \verb=\grecreatedim= and \verb=\grechangedim=.
+
 \subsection{Auxiliary File}
 Gregorio\TeX\ creates its own auxiliary file (extension \texttt{gaux}) which it uses to store information between successive typesetting runs.  This allows for such features as the dynamic interline spacing.  The following functions are used to interact with that auxiliary file.
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1079,9 +1079,9 @@ A class of macros for the horizontal episema which populates the \verb=\gre@box@
 
 Flags are either boolean (defined with \verb=\newif=), Lua\TeX\ attributes, or counts (defined with \verb=\newcount=).  They store settings and/or the current state of something so that Gregorio\TeX\ can typeset things in the desired manner.
 
-All distances in \nameref{distances} have a flag associated with them, of the form \verb=\gre@scale@*=.  This flag
-indicates if the distance should scale when the staff size changes (1)
-or not (0).
+All distances in \nameref{distances} and \texttt{stafflinefactor} have a boolean associated with them, of the form \verb=\ifgre@scale@*=.  This boolean
+indicates if the distance should scale when the staff size changes (true)
+or not (false).
 
 \macroname{\textbackslash ifgre@checklength}{}{gregoriotex-spaces.tex}
 Boolean used in \verb=\gresetdim= to indicate if we are attempting to set a rubber length.

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -805,11 +805,11 @@
     \fi%
   \fi%
   \IfStrEq{#3}{1}%	
-    {\gre@warning{Numerical arguments for \protect\grecreatedim\space are deprecated.\MessageBreak Use 'scaling' instead.}%
+    {\gre@warning{A numerical (1) last argument for \protect\grecreatedim}{'scaling'}%
     \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
     {\IfStrEq{#3}{0}%
-      {\gre@warning{Numerical arguments for \protect\grecreatedim\space are deprecated.\MessageBreak Use 'fixed' instead.}%
-    \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
+      {\gre@warning{A numerical (0) last argument for \protect\grecreatedim}{'fixed'}%
+      \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
       {\IfStrEq{#3}{scaling}%
         {\expandafter\xdef\csname gre@scale@#1\endcsname{1}}%
         {\IfStrEq{#3}{fixed}%
@@ -840,7 +840,13 @@
   \fi%
   \ifcsname gre@\gre@prefix @#1\endcsname%
     \gre@debugmsg{spacing}{It does exist.}%
-    \grecreatedim{#1}{#2}{#3}%
+    \IfStrEq{#3}{1}%
+      {\gre@warning{A numerical (1) last argument for \protect\grechangedim}{'scaling'}%
+      \grecreatedim{#1}{#2}{scaling}}%
+      {\IfStrEq{#3}{0}%
+        {\gre@deprecated{A numerical (0) last argument for \protect\grechangedim}{'fixed'}%
+        \grecreatedim{#1}{#2}{fixed}}%
+      }%
   \else%
     \gre@error{#1 is not a recognized distance.}%
   \fi%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -804,7 +804,20 @@
       \def\gre@prefix{dimen}%
     \fi%
   \fi%
-  \expandafter\xdef\csname gre@scale@#1\endcsname{#3}%
+  \IfStrEq{#3}{1}%	
+    {\gre@warning{Numerical arguments for \protect\grecreatedim\space are deprecated.\MessageBreak Use 'scaling' instead.}%
+    \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
+    {\IfStrEq{#3}{0}%
+      {\gre@warning{Numerical arguments for \protect\grecreatedim\space are deprecated.\MessageBreak Use 'fixed' instead.}%
+    \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
+      {\IfStrEq{#3}{scaling}%
+        {\expandafter\xdef\csname gre@scale@#1\endcsname{1}}%
+        {\IfStrEq{#3}{fixed}%
+          {\expandafter\xdef\csname gre@scale@#1\endcsname{0}}%
+          {\gre@error{Unrecognized option for \protect\grecreatedim}}%
+        }%
+      }%
+    }%
   \expandafter\xdef\csname gre@\gre@prefix @#1\endcsname{#2}%
   \relax %
 }%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -805,10 +805,10 @@
     \fi%
   \fi%
   \IfStrEq{#3}{1}%	
-    {\gre@warning{A numerical (1) last argument for \protect\grecreatedim}{'scaling'}%
+    {\gre@deprecated{A numerical (1) last argument for \protect\grecreatedim}{'scaling'}%
     \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
     {\IfStrEq{#3}{0}%
-      {\gre@warning{A numerical (0) last argument for \protect\grecreatedim}{'fixed'}%
+      {\gre@deprecated{A numerical (0) last argument for \protect\grecreatedim}{'fixed'}%
       \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
       {\IfStrEq{#3}{scaling}%
         {\expandafter\xdef\csname gre@scale@#1\endcsname{1}}%
@@ -841,7 +841,7 @@
   \ifcsname gre@\gre@prefix @#1\endcsname%
     \gre@debugmsg{spacing}{It does exist.}%
     \IfStrEq{#3}{1}%
-      {\gre@warning{A numerical (1) last argument for \protect\grechangedim}{'scaling'}%
+      {\gre@deprecated{A numerical (1) last argument for \protect\grechangedim}{'scaling'}%
       \grecreatedim{#1}{#2}{scaling}}%
       {\IfStrEq{#3}{0}%
         {\gre@deprecated{A numerical (0) last argument for \protect\grechangedim}{'fixed'}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -784,42 +784,24 @@
 %% dimension changing macros
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% This macro creates one dim (#1), setting its value to #2 and sets whether it should scale when the \gre@factor changes (#3, 1 if yes, 0 if no).  While it does check that #1 can accept the kind of distance given in #2, it does not propagate the changes through the calculated distances.
+%% This macro creates one dim (#1), setting its value to #2 and sets whether it should scale when the \gre@factor changes (#3, scaling or fixed).  Checks that #1 can accept the kind of distance given in #2.
 %% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
 \newif\ifgre@checklength%
 \def\grecreatedim#1#2#3{%
-  \gre@checklengthfalse%
-  %check if #2 is a rubber length (contains plus and/or minus)
-  \IfSubStr{#2}{plus}{\gre@checklengthtrue}{\relax}%
-  \IfSubStr{#2}{minus}{\gre@checklengthtrue}{\relax}%
-  %if #1 is one of the distances which cannot be rubber.
-  \gre@rubberpermit{#1}%
-  % do we try to assign a rubber to one where it's not permitted?
-  \ifgre@rubber%
-    \def\gre@prefix{skip}%
-  \else%
-    \ifgre@checklength%
-      \gre@error{#1 cannot be a rubber length.}%
-    \else%
-      \def\gre@prefix{dimen}%
-    \fi%
-  \fi%
   \IfStrEq{#3}{1}%	
     {\gre@deprecated{A numerical (1) last argument for \protect\grecreatedim}{'scaling'}%
-    \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
+    \gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
     {\IfStrEq{#3}{0}%
       {\gre@deprecated{A numerical (0) last argument for \protect\grecreatedim}{'fixed'}%
-      \expandafter\xdef\csname gre@scale@#1\endcsname{#3}}%
+      \gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
       {\IfStrEq{#3}{scaling}%
-        {\expandafter\xdef\csname gre@scale@#1\endcsname{1}}%
+        {\gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
         {\IfStrEq{#3}{fixed}%
-          {\expandafter\xdef\csname gre@scale@#1\endcsname{0}}%
+          {\gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
           {\gre@error{Unrecognized option for \protect\grecreatedim}}%
         }%
       }%
     }%
-  \expandafter\xdef\csname gre@\gre@prefix @#1\endcsname{#2}%
-  \relax %
 }%
 
 \def\gresetdim{%
@@ -842,27 +824,59 @@
     \gre@debugmsg{spacing}{It does exist.}%
     \IfStrEq{#3}{1}%
       {\gre@deprecated{A numerical (1) last argument for \protect\grechangedim}{'scaling'}%
-      \grecreatedim{#1}{#2}{scaling}}%
+      \gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
       {\IfStrEq{#3}{0}%
         {\gre@deprecated{A numerical (0) last argument for \protect\grechangedim}{'fixed'}%
-        \grecreatedim{#1}{#2}{fixed}}%
+        \gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
+        {\IfStrEq{#3}{scaling}%
+          {\gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
+          {\IfStrEq{#3}{fixed}%
+            {\gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
+            {\gre@error{Unrecognized option for \protect\grechangedim}}%
+          }%
+        }%
       }%
   \else%
     \gre@error{#1 is not a recognized distance.}%
   \fi%
 }%
 
+% The common internals for \grecreatedim and \grechangedim.
+\def\gre@dimension#1#2{%
+  \gre@checklengthfalse%
+  %check if #2 is a rubber length (contains plus and/or minus)
+  \IfSubStr{#2}{plus}{\gre@checklengthtrue}{\relax}%
+  \IfSubStr{#2}{minus}{\gre@checklengthtrue}{\relax}%
+  %if #1 is one of the distances which cannot be rubber.
+  \gre@rubberpermit{#1}%
+  % do we try to assign a rubber to one where it's not permitted?
+  \ifgre@rubber%
+    \def\gre@prefix{skip}%
+  \else%
+    \ifgre@checklength%
+      \gre@error{#1 cannot be a rubber length.}%
+    \else%
+      \def\gre@prefix{dimen}%
+    \fi%
+  \fi%
+  \expandafter\xdef\csname gre@\gre@prefix @#1\endcsname{#2}%
+  \relax %
+}
+
 %a macro to use if all you want to do is turn on or off the scaling for a particular distance
 \def\grescaledim#1#2{%
-  \IfStrEq{#2}{yes}%
-    {\expandafter\gdef\csname gre@scale@#1\endcsname{1}}%
-    {\expandafter\gdef\csname gre@scale@#1\endcsname{0}}%
   \IfStrEq{#2}{true}%
     {\expandafter\gdef\csname gre@scale@#1\endcsname{1}}%
-    {\expandafter\gdef\csname gre@scale@#1\endcsname{0}}%
-  \IfStrEq{#2}{on}%
-    {\expandafter\gdef\csname gre@scale@#1\endcsname{1}}%
-    {\expandafter\gdef\csname gre@scale@#1\endcsname{0}}%
+    {\IfStrEq{#2}{yes}%
+      {\grescaledim{true}}%
+      {\IfStrEq{#2}{on}%
+        {\grescaledim{true}}%
+        {\IfStrEq{#2}{scaling}%
+          {\grescaledim{true}}%
+          {\expandafter\gdef\csname gre@scale@#1\endcsname{0}}%
+        }%
+      }%
+    }%
 }
 
 \def\grenoscaledim#1{%
@@ -932,7 +946,6 @@
 }%
 
 %% an aux function adapting the value #1 from the factor #2 to the factor #3
-%% Note: This function is assumed to touch only dimensions which are meant to scale with the \gre@factor (i.e. if it acts on distance x, \gre@scale@x is 1)
 \def\gre@changeonedimenfactor#1#2#3{%
   \gre@rubberpermit{#1}%
   \ifgre@rubber% if we have a rubber allowed length we create a temporary skip
@@ -951,7 +964,7 @@
   \multiply \gre@scaledist by \number #3%
   \divide \gre@scaledist by \number #2%
   \gre@consistentunits{\gre@convert}{\gre@scaledist}%
-  \grecreatedim{#1}{\gre@stringdist}{1}%
+  \gre@dimension{#1}{\gre@stringdist}%
   \relax %
 }%
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -148,7 +148,8 @@
 % the stafflinefactor follows the same scale as the gre@factor, i.e. a stafflinefactor corresponds to the default staff line thickness for gre@factor 17, stafflinefactor 34 corresponds to the default staff line thickness for gre@factor 34, etc.
 \xdef\gre@stafflinefactor{17}%
 % flag for whether the stafflinefactor should scale with changes of the gre@factor
-\xdef\gre@scale@stafflinefactor{1}%
+\newif\ifgre@scale@stafflinefactor%
+\gre@scale@stafflinefactortrue
 
 % a macro for setting the thickness of the staff lines.  This changes the stafflinefactor and then adjusts the spaces that are affected by the thicker staff lines.
 \def\grechangestafflinethickness#1{%
@@ -788,16 +789,18 @@
 %% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
 \newif\ifgre@checklength%
 \def\grecreatedim#1#2#3{%
+  \gre@dimension{#1}{#2}
+  \csname newif\expandafter\endcsname\csname ifgre@scale@#1\endcsname%
   \IfStrEq{#3}{1}%	
     {\gre@deprecated{A numerical (1) last argument for \protect\grecreatedim}{'scaling'}%
-    \gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
+    \grescaledim{#1}{true}}%
     {\IfStrEq{#3}{0}%
       {\gre@deprecated{A numerical (0) last argument for \protect\grecreatedim}{'fixed'}%
-      \gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
+      \grescaledim{#1}{false}}%
       {\IfStrEq{#3}{scaling}%
-        {\gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
+        {\grescaledim{#1}{true}}%
         {\IfStrEq{#3}{fixed}%
-          {\gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
+          {\grescaledim{#1}{false}}%
           {\gre@error{Unrecognized option for \protect\grecreatedim}}%
         }%
       }%
@@ -822,16 +825,17 @@
   \fi%
   \ifcsname gre@\gre@prefix @#1\endcsname%
     \gre@debugmsg{spacing}{It does exist.}%
+    \gre@dimension{#1}{#2}%
     \IfStrEq{#3}{1}%
       {\gre@deprecated{A numerical (1) last argument for \protect\grechangedim}{'scaling'}%
-      \gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
+      \grescaledim{#1}{true}}%
       {\IfStrEq{#3}{0}%
         {\gre@deprecated{A numerical (0) last argument for \protect\grechangedim}{'fixed'}%
-        \gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
+        \grescaledim{#1}{false}}%
         {\IfStrEq{#3}{scaling}%
-          {\gre@dimension{#1}{#2}\grescaledim{#1}{true}}%
+          {\grescaledim{#1}{true}}%
           {\IfStrEq{#3}{fixed}%
-            {\gre@dimension{#1}{#2}\grescaledim{#1}{false}}%
+            {\grescaledim{#1}{false}}%
             {\gre@error{Unrecognized option for \protect\grechangedim}}%
           }%
         }%
@@ -859,21 +863,21 @@
       \def\gre@prefix{dimen}%
     \fi%
   \fi%
-  \expandafter\xdef\csname gre@\gre@prefix @#1\endcsname{#2}%
+  \expandafter\edef\csname gre@\gre@prefix @#1\endcsname{#2}%
   \relax %
 }
 
 %a macro to use if all you want to do is turn on or off the scaling for a particular distance
 \def\grescaledim#1#2{%
   \IfStrEq{#2}{true}%
-    {\expandafter\gdef\csname gre@scale@#1\endcsname{1}}%
+    {\csname gre@scale@#1true\endcsname}%
     {\IfStrEq{#2}{yes}%
       {\grescaledim{true}}%
       {\IfStrEq{#2}{on}%
         {\grescaledim{true}}%
         {\IfStrEq{#2}{scaling}%
           {\grescaledim{true}}%
-          {\expandafter\gdef\csname gre@scale@#1\endcsname{0}}%
+          {\csname gre@scale@#1false\endcsname}%
         }%
       }%
     }%
@@ -881,7 +885,7 @@
 
 \def\grenoscaledim#1{%
   \gre@deprecated{\protect\grenoscaledim}{\protect\grescaledim{...}{no}}%
-  \expandafter\gdef\csname gre@scale@#1\endcsname{0}%
+  \grescaledim{#1}{false}%
 }%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -914,7 +918,7 @@
 %% Rescaling dimensions (for when \gre@factor changes)
 %%%%%%%%%%%%%%
 
-% This function checks to see if the length is one of the ones which cannot be a rubber length
+% This function checks to see if the length is one of the ones which cannot be a rubber length.  The assumption is that any length not listed here is allowed to be rubber.
 \newif\ifgre@rubber%
 \def\gre@rubberpermit#1{%
   \gre@rubbertrue%
@@ -1072,190 +1076,190 @@
 %% simply by dividing them by the old factor, and multiplying them by the new one.
 % #1 is the old gre@factor, #2 is the new one
 \def\gre@changedimenfactor#1#2{%
-  \ifnum\gre@scale@additionallineswidth=1\relax%
+  \ifgre@scale@additionallineswidth%
     \gre@changeonedimenfactor{additionallineswidth}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@additionalcustoslineswidth=1\relax%
+  \ifgre@scale@additionalcustoslineswidth%
     \gre@changeonedimenfactor{additionalcustoslineswidth}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@zerowidthspace=1\relax%
+  \ifgre@scale@zerowidthspace%
     \gre@changeonedimenfactor{zerowidthspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@interglyphspace=1\relax%
+  \ifgre@scale@interglyphspace%
     \gre@changeonedimenfactor{interglyphspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@alterationspace=1\relax%
+  \ifgre@scale@alterationspace%
     \gre@changeonedimenfactor{alterationspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@clefflatspace=1\relax%
+  \ifgre@scale@clefflatspace%
     \gre@changeonedimenfactor{clefflatspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@beforelowchoralsignspace=1\relax%
+  \ifgre@scale@beforelowchoralsignspace%
     \gre@changeonedimenfactor{beforelowchoralsignspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@beforealterationspace=1\relax%
+  \ifgre@scale@beforealterationspace%
     \gre@changeonedimenfactor{beforealterationspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@interelementspace=1\relax%
+  \ifgre@scale@interelementspace%
     \gre@changeonedimenfactor{interelementspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@largerspace=1\relax%
+  \ifgre@scale@largerspace%
     \gre@changeonedimenfactor{largerspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@nabcinterelementspace=1\relax%
+  \ifgre@scale@nabcinterelementspace%
     \gre@changeonedimenfactor{nabcinterelementspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@nabclargerspace=1\relax%
+  \ifgre@scale@nabclargerspace%
     \gre@changeonedimenfactor{nabclargerspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@glyphspace=1\relax%
+  \ifgre@scale@glyphspace%
     \gre@changeonedimenfactor{glyphspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacebeforecustos=1\relax%
+  \ifgre@scale@spacebeforecustos%
     \gre@changeonedimenfactor{spacebeforecustos}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacebeforesigns=1\relax%
+  \ifgre@scale@spacebeforesigns%
     \gre@changeonedimenfactor{spacebeforesigns}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spaceaftersigns=1\relax%
+  \ifgre@scale@spaceaftersigns%
     \gre@changeonedimenfactor{spaceaftersigns}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spaceafterlineclef=1\relax%
+  \ifgre@scale@spaceafterlineclef%
     \gre@changeonedimenfactor{spaceafterlineclef}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@interwordspacenotes=1\relax%
+  \ifgre@scale@interwordspacenotes%
     \gre@changeonedimenfactor{interwordspacenotes}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@intersyllablespacenotes=1\relax%
+  \ifgre@scale@intersyllablespacenotes%
     \gre@changeonedimenfactor{intersyllablespacenotes}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@interwordspacetext=1\relax%
+  \ifgre@scale@interwordspacetext%
     \gre@changeonedimenfactor{interwordspacetext}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@interwordspacenotes@euouae=1\relax%
+  \ifgre@scale@interwordspacenotes@euouae%
     \gre@changeonedimenfactor{interwordspacenotes@euouae}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@interwordspacetext@euouae=1\relax%
+  \ifgre@scale@interwordspacetext@euouae%
     \gre@changeonedimenfactor{interwordspacetext@euouae}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@bitrivirspace=1\relax%
+  \ifgre@scale@bitrivirspace%
     \gre@changeonedimenfactor{bitrivirspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@bitristrospace=1\relax%
+  \ifgre@scale@bitristrospace%
     \gre@changeonedimenfactor{bitristrospace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@punctuminclinatumshift=1\relax%
+  \ifgre@scale@punctuminclinatumshift%
     \gre@changeonedimenfactor{punctuminclinatumshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@beforepunctainclinatashift=1\relax%
+  \ifgre@scale@beforepunctainclinatashift%
     \gre@changeonedimenfactor{beforepunctainclinatashift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@punctuminclinatumanddebilisshift=1\relax%
+  \ifgre@scale@punctuminclinatumanddebilisshift%
     \gre@changeonedimenfactor{punctuminclinatumanddebilisshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@punctuminclinatumdebilisshift=1\relax%
+  \ifgre@scale@punctuminclinatumdebilisshift%
     \gre@changeonedimenfactor{punctuminclinatumdebilisshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@punctuminclinatumbigshift=1\relax%
+  \ifgre@scale@punctuminclinatumbigshift%
     \gre@changeonedimenfactor{punctuminclinatumbigshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@punctuminclinatummaxshift=1\relax%
+  \ifgre@scale@punctuminclinatummaxshift%
     \gre@changeonedimenfactor{punctuminclinatummaxshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacearoundsmallbar=1\relax%
+  \ifgre@scale@spacearoundsmallbar%
     \gre@changeonedimenfactor{spacearoundsmallbar}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacearoundminor=1\relax%
+  \ifgre@scale@spacearoundminor%
     \gre@changeonedimenfactor{spacearoundminor}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacearoundmaior=1\relax%
+  \ifgre@scale@spacearoundmaior%
     \gre@changeonedimenfactor{spacearoundmaior}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacearoundfinalis=1\relax%
+  \ifgre@scale@spacearoundfinalis%
     \gre@changeonedimenfactor{spacearoundfinalis}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacebeforefinalfinalis=1\relax%
+  \ifgre@scale@spacebeforefinalfinalis%
     \gre@changeonedimenfactor{spacebeforefinalfinalis}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacearoundclefbars=1\relax%
+  \ifgre@scale@spacearoundclefbars%
     \gre@changeonedimenfactor{spacearoundclefbars}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@textbartextspace=1\relax%
+  \ifgre@scale@textbartextspace%
     \gre@changeonedimenfactor{textbartextspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@notebarspace=1\relax%
+  \ifgre@scale@notebarspace%
     \gre@changeonedimenfactor{notebarspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@maximumspacewithoutdash=1\relax%
+  \ifgre@scale@maximumspacewithoutdash%
     \gre@changeonedimenfactor{maximumspacewithoutdash}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@afterclefnospace=1\relax%
+  \ifgre@scale@afterclefnospace%
     \gre@changeonedimenfactor{afterclefnospace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@afterinitialshift=1\relax%
+  \ifgre@scale@afterinitialshift%
     \gre@changeonedimenfactor{afterinitialshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@beforeinitialshift=1\relax%
+  \ifgre@scale@beforeinitialshift%
     \gre@changeonedimenfactor{beforeinitialshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@minimalspaceatlinebeginning=1\relax%
+  \ifgre@scale@minimalspaceatlinebeginning%
     \gre@changeonedimenfactor{minimalspaceatlinebeginning}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@manualinitialwidth=1\relax%
+  \ifgre@scale@manualinitialwidth%
     \gre@changeonedimenfactor{manualinitialwidth}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@annotationseparation=1\relax%
+  \ifgre@scale@annotationseparation%
     \gre@changeonedimenfactor{annotationseparation}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@annotationraise=1\relax%
+  \ifgre@scale@annotationraise%
     \gre@changeonedimenfactor{annotationraise}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@noclefspace=1\relax%
+  \ifgre@scale@noclefspace%
     \gre@changeonedimenfactor{noclefspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@clefchangespace=1\relax%
+  \ifgre@scale@clefchangespace%
     \gre@changeonedimenfactor{clefchangespace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@clivisalignmentmin=1\relax%
+  \ifgre@scale@clivisalignmentmin%
     \gre@changeonedimenfactor{clivisalignmentmin}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@abovesignsspace=1\relax%
+  \ifgre@scale@abovesignsspace%
     \gre@changeonedimenfactor{abovesignsspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@belowsignsspace=1\relax%
+  \ifgre@scale@belowsignsspace%
     \gre@changeonedimenfactor{belowsignsspace}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@choralsigndownshift=1\relax%
+  \ifgre@scale@choralsigndownshift%
     \gre@changeonedimenfactor{choralsigndownshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@choralsignupshift=1\relax%
+  \ifgre@scale@choralsignupshift%
     \gre@changeonedimenfactor{choralsignupshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@translationheight=1\relax%
+  \ifgre@scale@translationheight%
     \gre@changeonedimenfactor{translationheight}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spaceabovelines=1\relax%
+  \ifgre@scale@spaceabovelines%
     \gre@changeonedimenfactor{spaceabovelines}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacelinestext=1\relax%
+  \ifgre@scale@spacelinestext%
     \gre@changeonedimenfactor{spacelinestext}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@spacebeneathtext=1\relax%
+  \ifgre@scale@spacebeneathtext%
     \gre@changeonedimenfactor{spacebeneathtext}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@abovelinestextraise=1\relax%
+  \ifgre@scale@abovelinestextraise%
     \gre@changeonedimenfactor{abovelinestextraise}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@abovelinestextheight=1\relax%
+  \ifgre@scale@abovelinestextheight%
     \gre@changeonedimenfactor{abovelinestextheight}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@braceshift=1\relax%
+  \ifgre@scale@braceshift%
     \gre@changeonedimenfactor{braceshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@curlybraceaccentusshift=1\relax%
+  \ifgre@scale@curlybraceaccentusshift%
     \gre@changeonedimenfactor{curlybraceaccentusshift}{#1}{#2}%
   \fi%
-  \ifnum\gre@scale@stafflinefactor=1\relax%
+  \ifgre@scale@stafflinefactor%
     \gre@count@temp@two = \gre@stafflinefactor%
     \multiply\gre@count@temp@two by #2\relax%
     \divide\gre@count@temp@two by #1\relax%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -785,19 +785,19 @@
 %% dimension changing macros
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% This macro creates one dim (#1), setting its value to #2 and sets whether it should scale when the \gre@factor changes (#3, scaling or fixed).  Checks that #1 can accept the kind of distance given in #2.
+%% This macro creates one dim (#1), setting its value to #2 and sets whether it should scale when the \gre@factor changes (#3, scalable or fixed).  Checks that #1 can accept the kind of distance given in #2.
 %% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
 \newif\ifgre@checklength%
 \def\grecreatedim#1#2#3{%
   \gre@dimension{#1}{#2}
   \csname newif\expandafter\endcsname\csname ifgre@scale@#1\endcsname%
   \IfStrEq{#3}{1}%	
-    {\gre@deprecated{A numerical (1) last argument for \protect\grecreatedim}{'scaling'}%
+    {\gre@deprecated{A numerical (1) last argument for \protect\grecreatedim}{'scalable'}%
     \grescaledim{#1}{true}}%
     {\IfStrEq{#3}{0}%
       {\gre@deprecated{A numerical (0) last argument for \protect\grecreatedim}{'fixed'}%
       \grescaledim{#1}{false}}%
-      {\IfStrEq{#3}{scaling}%
+      {\IfStrEq{#3}{scalable}%
         {\grescaledim{#1}{true}}%
         {\IfStrEq{#3}{fixed}%
           {\grescaledim{#1}{false}}%
@@ -827,12 +827,12 @@
     \gre@debugmsg{spacing}{It does exist.}%
     \gre@dimension{#1}{#2}%
     \IfStrEq{#3}{1}%
-      {\gre@deprecated{A numerical (1) last argument for \protect\grechangedim}{'scaling'}%
+      {\gre@deprecated{A numerical (1) last argument for \protect\grechangedim}{'scalable'}%
       \grescaledim{#1}{true}}%
       {\IfStrEq{#3}{0}%
         {\gre@deprecated{A numerical (0) last argument for \protect\grechangedim}{'fixed'}%
         \grescaledim{#1}{false}}%
-        {\IfStrEq{#3}{scaling}%
+        {\IfStrEq{#3}{scalable}%
           {\grescaledim{#1}{true}}%
           {\IfStrEq{#3}{fixed}%
             {\grescaledim{#1}{false}}%
@@ -875,7 +875,7 @@
       {\grescaledim{true}}%
       {\IfStrEq{#2}{on}%
         {\grescaledim{true}}%
-        {\IfStrEq{#2}{scaling}%
+        {\IfStrEq{#2}{scalable}%
           {\grescaledim{true}}%
           {\csname gre@scale@#1false\endcsname}%
         }%

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -77,109 +77,109 @@
 \greconffactor=17%
 
 % the additional width of the additional lines (compared to the width of the glyph they're associated with)
-\grecreatedim{additionallineswidth}{0.14584 cm}{1}%
+\grecreatedim{additionallineswidth}{0.14584 cm}{scaling}%
 % width of the additional lines, used only for the custos (maybe should depend on the width of the custos...)
 % the width is the one for the custos at end of lines, the line for custos in the middle of a score is the same
 % multiplied by 2.
-\grecreatedim{additionalcustoslineswidth}{0.09114 cm}{1}%
+\grecreatedim{additionalcustoslineswidth}{0.09114 cm}{scaling}%
 % null space
-\grecreatedim{zerowidthspace}{0 cm}{1}%
+\grecreatedim{zerowidthspace}{0 cm}{scaling}%
 % space between glyphs in the same element
-\grecreatedim{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{1}%
+\grecreatedim{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{scaling}%
 % space between an alteration (flat or natural) and the next glyph
-\grecreatedim{alterationspace}{0.07747 cm plus 0.01276 cm minus 0.00455 cm}{1}%
+\grecreatedim{alterationspace}{0.07747 cm plus 0.01276 cm minus 0.00455 cm}{scaling}%
 % space between a clef and a flat (for clefs with flat)
-\grecreatedim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{1}%
+\grecreatedim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{scaling}%
 % space before a choral sign
-\grecreatedim{beforelowchoralsignspace}{0.04556 cm plus 0.00638 cm minus 0.00638 cm}{1}%
+\grecreatedim{beforelowchoralsignspace}{0.04556 cm plus 0.00638 cm minus 0.00638 cm}{scaling}%
 % negative space, difference between the normal space between two notes and the space between a note and a flat
-\grecreatedim{beforealterationspace}{-0.32816 cm plus 0.01093 cm minus 0.01093 cm}{1}%
+\grecreatedim{beforealterationspace}{-0.32816 cm plus 0.01093 cm minus 0.01093 cm}{scaling}%
 % space between elements
-\grecreatedim{interelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{1}%
+\grecreatedim{interelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scaling}%
 % larger space between elements
-\grecreatedim{largerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{1}%
+\grecreatedim{largerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scaling}%
 % space between elements in ancient notation
-\grecreatedim{nabcinterelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{1}%
+\grecreatedim{nabcinterelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scaling}%
 % larger space between elements in ancient notation
-\grecreatedim{nabclargerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{1}%
+\grecreatedim{nabclargerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scaling}%
 % space between elements which has the size of a note
-\grecreatedim{glyphspace}{0.21877 cm plus 0.01822 cm minus 0.01822 cm}{1}%
+\grecreatedim{glyphspace}{0.21877 cm plus 0.01822 cm minus 0.01822 cm}{scaling}%
 % space before custos
-\grecreatedim{spacebeforecustos}{0.1823 cm plus 0.31903 cm minus 0.0638 cm}{1}%
+\grecreatedim{spacebeforecustos}{0.1823 cm plus 0.31903 cm minus 0.0638 cm}{scaling}%
 % space before punctum mora and augmentum duplex
-\grecreatedim{spacebeforesigns}{0.05469 cm plus 0.00455 cm minus 0.00455 cm}{1}%
+\grecreatedim{spacebeforesigns}{0.05469 cm plus 0.00455 cm minus 0.00455 cm}{scaling}%
 % space after punctum mora and augmentum duplex
-\grecreatedim{spaceaftersigns}{0.08203 cm plus 0.0082 cm minus 0.0082 cm}{1}%
+\grecreatedim{spaceaftersigns}{0.08203 cm plus 0.0082 cm minus 0.0082 cm}{scaling}%
 % space after a clef at the beginning of a line
-\grecreatedim{spaceafterlineclef}{0.27345 cm plus 0.14584 cm minus 0.01367 cm}{1}%
+\grecreatedim{spaceafterlineclef}{0.27345 cm plus 0.14584 cm minus 0.01367 cm}{scaling}%
 % minimal space between notes of different words
-\grecreatedim{interwordspacenotes}{0.27 cm plus 0.15 cm minus 0.05 cm}{1}%
+\grecreatedim{interwordspacenotes}{0.27 cm plus 0.15 cm minus 0.05 cm}{scaling}%
 % minimal space between notes of the same syllable.
 % Warning: always keep minus to 0; also keep plus very low, or some words won't be hyphenated
-\grecreatedim{intersyllablespacenotes}{0.24 cm plus 0.04cm minus 0cm}{1}%
+\grecreatedim{intersyllablespacenotes}{0.24 cm plus 0.04cm minus 0cm}{scaling}%
 % minimal space between letters of different words. Makes sense to have
 % the same plus and minus as interwordspacenotes.
-\grecreatedim{interwordspacetext}{0.38 cm plus 0.15 cm minus 0.05 cm}{1}%
+\grecreatedim{interwordspacetext}{0.38 cm plus 0.15 cm minus 0.05 cm}{scaling}%
 % Versions of interword spaces for euouae blocks
-\grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{1}%
-\grecreatedim{interwordspacetext@euouae}{0.27 cm plus 0.1 cm minus 0.05 cm}{1}%
+\grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scaling}%
+\grecreatedim{interwordspacetext@euouae}{0.27 cm plus 0.1 cm minus 0.05 cm}{scaling}%
 % space between notes of a bivirga or trivirga
-\grecreatedim{bitrivirspace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{1}%
+\grecreatedim{bitrivirspace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scaling}%
 % space between notes of a bistropha or tristrophae
-\grecreatedim{bitristrospace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{1}%
+\grecreatedim{bitristrospace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scaling}%
 % space between two punctum inclinatum
-\grecreatedim{punctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{1}%
+\grecreatedim{punctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
 % space before puncta inclinata
-\grecreatedim{beforepunctainclinatashift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{1}%
+\grecreatedim{beforepunctainclinatashift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scaling}%
 % space between a punctum inclinatum and a punctum inclinatum deminutus
-\grecreatedim{punctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{1}%
+\grecreatedim{punctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
 % space between two punctum inclinatum deminutus
-\grecreatedim{punctuminclinatumdebilisshift}{-0.00728 cm plus 0.0009 cm minus 0.0009 cm}{1}%
+\grecreatedim{punctuminclinatumdebilisshift}{-0.00728 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
 % space between puncta inclinata, larger ambitus (range=3rd)
-\grecreatedim{punctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{1}%
+\grecreatedim{punctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
 % space between puncta inclinata, larger ambitus (range=4th -or more?-)
-\grecreatedim{punctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{1}%
+\grecreatedim{punctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
 % space for the bars (inside syllables)
 %first for virgula and divisio minima
-\grecreatedim{spacearoundsmallbar}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
+\grecreatedim{spacearoundsmallbar}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
 %then divisio minor
-\grecreatedim{spacearoundminor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
+\grecreatedim{spacearoundminor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
 %divisio major
-\grecreatedim{spacearoundmaior}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
+\grecreatedim{spacearoundmaior}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
 %divisio finalis
-\grecreatedim{spacearoundfinalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{1}%
+\grecreatedim{spacearoundfinalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
 %a special space for finalis, for when it is the last glyph
-\grecreatedim{spacebeforefinalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{1}%
+\grecreatedim{spacebeforefinalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{scaling}%
 % additional space that will appear around bars that are preceded by a custos and followed by a key.
-\grecreatedim{spacearoundclefbars}{0.03645 cm plus 0.00455 cm minus 0.0009 cm}{1}%
+\grecreatedim{spacearoundclefbars}{0.03645 cm plus 0.00455 cm minus 0.0009 cm}{scaling}%
 % space between the text and the text of the bar
-\grecreatedim{textbartextspace}{0.24611 cm plus 0.13672 cm minus 0.04921 cm}{1}%
+\grecreatedim{textbartextspace}{0.24611 cm plus 0.13672 cm minus 0.04921 cm}{scaling}%
 % minimal space between a note and a bar
-\grecreatedim{notebarspace}{0.31903 cm plus 0.27345 cm minus 0.02824 cm}{1}%
+\grecreatedim{notebarspace}{0.31903 cm plus 0.27345 cm minus 0.02824 cm}{scaling}%
 % maximal space between two syllables for which we consider a dash is not needed
-\grecreatedim{maximumspacewithoutdash}{0.02 cm}{1}%
+\grecreatedim{maximumspacewithoutdash}{0.02 cm}{scaling}%
 % an extensible space for the beginning of lines
-\grecreatedim{afterclefnospace}{0 cm plus 0.27345 cm minus 0 cm}{1}%
+\grecreatedim{afterclefnospace}{0 cm plus 0.27345 cm minus 0 cm}{scaling}%
 % space between the initial and the beginning of the score
-\grecreatedim{afterinitialshift}{0.2457 cm}{1}%
+\grecreatedim{afterinitialshift}{0.2457 cm}{scaling}%
 % space before the initial
-\grecreatedim{beforeinitialshift}{0.2457 cm}{1}%
+\grecreatedim{beforeinitialshift}{0.2457 cm}{scaling}%
 % minimum space between beginning of line and first syllable text
-\grecreatedim{minimalspaceatlinebeginning}{0.05 cm}{1}%
+\grecreatedim{minimalspaceatlinebeginning}{0.05 cm}{scaling}%
 % space to force the initial width to.  Ignored when 0.
-\grecreatedim{manualinitialwidth}{0 cm}{1}%
+\grecreatedim{manualinitialwidth}{0 cm}{scaling}%
 % distance to move the initial up by
-\grecreatedim{initialraise}{0 cm}{1}%
+\grecreatedim{initialraise}{0 cm}{scaling}%
 % Space between lines in the annotation
-\grecreatedim{annotationseparation}{0.05cm}{1}%
+\grecreatedim{annotationseparation}{0.05cm}{scaling}%
 % Amount to raise (positive) or lower (negative) the annotations from the default position (base line of top annotation aligned with top line of staff)
-\grecreatedim{annotationraise}{0cm}{1}%
+\grecreatedim{annotationraise}{0cm}{scaling}%
 % space at the beginning of the lines if there is no clef
-\grecreatedim{noclefspace}{0.1 cm}{1}%
+\grecreatedim{noclefspace}{0.1 cm}{scaling}%
 % space around a clef change
-\grecreatedim{clefchangespace}{0.01768 cm plus 0.00175 cm minus 0.01768 cm}{1}%
+\grecreatedim{clefchangespace}{0.01768 cm plus 0.00175 cm minus 0.01768 cm}{scaling}%
 %When \gre@clivisalignment is 2, this distance is the maximum length of the consonants after vowels for which the clivis will be aligned on its center.
-\grecreatedim{clivisalignmentmin}{0.3 cm}{1}%
+\grecreatedim{clivisalignmentmin}{0.3 cm}{scaling}%
 
 
 
@@ -188,32 +188,32 @@
 %%%%%%%%%%%%%%%%%%
 
 % first, we have two spaces for the chironomic signs
-\grecreatedim{abovesignsspace}{0.8 cm}{1}%
-\grecreatedim{belowsignsspace}{0 cm}{1}%
+\grecreatedim{abovesignsspace}{0.8 cm}{scaling}%
+\grecreatedim{belowsignsspace}{0 cm}{scaling}%
 % the amount to shift down:
 % (a) low choral signs that are not lower than the note, regardless of whether
 %     it's on a line or in a space
 % (b) high choral signs and low choral signs that are lower than the note which
 %     are in a space
-\grecreatedim{choralsigndownshift}{0.00911 cm}{1}%
+\grecreatedim{choralsigndownshift}{0.00911 cm}{scaling}%
 % the amount to shift up:
 % (a) high choral signs and low choral signs that are lower than the note which
 %     are on a line
-\grecreatedim{choralsignupshift}{0.04556 cm}{1}%
+\grecreatedim{choralsignupshift}{0.04556 cm}{scaling}%
 % the space for the translation
-\grecreatedim{translationheight}{0.5 cm}{1}%
+\grecreatedim{translationheight}{0.5 cm}{scaling}%
 %the space above the lines
-\grecreatedim{spaceabovelines}{0.45576 cm plus 0.36461 cm minus 0.09114 cm}{1}%
+\grecreatedim{spaceabovelines}{0.45576 cm plus 0.36461 cm minus 0.09114 cm}{scaling}%
 %the space between the lines and the bottom of the text
-\grecreatedim{spacelinestext}{0.60617 cm}{1}%
+\grecreatedim{spacelinestext}{0.60617 cm}{scaling}%
 %the space beneath the text
-\grecreatedim{spacebeneathtext}{0 cm}{1}%
+\grecreatedim{spacebeneathtext}{0 cm}{scaling}%
 % height of the text above the note line
-\grecreatedim{abovelinestextraise}{-0.1 cm}{1}%
+\grecreatedim{abovelinestextraise}{-0.1 cm}{scaling}%
 % height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration)
-\grecreatedim{abovelinestextheight}{0.3 cm}{1}%
+\grecreatedim{abovelinestextheight}{0.3 cm}{scaling}%
 % an additional shift you can give to the brace above the bars if you don't like it
-\grecreatedim{braceshift}{0 cm}{1}%
+\grecreatedim{braceshift}{0 cm}{scaling}%
 % a shift you can give to the accentus above the curly brace
-\grecreatedim{curlybraceaccentusshift}{-0.05 cm}{1}%
+\grecreatedim{curlybraceaccentusshift}{-0.05 cm}{scaling}%
 

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -77,109 +77,109 @@
 \greconffactor=17%
 
 % the additional width of the additional lines (compared to the width of the glyph they're associated with)
-\grecreatedim{additionallineswidth}{0.14584 cm}{scaling}%
+\grecreatedim{additionallineswidth}{0.14584 cm}{scalable}%
 % width of the additional lines, used only for the custos (maybe should depend on the width of the custos...)
 % the width is the one for the custos at end of lines, the line for custos in the middle of a score is the same
 % multiplied by 2.
-\grecreatedim{additionalcustoslineswidth}{0.09114 cm}{scaling}%
+\grecreatedim{additionalcustoslineswidth}{0.09114 cm}{scalable}%
 % null space
-\grecreatedim{zerowidthspace}{0 cm}{scaling}%
+\grecreatedim{zerowidthspace}{0 cm}{scalable}%
 % space between glyphs in the same element
-\grecreatedim{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{scaling}%
+\grecreatedim{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between an alteration (flat or natural) and the next glyph
-\grecreatedim{alterationspace}{0.07747 cm plus 0.01276 cm minus 0.00455 cm}{scaling}%
+\grecreatedim{alterationspace}{0.07747 cm plus 0.01276 cm minus 0.00455 cm}{scalable}%
 % space between a clef and a flat (for clefs with flat)
-\grecreatedim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{scaling}%
+\grecreatedim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
 % space before a choral sign
-\grecreatedim{beforelowchoralsignspace}{0.04556 cm plus 0.00638 cm minus 0.00638 cm}{scaling}%
+\grecreatedim{beforelowchoralsignspace}{0.04556 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
 % negative space, difference between the normal space between two notes and the space between a note and a flat
-\grecreatedim{beforealterationspace}{-0.32816 cm plus 0.01093 cm minus 0.01093 cm}{scaling}%
+\grecreatedim{beforealterationspace}{-0.32816 cm plus 0.01093 cm minus 0.01093 cm}{scalable}%
 % space between elements
-\grecreatedim{interelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scaling}%
+\grecreatedim{interelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scalable}%
 % larger space between elements
-\grecreatedim{largerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scaling}%
+\grecreatedim{largerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
 % space between elements in ancient notation
-\grecreatedim{nabcinterelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scaling}%
+\grecreatedim{nabcinterelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scalable}%
 % larger space between elements in ancient notation
-\grecreatedim{nabclargerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scaling}%
+\grecreatedim{nabclargerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
 % space between elements which has the size of a note
-\grecreatedim{glyphspace}{0.21877 cm plus 0.01822 cm minus 0.01822 cm}{scaling}%
+\grecreatedim{glyphspace}{0.21877 cm plus 0.01822 cm minus 0.01822 cm}{scalable}%
 % space before custos
-\grecreatedim{spacebeforecustos}{0.1823 cm plus 0.31903 cm minus 0.0638 cm}{scaling}%
+\grecreatedim{spacebeforecustos}{0.1823 cm plus 0.31903 cm minus 0.0638 cm}{scalable}%
 % space before punctum mora and augmentum duplex
-\grecreatedim{spacebeforesigns}{0.05469 cm plus 0.00455 cm minus 0.00455 cm}{scaling}%
+\grecreatedim{spacebeforesigns}{0.05469 cm plus 0.00455 cm minus 0.00455 cm}{scalable}%
 % space after punctum mora and augmentum duplex
-\grecreatedim{spaceaftersigns}{0.08203 cm plus 0.0082 cm minus 0.0082 cm}{scaling}%
+\grecreatedim{spaceaftersigns}{0.08203 cm plus 0.0082 cm minus 0.0082 cm}{scalable}%
 % space after a clef at the beginning of a line
-\grecreatedim{spaceafterlineclef}{0.27345 cm plus 0.14584 cm minus 0.01367 cm}{scaling}%
+\grecreatedim{spaceafterlineclef}{0.27345 cm plus 0.14584 cm minus 0.01367 cm}{scalable}%
 % minimal space between notes of different words
-\grecreatedim{interwordspacenotes}{0.27 cm plus 0.15 cm minus 0.05 cm}{scaling}%
+\grecreatedim{interwordspacenotes}{0.27 cm plus 0.15 cm minus 0.05 cm}{scalable}%
 % minimal space between notes of the same syllable.
 % Warning: always keep minus to 0; also keep plus very low, or some words won't be hyphenated
-\grecreatedim{intersyllablespacenotes}{0.24 cm plus 0.04cm minus 0cm}{scaling}%
+\grecreatedim{intersyllablespacenotes}{0.24 cm plus 0.04cm minus 0cm}{scalable}%
 % minimal space between letters of different words. Makes sense to have
 % the same plus and minus as interwordspacenotes.
-\grecreatedim{interwordspacetext}{0.38 cm plus 0.15 cm minus 0.05 cm}{scaling}%
+\grecreatedim{interwordspacetext}{0.38 cm plus 0.15 cm minus 0.05 cm}{scalable}%
 % Versions of interword spaces for euouae blocks
-\grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scaling}%
-\grecreatedim{interwordspacetext@euouae}{0.27 cm plus 0.1 cm minus 0.05 cm}{scaling}%
+\grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scalable}%
+\grecreatedim{interwordspacetext@euouae}{0.27 cm plus 0.1 cm minus 0.05 cm}{scalable}%
 % space between notes of a bivirga or trivirga
-\grecreatedim{bitrivirspace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scaling}%
+\grecreatedim{bitrivirspace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scalable}%
 % space between notes of a bistropha or tristrophae
-\grecreatedim{bitristrospace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scaling}%
+\grecreatedim{bitristrospace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scalable}%
 % space between two punctum inclinatum
-\grecreatedim{punctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
+\grecreatedim{punctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space before puncta inclinata
-\grecreatedim{beforepunctainclinatashift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scaling}%
+\grecreatedim{beforepunctainclinatashift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 % space between a punctum inclinatum and a punctum inclinatum deminutus
-\grecreatedim{punctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
+\grecreatedim{punctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between two punctum inclinatum deminutus
-\grecreatedim{punctuminclinatumdebilisshift}{-0.00728 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
+\grecreatedim{punctuminclinatumdebilisshift}{-0.00728 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between puncta inclinata, larger ambitus (range=3rd)
-\grecreatedim{punctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
+\grecreatedim{punctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between puncta inclinata, larger ambitus (range=4th -or more?-)
-\grecreatedim{punctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{scaling}%
+\grecreatedim{punctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space for the bars (inside syllables)
 %first for virgula and divisio minima
-\grecreatedim{spacearoundsmallbar}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
+\grecreatedim{spacearoundsmallbar}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 %then divisio minor
-\grecreatedim{spacearoundminor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
+\grecreatedim{spacearoundminor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 %divisio major
-\grecreatedim{spacearoundmaior}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
+\grecreatedim{spacearoundmaior}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 %divisio finalis
-\grecreatedim{spacearoundfinalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scaling}%
+\grecreatedim{spacearoundfinalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 %a special space for finalis, for when it is the last glyph
-\grecreatedim{spacebeforefinalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{scaling}%
+\grecreatedim{spacebeforefinalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{scalable}%
 % additional space that will appear around bars that are preceded by a custos and followed by a key.
-\grecreatedim{spacearoundclefbars}{0.03645 cm plus 0.00455 cm minus 0.0009 cm}{scaling}%
+\grecreatedim{spacearoundclefbars}{0.03645 cm plus 0.00455 cm minus 0.0009 cm}{scalable}%
 % space between the text and the text of the bar
-\grecreatedim{textbartextspace}{0.24611 cm plus 0.13672 cm minus 0.04921 cm}{scaling}%
+\grecreatedim{textbartextspace}{0.24611 cm plus 0.13672 cm minus 0.04921 cm}{scalable}%
 % minimal space between a note and a bar
-\grecreatedim{notebarspace}{0.31903 cm plus 0.27345 cm minus 0.02824 cm}{scaling}%
+\grecreatedim{notebarspace}{0.31903 cm plus 0.27345 cm minus 0.02824 cm}{scalable}%
 % maximal space between two syllables for which we consider a dash is not needed
-\grecreatedim{maximumspacewithoutdash}{0.02 cm}{scaling}%
+\grecreatedim{maximumspacewithoutdash}{0.02 cm}{scalable}%
 % an extensible space for the beginning of lines
-\grecreatedim{afterclefnospace}{0 cm plus 0.27345 cm minus 0 cm}{scaling}%
+\grecreatedim{afterclefnospace}{0 cm plus 0.27345 cm minus 0 cm}{scalable}%
 % space between the initial and the beginning of the score
-\grecreatedim{afterinitialshift}{0.2457 cm}{scaling}%
+\grecreatedim{afterinitialshift}{0.2457 cm}{scalable}%
 % space before the initial
-\grecreatedim{beforeinitialshift}{0.2457 cm}{scaling}%
+\grecreatedim{beforeinitialshift}{0.2457 cm}{scalable}%
 % minimum space between beginning of line and first syllable text
-\grecreatedim{minimalspaceatlinebeginning}{0.05 cm}{scaling}%
+\grecreatedim{minimalspaceatlinebeginning}{0.05 cm}{scalable}%
 % space to force the initial width to.  Ignored when 0.
-\grecreatedim{manualinitialwidth}{0 cm}{scaling}%
+\grecreatedim{manualinitialwidth}{0 cm}{scalable}%
 % distance to move the initial up by
-\grecreatedim{initialraise}{0 cm}{scaling}%
+\grecreatedim{initialraise}{0 cm}{scalable}%
 % Space between lines in the annotation
-\grecreatedim{annotationseparation}{0.05cm}{scaling}%
+\grecreatedim{annotationseparation}{0.05cm}{scalable}%
 % Amount to raise (positive) or lower (negative) the annotations from the default position (base line of top annotation aligned with top line of staff)
-\grecreatedim{annotationraise}{0cm}{scaling}%
+\grecreatedim{annotationraise}{0cm}{scalable}%
 % space at the beginning of the lines if there is no clef
-\grecreatedim{noclefspace}{0.1 cm}{scaling}%
+\grecreatedim{noclefspace}{0.1 cm}{scalable}%
 % space around a clef change
-\grecreatedim{clefchangespace}{0.01768 cm plus 0.00175 cm minus 0.01768 cm}{scaling}%
+\grecreatedim{clefchangespace}{0.01768 cm plus 0.00175 cm minus 0.01768 cm}{scalable}%
 %When \gre@clivisalignment is 2, this distance is the maximum length of the consonants after vowels for which the clivis will be aligned on its center.
-\grecreatedim{clivisalignmentmin}{0.3 cm}{scaling}%
+\grecreatedim{clivisalignmentmin}{0.3 cm}{scalable}%
 
 
 
@@ -188,32 +188,32 @@
 %%%%%%%%%%%%%%%%%%
 
 % first, we have two spaces for the chironomic signs
-\grecreatedim{abovesignsspace}{0.8 cm}{scaling}%
-\grecreatedim{belowsignsspace}{0 cm}{scaling}%
+\grecreatedim{abovesignsspace}{0.8 cm}{scalable}%
+\grecreatedim{belowsignsspace}{0 cm}{scalable}%
 % the amount to shift down:
 % (a) low choral signs that are not lower than the note, regardless of whether
 %     it's on a line or in a space
 % (b) high choral signs and low choral signs that are lower than the note which
 %     are in a space
-\grecreatedim{choralsigndownshift}{0.00911 cm}{scaling}%
+\grecreatedim{choralsigndownshift}{0.00911 cm}{scalable}%
 % the amount to shift up:
 % (a) high choral signs and low choral signs that are lower than the note which
 %     are on a line
-\grecreatedim{choralsignupshift}{0.04556 cm}{scaling}%
+\grecreatedim{choralsignupshift}{0.04556 cm}{scalable}%
 % the space for the translation
-\grecreatedim{translationheight}{0.5 cm}{scaling}%
+\grecreatedim{translationheight}{0.5 cm}{scalable}%
 %the space above the lines
-\grecreatedim{spaceabovelines}{0.45576 cm plus 0.36461 cm minus 0.09114 cm}{scaling}%
+\grecreatedim{spaceabovelines}{0.45576 cm plus 0.36461 cm minus 0.09114 cm}{scalable}%
 %the space between the lines and the bottom of the text
-\grecreatedim{spacelinestext}{0.60617 cm}{scaling}%
+\grecreatedim{spacelinestext}{0.60617 cm}{scalable}%
 %the space beneath the text
-\grecreatedim{spacebeneathtext}{0 cm}{scaling}%
+\grecreatedim{spacebeneathtext}{0 cm}{scalable}%
 % height of the text above the note line
-\grecreatedim{abovelinestextraise}{-0.1 cm}{scaling}%
+\grecreatedim{abovelinestextraise}{-0.1 cm}{scalable}%
 % height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration)
-\grecreatedim{abovelinestextheight}{0.3 cm}{scaling}%
+\grecreatedim{abovelinestextheight}{0.3 cm}{scalable}%
 % an additional shift you can give to the brace above the bars if you don't like it
-\grecreatedim{braceshift}{0 cm}{scaling}%
+\grecreatedim{braceshift}{0 cm}{scalable}%
 % a shift you can give to the accentus above the curly brace
-\grecreatedim{curlybraceaccentusshift}{-0.05 cm}{scaling}%
+\grecreatedim{curlybraceaccentusshift}{-0.05 cm}{scalable}%
 


### PR DESCRIPTION
This PR changes a few things related to the distances:

1. In keeping with the new naming conventions the `0` and `1` arguments of `\grecreatedim` and `\grechangedim` are changed to `fixed` and `scaling` respectively.
2. Previously `\grechangedim` had called `\grecreatedim` as its internal workhorse function.  This was messy when I went looking to introduce deprecation messages, so I refactored out the common internals into a separate function `\gre@dimension` which both functions can now call.
3. The scaling flag for each distance is switched from being a number stored in a macro to being a boolean.
4. `\grescaledim` wasn't working right for all of its keywords.  I've fixed this and added a new keyword (`scaling`).