### PR TITLE
Adapted GregorioTeX to the new version of LaTeX and corresponding luatexbase.

### DIFF
--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -70,13 +70,19 @@
 
 \AtBeginDocument{\IfStrEq{\gre@debug}{}{}{\typeout{GregorioTeX is in debug mode}\typeout{\gre@debug\space messages will be printed to the log.}}}%
 
-% Since TeXLive 2009, the extra primitives of LuaTeX have a luatex prefix, and are not
-% available without prefix. We mostly rely on \directlua that is still available
-% without prefix, but we also rely on the Omega primitives, that have a luatex
-% prefix in TeXLive 2009.
+% Depending on version of TeX / LaTeX, some primitives may or may not have a
+% luatex prefix, so we need to check and handle either
 
-\let\gre@localleftbox\luatexlocalleftbox%
-\let\gre@localrightbox\luatexlocalrightbox%
+\ifdefined\localleftbox%
+  \let\gre@localleftbox\localleftbox%
+\else%
+  \let\gre@localleftbox\luatexlocalleftbox%
+\fi%
+\ifdefined\localrightbox%
+  \let\gre@localrightbox\localrightbox%
+\else%
+  \let\gre@localrightbox\luatexlocalrightbox%
+\fi%
 % an attribute we put on the text nodes.
 % if it is 1, it means that there may be a dash here if this syllable is at the end of a line
 % if it is 2, it means that it's never useful to typeset a dash

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -214,7 +214,8 @@ local function init(arg, enable_height_computation)
   if enable_height_computation then
     new_line_heights = {}
 
-    local mcb_version = luatexbase.get_module_version('luatexbase-mcb')
+    local mcb_version = luatexbase.get_module_version and
+        luatexbase.get_module_version('luatexbase-mcb') or 9999
     if mcb_version and mcb_version > 0.6 then
       luatexbase.add_to_callback('finish_pdffile', write_greaux,
           'gregoriotex.write_greaux')


### PR DESCRIPTION
Fixes #629.

Caveats:

- This requires the fixes made for josephwright/ltluatexsupp#2 and josephwright/ltluatexsupp#4.
- There is a problem running our tests that I believe is a bug in fontspec (more likely that they have not yet updated for the new LaTeX).

In order to run tests, you need to add the following lines after loading fontspec to work around the fontspec bug (see wspr/fontspec#215):
```
\expandafter\let\csname xetex_suppressfontnotfounderror:D\endcsname=\suppressfontnotfounderror
\expandafter\let\csname luatex_prehyphenchar:D\endcsname=\prehyphenchar
\expandafter\let\csname luatex_posthyphenchar:D\endcsname=\posthyphenchar
\expandafter\let\csname luatex_preexhyphenchar:D\endcsname=\preexhyphenchar
\expandafter\let\csname luatex_postexhyphenchar:D\endcsname=\postexhyphenchar
```

(Note that this workaround uses the new luatex-prefix-less-names in the new LaTeX).

All tests run fine under vanilla TeX Live 2015 (to which I finally upgraded)

Please review and merge if satisfactory.