### PR TITLE
Feature/ornamentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Changed
 - `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scalable` and `fixed`( instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
 - `\grescaledim` now accepts `scalable` as a keyword to turn on scalable (in keeping with the above change)
+- `gregoriotex.sty` and `gregoriosyms.sty` now check to make sure that they are not both loaded.  If `gregoriotex` detects that `gregoriosyms` is loaded, then an error is raised.  If `gregoriosyms` detects that `gregoriotex` is loaded, then the loading of `gregoriosyms` is silently aborted and compilation proceeds.
 
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.
 - The first word of the score is now passed to a macro that allow it to be styled from TeX.  The first word is passed to `\GreFirstWord#1` and is styled by changing the `firstword` style.
 - A new type of lyric centering, enabled with `\gresetlyriccentering{firstletter}`, which aligns the neume with the first letter of each syllable.
+- `\greornamentation` allows access to the two ornamentation glyphs.  The ability to access these two glyphs via `{\gregoriosymbolfont \char 75}` was broken by the new interface to the glyphs in greextra.
 
 ## [4.0.0-beta2] - 2015-08-26
 ### Fixed

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -52,6 +52,8 @@ Module gregoriotex warning: Line heights or variable brace lengths may have chan
 
 Gregorio\TeX{} two-pass processing is compatible with \texttt{latexmk}.
 
+If you only need the special symbols which Gregorio\TeX\ contains, and not the ability to include scores or musical glyphs, then you can load \texttt{gregoriosyms} instead of \texttt{gregoriotex}.  It supports all of the above options except those specifically related to scores.  \textbf{You should not try to load both packages}.
+
 \subsection{Commands}
 
 In general, commands should not be modified.  Exceptions are noted below.

--- a/tex/gregoriosyms.sty
+++ b/tex/gregoriosyms.sty
@@ -21,6 +21,9 @@
 \ProvidesPackage{gregoriosyms}
     [2015/08/26 v4.0.0-beta2 GregorioTeX symbols only.]% PARSE_VERSION_DATE_LTX
 
+% If gregoriotex has been loaded, then we need to abort the loading process of this package here in order to avoid some conflicts.
+\ifcsname gregoriotex@symbols@loaded\endcsname\endinput\fi%
+
 \RequirePackage{kvoptions}%
 \RequirePackage{ifluatex}%
 \RequirePackage{luatexbase}%

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -196,3 +196,17 @@
   \gre@deprecated{\protect\gresep}{\protect\greseparator}%
   \greseparator{#1}{#2}%
 }
+
+%%%%%%%%%%%
+%% Ornamentation
+%%%%%%%%%%%
+
+\gredefsizedsymbol{greOrnamentOne}{greextra}{Drawing1}%
+\gredefsizedsymbol{greOrnamentTwo}{greextra}{Drawing2}%
+
+\def\greornamentation#1#2{%
+  \ifcase#1\relax%
+  \or\greOrnamentOne{#2}%
+  \or\greOrnamentTwo{#2}%
+  \fi%
+}%

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -20,6 +20,10 @@
 \NeedsTeXFormat{LaTeX2e}%
 \ProvidesPackage{gregoriotex}%
     [2015/08/26 v4.0.0-beta2 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
+
+% If gregoriosyms has been loaded then there are going to be some conflicts in the definitions made in that package and this one.  In order to provide for a more informative error message, we check for that conflict right away
+\ifcsname gregoriotex@symbols@loaded\endcsname\gre@error{Loading gregoriotex after\MessageBreak gregoriosyms is not supported.  Please remove the\MessageBreak loading of gregoriosyms (its contents are loaded\MessageBreak by gregoriotex)}\fi%
+
 \RequirePackage{xcolor}%
 \RequirePackage{kvoptions}%
 \RequirePackage{ifluatex}%


### PR DESCRIPTION
This PR restores access to the ornamentation (which was broken by the new glyph interface) and prevents conflicts which arise from trying to load both `gregoriotex` and `gregoriosyms`.