### PR TITLE
Corrected the sign positions on the final note of liquescent salicus glyphs.

### DIFF
--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -24,10 +24,6 @@
 
 #include "gregoriotex.h"
 
-/* TODO: The numbers in the comments are a vestige of the older code; I'm
- * leaving them here for now, in case the refactor missed an instance
- * somewhere, but the numbers should evenually be removed */
-
 /* (loose) naming convention, employing camel case to be TeX-csname-compliant:
  * {specific-glyph-shape}{note-position}{note-shape}{first-ambitus}{second-ambitus}
  */
@@ -753,7 +749,11 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
             h_episemus = VPOS_ABOVE;
             break;
         default:
-            note->gtex_offset_case = FinalConnectedVirga;
+            note->gtex_offset_case = last_note_case(glyph, FinalPunctum, note,
+                    false);
+            if (glyph->u.notes.liquescentia & L_DEMINUTUS) {
+                v_episemus = VPOS_ABOVE;
+            }
             h_episemus = VPOS_ABOVE;
             break;
         }


### PR DESCRIPTION
This is a missing part of #622.

While implementing #631, I found a bug in sign positions on last note of liquescent salicus glyphs, most noticeable with then the last note is deminutus.  This should fix it.

As this is a bug-fix for an as-yet unreleased change, I am not adding to the changelog.

Please review and merge if satisfactory.