### PR TITLE
Made it so that liquescence on a multi-stropha only affects the marked notes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `\grescaledim` now accepts `scalable` as a keyword to turn on scalable (in keeping with the above change)
 - Alterations are partially ignored when aligning lines on the notes (i.e. `\gresetbolshifts{enabled}`).  They are not allowed to get any closer to the clef than `beforealterationspace` and the lyrics are not allowed to get any closer to the left-hand margin than `minimalspaceatlinebeginning`, but other than that GregorioTeX will shift them left as much as possible to make the notes align `spaceafterlineclef` away from the clef.  Note that for the default values of these distances, only the natural is small enough to acheive true alignment.
 - `gregoriotex.sty` and `gregoriosyms.sty` now check to make sure that they are not both loaded.  If `gregoriotex` detects that `gregoriosyms` is loaded, then an error is raised.  If `gregoriosyms` detects that `gregoriotex` is loaded, then the loading of `gregoriosyms` is silently aborted and compilation proceeds.
+- Liquescence on a bistropha or tristropha will only appear on the note(s) marked by `<` in gabc, rather than on all notes in the figure.  This means that a figure like `(gsss<)` will only have a liquescent "tail" on the final note.  If you would like all notes to be liquescent for some reason, you can use a figure like `(gs<gs<gs<)` instead.
 
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -162,6 +162,10 @@ You can freely switch between the two behaviors within a TeX document.
 
 In order to better match the new command naming conventions, the third argument of `\grecreatedim` and `\grechangedim` should now be `scaling` or `fixed` instead of `1` or `0`, respectively.
 
+#### Liquescence on bistropha and tristropha
+
+In order to be more consistent, making a bistropha or tristropha liquescent by adding `<` in gabc will now only affect the note thus marked.  This means that a tristropha like `(gsss<)` will only show the final stropha as liquescent, which is different from the older behavior of making every stropha liquescent.  If you prefer the old behavior, mark every note explicitly as liquescent with something like `(gs<gs<gs<)`.
+
 ## 3.0
 ### TeX Live 2013
 

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -256,7 +256,7 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
         return "OriscusScapusLongqueue";
     case S_STROPHA:
         *type = AT_STROPHA;
-        if (glyph->u.notes.liquescentia == L_AUCTA) {
+        if (note->u.note.liquescentia == L_AUCTA) {
             return "StrophaAucta";
         }
         return "Stropha";


### PR DESCRIPTION
Fixes #623.

The tests that use bistropha and tristropha obviously break.  See gregorio-project/gregorio-test#28.

This is ready for review and merge if appropriate and satisfactory.