### PR TITLE
Fixed incorrect inclusion of initial in the first letter centering argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Fixed
 - The spacing of manual in-line custos (`(f+)` in gabc) is now consistent with the spacing of automatic in-line custos (`(z0)` in gabc).  See [#642](https://github.com/gregorio-project/gregorio/issues/642).
+- When using first letter lyric centering and big initials, the initial is no longer incorrectly included in the first syllable.  See [#648](https://github.com/gregorio-project/gregorio/issues/648).  This is a fix for a bug in a new 4.0.0 feature, so this changelog entry should be removed when the change log is merged for the 4.0.0 release.
 
 
 ## [4.0.0-rc1] - 2015-10-08

--- a/src/characters.c
+++ b/src/characters.c
@@ -463,17 +463,7 @@ void gregorio_write_first_letter_alignment_text(const bool skip_initial,
     }
 
     /* go to the first character */
-    if (go_to_end_initial(&current_character)) {
-        if (!current_character->next_character) {
-            return;
-        }
-        if (skip_initial) {
-            /* move to the character after the initial */
-            current_character = current_character->next_character;
-        } else {
-            gregorio_go_to_first_character(&current_character);
-        }
-    }
+    gregorio_go_to_first_character(&current_character);
 
     begin(f, ST_SYLLABLE_INITIAL);
 
@@ -494,8 +484,20 @@ void gregorio_write_first_letter_alignment_text(const bool skip_initial,
             switch (current_character->cos.s.style) {
             case ST_CENTER:
             case ST_FORCED_CENTER:
-            case ST_INITIAL:
                 /* ignore */
+                break;
+            case ST_INITIAL:
+                if (skip_initial) {
+                    while (current_character) {
+                        if (!current_character->is_character
+                                && current_character->cos.s.type == ST_T_END
+                                && current_character->cos.s.style ==
+                                ST_INITIAL) {
+                            break;
+                        }
+                        current_character = current_character->next_character;
+                    }
+                } /* else ignore */
                 break;
             case ST_VERBATIM:
                 verb_or_sp(&current_character, ST_VERBATIM, f, printverb);


### PR DESCRIPTION
Fixes #648.

Please review and merge if satisfactory.

Note: the change log entry should be removed when the final change log entry for 4.0.0 is prepared.