### PR TITLE
Initial alterations are ignored when aligning the first note of each line (bolshift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Changed
 - `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scalable` and `fixed`( instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
 - `\grescaledim` now accepts `scalable` as a keyword to turn on scalable (in keeping with the above change)
+- Alterations are partially ignored when aligning lines on the notes (i.e. `\gresetbolshifts{enabled}`).  They are not allowed to get any closer to the clef than `beforealterationspace` and the lyrics are not allowed to get any closer to the left-hand margin than `minimalspaceatlinebeginning`, but other than that GregorioTeX will shift them left as much as possible to make the notes align `spaceafterlineclef` away from the clef.  Note that for the default values of these distances, only the natural is small enough to acheive true alignment.
 
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -860,7 +860,7 @@ Space between an alteration (flat or natural) and the next glyph.
 Default: \unit[0.07747]{cm} plus \unit[0.01276]{cm} minus \unit[0.00455]{cm}
 
 \macroname{beforealterationspace}{}{gsp-default.tex}
-Negative space, difference between the normal space between two notes and the space between a note and a flat.  
+When bolshifts are enabled, minimal space between a clef at the beginning of the line and a leading alteration glyph (should be larger than \texttt{clefflatspace} so that a flatted clef can be distinguished from a flat which is part of the first glyph on a line, but also smaller than \texttt{spaceafterlineclef}, the distance from the clef to the first notes).
 
 Default: $\unit[-0.32816]{cm}$ plus \unit[0.01093]{cm} minus \unit[0.01093]{cm}
 
@@ -1050,7 +1050,7 @@ Space between the initial and the beginning of the score.
 Default: \unit[0.2457]{cm} plus \unit[0]{cm} minus \unit[0]{cm}
 
 \macroname{minimalspaceatlinebeginning}{}{gsp-default.tex}
-Minimal space at the beginning of a line.
+Minimal space in front of the lyrics at the beginning of a line when \texttt{bolshift}s are enabled.
 
 Default: \unit[1.7]{cm}
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1357,6 +1357,9 @@ The left kern that should appear before an end of line.
 \macroname{\textbackslash gre@dimen@bolshift}{}{gregoriotex-spaces.tex}
 The left kern that should appear at the beginning of line in case of a forced line break.
 
+\macroname{\textbackslash gre@dimen@bolextra}{}{gregoriotex-spaces.tex}
+An extra space that is added to \verb=\gre@dimen@bolshift= when the first glyph is a flat or a natural.
+
 \macroname{\textbackslash gre@dimen@annotationtrueraise}{}{gregoriotex-spaces.tex}
 The distance from the baseline of the initial to the baseline of the annotation.
 

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1652,7 +1652,6 @@
       \gre@skip@temp@four = \gre@skip@alterationspace\relax%
       \global\advance\gre@dimen@bolextra by \dimexpr\gre@skip@temp@four\relax%
       \gre@debugmsg{bolshift}{bolextra: \the\ger@diment@bolextra}%
-%			\kern -\gre@dimen@bolextra\relax%
     \fi%
   \fi %
   \gre@calculate@glyphraisevalue{#1}{0}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1647,12 +1647,6 @@
   \setbox\gre@box@temp@width=\hbox{#2}%
   \ifnum#4=0\relax %
     \gre@newglyphcommon %
-    \ifgre@firstglyph%
-      \global\gre@dimen@bolextra = \wd\gre@box@temp@width%
-      \gre@skip@temp@four = \gre@skip@alterationspace\relax%
-      \global\advance\gre@dimen@bolextra by \dimexpr\gre@skip@temp@four\relax%
-      \gre@debugmsg{bolshift}{bolextra: \the\ger@diment@bolextra}%
-    \fi%
   \fi %
   \gre@calculate@glyphraisevalue{#1}{0}%
   \ifgre@hidealtlines %
@@ -1665,9 +1659,14 @@
     \GreNoBreak %
     \gre@skip@temp@four = \gre@skip@alterationspace\relax%
     \ifgre@firstglyph%
+      \gre@debugmsg{bolshift}{making adjustments for leading alteration}%
       \global\advance\gre@dimen@notesaligncenter by \wd\gre@box@temp@width %
       \global\advance\gre@dimen@notesaligncenter by \dimexpr\gre@skip@temp@four\relax %
       \kern\gre@skip@temp@four %
+      \global\gre@dimen@bolextra = \wd\gre@box@temp@width%
+      \gre@skip@temp@four = \gre@skip@alterationspace\relax%
+      \global\advance\gre@dimen@bolextra by \dimexpr\gre@skip@temp@four\relax%
+      \gre@debugmsg{bolshift}{bolextra: \the\gre@dimen@bolextra}%
     \else %
       \gre@hskip\gre@skip@temp@four %
     \fi %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1620,12 +1620,12 @@
 % the argument is the character with which we fill the hole, and we suppose that
 % isonaline and glyphraisevalue are correctly set.
 \def\gre@fillhole#1{%
-  \setbox\gre@box@temp@width=\hbox{#1}%
+  \setbox\gre@box@temp@sign=\hbox{#1}%
   \hbox to 0pt{%
     {%
     \color{grebackgroundcolor}%
     \raise \gre@dimen@glyphraisevalue\relax%
-    \copy\gre@box@temp@width %
+    \copy\gre@box@temp@sign %
     }%
     %\pdfliteral{}% this is a ugly hack for old versions of LuaTeX to work
     \hss %
@@ -1644,19 +1644,21 @@
 % #3 is the char of the alteration hole
 % #4 is 1 in the case of a flat for a key change, 0 otherwise
 \def\gre@alteration#1#2#3#4{%
-  % to see why we reset \gre@lastoflinecount, see comments of \GreGlyph.
+  \setbox\gre@box@temp@width=\hbox{#2}%
   \ifnum#4=0\relax %
     \gre@newglyphcommon %
+    \ifgre@firstglyph%
+      \global\gre@dimen@bolextra = \wd\gre@box@temp@width%
+      \gre@skip@temp@four = \gre@skip@alterationspace\relax%
+      \global\advance\gre@dimen@bolextra by \dimexpr\gre@skip@temp@four\relax%
+      \gre@debugmsg{bolshift}{bolextra: \the\ger@diment@bolextra}%
+%			\kern -\gre@dimen@bolextra\relax%
+    \fi%
   \fi %
   \gre@calculate@glyphraisevalue{#1}{0}%
   \ifgre@hidealtlines %
     \gre@fillhole{#3}%
   \fi %
-  \setbox\gre@box@temp@width=\hbox{#2}%
-  %\gre@dimen@temp@three=\wd\gre@box@temp@width 
-  %\kern\gre@dimen@temp@three 
-  %#3\relax 
-  %\kern-\gre@dimen@temp@three 
   \raise \gre@dimen@glyphraisevalue\relax%
   \copy\gre@box@temp@width%
   \ifnum#4=0\relax %
@@ -1672,13 +1674,11 @@
     \fi %
     \GreNoBreak %
   \fi %
-  %#4\relax 
-  %\GreNoBreak 
   \relax %
 }%
   %
 % This macro typesets a flat on the height provided by #1. #2 is not used yet, but it
-% will determine if the flat has zero width or not. #3 and #4 should be the same as GreGlyph's #5 and #6, but it's not really done nor useful...
+% will determine if the flat has zero width or not.
 
 \def\GreFlat#1#2{%
   \gre@alteration{#1}{\gre@fontchar@flat}{\gre@fontchar@flathole}{#2}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -338,27 +338,37 @@
 %%
 %% @arg#1 \gre@dimen@begindifference of the first syllable of the line
 \def\gre@calculate@bolshift#1{%
-  % as the \gre@dimen@bolshift is computed from skips, we compute it in a
-  % skip temp registry, and then "cast" it into a dimen
-  \gre@skip@temp@three=\gre@skip@spaceafterlineclef\relax%
-  \advance\gre@skip@temp@three by #1%
-  % we don't want to kern more than clefwidth minus minimalspaceatlinebeginning
-  \gre@dimen@temp@one = \gre@dimen@clefwidth\relax%
-  \advance\gre@dimen@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
-  \ifdim\gre@skip@temp@three <-\gre@dimen@temp@one %
-    \gre@skip@temp@three=-\gre@dimen@temp@one %
-  \fi %
-  \advance\gre@skip@temp@three by -\gre@skip@spaceafterlineclef\relax%
-  \ifdim\gre@skip@temp@three < #1\relax %
-    \gre@skip@temp@three=\the #1\relax %
-  \fi %
-  \gre@debugmsg{bolshift}{ temp@three = \the\gre@skip@temp@three}%
-  \ifdim\gre@skip@temp@three > 0pt\relax %
-    \global\gre@dimen@bolshift=0pt\relax %
-  \else %
-    \global\gre@dimen@bolshift=-\gre@skip@temp@three %
-  \fi %
-  \global\advance\gre@dimen@bolshift by \gre@dimen@bolextra%
+  \gre@skip@temp@three = 0pt\relax%
+  % bolextra is the space taken up by a leading alteration (it's 0 if there is no leading alteration)
+  % it's allowed to invade spaceafterlineclef, so long as it leaves at least beforealterationspace between itself and the clef
+  % and minimalspaceatlinebeginning between the lyrics and the beginning of the line
+  \gre@skip@temp@one = \gre@skip@spaceafterlineclef\relax%
+  \advance\gre@skip@temp@one by -\gre@dimen@beforealterationspace\relax%
+  \ifdim\gre@dimen@bolextra>\gre@skip@temp@one\relax%
+    \global\advance\gre@skip@temp@three by \gre@skip@temp@one\relax%
+  \else%
+    \global\advance\gre@skip@temp@three by \gre@dimen@bolextra\relax%
+  \fi%
+  \ifdim#1>0pt\relax%
+    % no additional shift is needed if the notes start before the text
+    \global\gre@dimen@bolshift = \gre@skip@temp@three\relax%
+  \else%
+    % as the \gre@dimen@bolshift is computed from skips, we compute it in 
+    % a skip temp registry, and then "cast" it into a dimen
+    % basic value for bolshift needs to incorporate -begindifference
+    \advance\gre@skip@temp@three by -#1\relax%
+    % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
+    % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef) 
+    % or that the lyrics are closer than minimalspaceatlinebeginning
+    \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
+    \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
+    \advance\gre@skip@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
+    \ifdim\gre@skip@temp@three < \gre@skip@temp@one %
+      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@three\relax%
+    \else%
+      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@one\relax%
+    \fi %
+  \fi%
   \gre@debugmsg{bolshift}{ bolshift = \the\gre@dimen@bolshift}%
   \relax %
 }
@@ -913,6 +923,7 @@
   \IfStrEq{#1}{braceshift}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{curlybraceaccentusshift}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{initialraise}{\gre@rubberfalse}{\relax}%
+  \IfStrEq{#1}{beforealterationspace}{\gre@rubberfalse}{\relax}%
 }%
 
 %% an aux function adapting the value #1 from the factor #2 to the factor #3

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -328,6 +328,8 @@
 
 % dimen keeping the shift computed with next function
 \newdimen\gre@dimen@bolshift
+% dimen which is used to add a bit extra to the previous one in the case where the first glyph is a flat or a natural
+\newdimen\gre@dimen@bolextra
 
 %% @desc Macro used in \GreSyllable. Sets \gre@skip@bolshift to the left kern that
 %%       should appear at the beginning of a line in case of a linebreak.
@@ -341,7 +343,7 @@
   \gre@skip@temp@three=\gre@skip@spaceafterlineclef\relax%
   \advance\gre@skip@temp@three by #1%
   % we don't want to kern more than clefwidth minus minimalspaceatlinebeginning
-  \gre@dimen@temp@one = \gre@dimen@clefwidth
+  \gre@dimen@temp@one = \gre@dimen@clefwidth\relax%
   \advance\gre@dimen@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
   \ifdim\gre@skip@temp@three <-\gre@dimen@temp@one %
     \gre@skip@temp@three=-\gre@dimen@temp@one %
@@ -356,6 +358,7 @@
   \else %
     \global\gre@dimen@bolshift=-\gre@skip@temp@three %
   \fi %
+  \global\advance\gre@dimen@bolshift by \gre@dimen@bolextra%
   \gre@debugmsg{bolshift}{ bolshift = \the\gre@dimen@bolshift}%
   \relax %
 }

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -538,6 +538,7 @@
   \gre@debugmsg{general}{}%
   #1%
   \gre@firstglyphtrue%
+  \gre@dimen@bolextra = 0pt\relax%
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}% we first get the width between the alignment point and the end of the syllable
   \gre@syllablenotes{#9}% we put the notes in a box, so that we have the width of it
   % now we calculate the begin difference, that is to say \gre@dimen@notesaligncenter - \gre@dimen@textaligncenter

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -92,8 +92,8 @@
 \grecreatedim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{1}%
 % space before a choral sign
 \grecreatedim{beforelowchoralsignspace}{0.04556 cm plus 0.00638 cm minus 0.00638 cm}{1}%
-% negative space, difference between the normal space between two notes and the space between a note and a flat
-\grecreatedim{beforealterationspace}{-0.32816 cm plus 0.01093 cm minus 0.01093 cm}{1}%
+% when bolshifts are enabled, minimal space between a clef at the beginning of the line and a leading alteration glyph (should be larger than clefflatspace so that a flatted clef can be distinguished from a flat which is part of the first glyph on a line, but also smaller than spaceafterlineclef, the distance from the clef to the first notes)
+\grecreatedim{beforealterationspace}{0.1 cm}{1}%
 % space between elements
 \grecreatedim{interelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{1}%
 % larger space between elements
@@ -164,7 +164,7 @@
 \grecreatedim{afterinitialshift}{0.2457 cm}{1}%
 % space before the initial
 \grecreatedim{beforeinitialshift}{0.2457 cm}{1}%
-% minimum space between beginning of line and first syllable text
+% when bolshifts are enabled, minimum space between beginning of line and first syllable text
 \grecreatedim{minimalspaceatlinebeginning}{0.05 cm}{1}%
 % space to force the initial width to.  Ignored when 0.
 \grecreatedim{manualinitialwidth}{0 cm}{1}%


### PR DESCRIPTION
Addressing #599

I've added an additional component (`bolextra`) to the `bolshift` which allows an initial alteration to be ignored when aligning the first notes of each line.  This works with the current setting for `minimalspaceatlinebeginning` but there are a couple of problems:
  1. if `minimalspaceatlinebeginning` is increased the lines which start with an alteration do not move
  2. if the initial alteration is a sharp, it overlaps with the clef.  i.e. there is not enough space for the alteration

I have also noticed that `minimalspaceatlinebeginning` has an upper limit on what is respected.  This makes me think that `bolshift` isn't being calculated correctly (at least in this aspect) and may be the source of the above two problems.

Any suggestions on improving this are appreciated.