### PR TITLE
Added biginitialraise dimension to allow a separate shift for big initials.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ### Added
 - New distance, `initialraise`, which will lift (or lower, if negative) the initial.
+- New distance, `biginitialraise`, which will lift (or lower, if negative) the big initial.
 - The first word of the score is now passed to a macro that allow it to be styled from TeX.  The first word is passed to `\GreFirstWord#1` and is styled by changing the `firstword` style.
 - A new type of lyric centering, enabled with `\gresetlyriccentering{firstletter}`, which aligns the neume with the first letter of each syllable.
 - `\greornamentation` allows access to the two ornamentation glyphs.  The ability to access these two glyphs via `{\gregoriosymbolfont \char 75}` was broken by the new interface to the glyphs in greextra.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -92,6 +92,8 @@ This would have made the text which was wrapped with `<alt></alt>` in your gabc 
 
     \grechangestyle{abovelinetext}{\small\it}
 
+Additionally, if you had been raising the initial and big initial (i.e., with `\raisebox`) with `\greinitialformat` and `\grebiginitialformat`, you will not be able to do that with styles.  In order to raise the initial and big initial, respectively change the `initialraise` and `biginitialraise` dimensions.
+
 ### Centering scheme
 
 The gabc `centering-scheme` header is now deprecated and will disappear soon.  Use the `\grelyriccentering` command from TeX instead.  If you were using `centering-scheme: latine;` in gabc, now use `\grelyriccentering{vowel}` in the TeX file that includes the gabc.  If you were using `centering-scheme: english;` in gabc, now use `\grelyriccentering{syllable}` in the TeX file that includes the gabc.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1183,6 +1183,11 @@ Distance the initial will be raised by (by default the baseline for the initial 
 
 Default: \unit[0]{cm}
 
+\macroname{biginitialraise}{}{gsp-default.tex}
+Distance the big initial will be raised by (by default the baseline for the initial coincides with the baseline for the text below the staff).
+
+Default: \unit[0]{cm}
+
 
 \subsection{Penalties}\label{penalties}
 Penalties are used by \TeX\ to determine where line and page breaks should occur.  Gregorio\TeX\ modifies or defines a few of its own to help with that process in scores.

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -384,7 +384,7 @@
     \advance\gre@dimen@temp@five by -4\gre@dimen@stafflineheight\relax%
     \advance\gre@dimen@temp@five by -\gre@dimen@currenttranslationheight\relax%
     \advance\gre@dimen@temp@five by -\f@size pt%
-    \advance\gre@dimen@temp@five by \gre@dimen@initialraise\relax%
+    \advance\gre@dimen@temp@five by \gre@dimen@biginitialraise\relax%
     \ifx\gre@empty@biginitialformat\grebiginitialformat% DEPRECATED
       \ifvoid\gre@box@initial% keep this line
         \gre@debugmsg{initial}{fill big initial box}% keep this line

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -960,6 +960,7 @@
   \IfStrEq{#1}{braceshift}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{curlybraceaccentusshift}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{initialraise}{\gre@rubberfalse}{\relax}%
+  \IfStrEq{#1}{biginitialraise}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{beforealterationspace}{\gre@rubberfalse}{\relax}%
 }%
 

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -170,6 +170,8 @@
 \grecreatedim{manualinitialwidth}{0 cm}{scalable}%
 % distance to move the initial up by
 \grecreatedim{initialraise}{0 cm}{scalable}%
+% distance to move the big initial up by
+\grecreatedim{biginitialraise}{0 cm}{scalable}%
 % Space between lines in the annotation
 \grecreatedim{annotationseparation}{0.05cm}{scalable}%
 % Amount to raise (positive) or lower (negative) the annotations from the default position (base line of top annotation aligned with top line of staff)


### PR DESCRIPTION
Since you can style initials separately from big initials, I think the same should be true for the shift.

All the tests pass.

Please review and merge if acceptable.