### PR TITLE
Implemented a toggle-able forced hyphen for empty initial syllables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The spacing of manual in-line custos (`(f+)` in gabc) is now consistent with the spacing of automatic in-line custos (`(z0)` in gabc).  See [#642](https://github.com/gregorio-project/gregorio/issues/642).
 - Signs on the climacus praepunctis deminutus `(ghgf~)` neume are now positioned correctly.  See [#650]((https://github.com/gregorio-project/gregorio/issues/650)
 
+### Added
+- The ability to force a hyphen after an empty first syllable, enabled by default since this was the behavior prior to 4.0.  Version 4.0 has an improved spacing algorithm which will eliminate the hyphen if the notes for the first syllable are too close to the second.  To switch to this behavior, use `\gresetemptyfirstsyllablehyphen{auto}`.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#653](https://github.com/gregorio-project/gregorio/issues/653)).
+
 
 ## [4.0.0-rc1] - 2015-10-08
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -170,6 +170,10 @@ In order to better match the new command naming conventions, the third argument 
 
 In order to be more consistent, making a bistropha or tristropha liquescent by adding `<` in gabc will now only affect the note thus marked.  This means that a tristropha like `(gsss<)` will only show the final stropha as liquescent, which is different from the older behavior of making every stropha liquescent.  If you prefer the old behavior, mark every note explicitly as liquescent with something like `(gs<gs<gs<)`.
 
+### Empty first syllable hyphen
+
+Prior to version 4.0, GregorioTeX would put a hyphen below an empty first syllable (which happens when the first syllable consists only of the initial).  The spacing algorithm is improved in 4.0, but that eliminates the hyphen if there is not enough space between the note of the first syllable and the next syllable.  The `\gresetemptyfirstsyllablehyphen` command controls this behavior.  It defaults to `force`, which restores the pre-4.0 behavior, but may be changed to `auto` (i.e., `\gresetemptyfirstsyllablehyphen{auto}`) if you prefer the space-based behavior.
+
 ## 3.0
 ### TeX Live 2013
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -790,15 +790,22 @@ Macro to determine whether the last line of the score should be justified or not
 \subsubsection{Hyphenation}
 
 \macroname{\textbackslash gresethyphen}{\{\#1\}}{gregoriotex-main.tex}
-Tell Gregorio\TeX\ to when to place a hyphen between
-syllables in polysyllabic words in a score.  This is done by overriding \texttt{maximumspacewithoutdash} so subsequent changes to this dimension will override this command.
+Tells Gregorio\TeX\ how to place a hyphen between syllables in polysyllabic words in a score.  This is done by overriding \texttt{maximumspacewithoutdash} so subsequent changes to this dimension will override this command.
 
 \begin{argtable}
   \#1 & force & Hyphens will appear between all syllables in polysyllabic words.\\
-  & auto & Hyphens will appear based on the setting of \texttt{maximumspacewithoutdash}
+      & auto  & Hyphens will appear based on the setting of \texttt{maximumspacewithoutdash} (default)
 \end{argtable}
 
 \textbf{Nota Bene:} \verb=\gresethyphen{auto}= restores \texttt{maximumspacewithoutdash} to the value found in \textit{gsp-default.tex}.  If you have changed your score size, you may need to change this distance to a more appropriate value using \verb=\grechangedim=.
+
+\macroname{\textbackslash gresetemptyfirstsyllablehyphen}{\{\#1\}}{gregoriotex-syllable.tex}
+Tells Gregorio\TeX\ how to place a hyphen after an empty first syllable (\ie, when the first syllable consists only of the big initial).
+
+\begin{argtable}
+  \#1 & force & A hyphen will appear after an empty first syllable. (default)\\
+      & auto  & A hyphen will appear after an empty fiest syllable based on the setting of \texttt{maximumspacewithoutdash}
+\end{argtable}
 
 \macroname{\textbackslash greseteolhyphen}{\{\#1\}}{gregoriotex-main.tex}
 Marco to determine how much space the hyphen at the end of a line occupies for the purposes of spacing caluclations.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -330,6 +330,9 @@ Macro to typeset a flat.
       & 1       & Indicates the flat for a key change.\\
 \end{argtable}
 
+\macroname{\textbackslash GreForceHyphen}{}{gregoriotex-syllable.tex}
+Macro that indicates that a hyphen should be forced (if enabled) after the given syllable.
+
 \macroname{\textbackslash GreFuseTwo}{\#1\#2}{gregoriotex-main.tex}
 Macro for fusing two glyphs to create a larger neume.
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1210,7 +1210,11 @@ Boolean which indicates that the last line of the score should be justified.
 \macroname{\textbackslash ifgre@showclef}{}{gregoriotex-main.tex}
 Boolean which indicates that the clef should be visible.
 
+\macroname{\textbackslash gre@forceemptyfirstsyllablehyphen}{}{gregoriotex-syllable.tex}
+Boolean which indicates that a hyphen after an empty first syllable should be forced.
 
+\macroname{\textbackslash gre@forcehyphen}{}{gregoriotex-syllable.tex}
+Boolean which indicates that the hyphen after this syllable should be forced.
 
 
 \subsection{Boxes}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1213,8 +1213,8 @@ Boolean which indicates that the clef should be visible.
 \macroname{\textbackslash gre@forceemptyfirstsyllablehyphen}{}{gregoriotex-syllable.tex}
 Boolean which indicates that a hyphen after an empty first syllable should be forced.
 
-\macroname{\textbackslash gre@forcehyphen}{}{gregoriotex-syllable.tex}
-Boolean which indicates that the hyphen after this syllable should be forced.
+\macroname{\textbackslash gre@showhyphenafterthissyllable}{}{gregoriotex-syllable.tex}
+Boolean used by \verb=\GreSyllable= to decide if a hyphen should be shown after the syllable.
 
 
 \subsection{Boxes}

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2574,17 +2574,20 @@ static void write_fixed_text_styles(FILE *f, gregorio_character *syllable_text,
 static void gregoriotex_write_text(FILE *f, gregorio_character *text,
         bool *first_syllable)
 {
+    bool skip_initial = first_syllable && *first_syllable;
     if (text == NULL) {
         fprintf(f, "{}{}{}{}{}");
+        if (skip_initial) {
+            fprintf(f, "\\GreForceHyphen{}");
+        }
         return;
     }
     fprintf(f, "{");
-    gregorio_write_text(first_syllable && *first_syllable, text, f,
+    gregorio_write_text(skip_initial, text, f,
             (&gtex_write_verb), (&gtex_print_char), (&gtex_write_begin),
             (&gtex_write_end), (&gtex_write_special_char));
     fprintf(f, "}{");
-    gregorio_write_first_letter_alignment_text(
-            first_syllable && *first_syllable, text, f,
+    gregorio_write_first_letter_alignment_text(skip_initial, text, f,
             (&gtex_write_verb), (&gtex_print_char), (&gtex_write_begin),
             (&gtex_write_end), (&gtex_write_special_char));
     if (first_syllable) {
@@ -2593,6 +2596,29 @@ static void gregoriotex_write_text(FILE *f, gregorio_character *text,
     gregoriotex_ignore_style = gregoriotex_next_ignore_style;
     gregoriotex_next_ignore_style = ST_NO_STYLE;
     fprintf(f, "}");
+    if (skip_initial) {
+        /* Check to see if we need to force a hyphen (empty first syllable) */
+        for (; text; text = text->next_character) {
+            if (text->is_character) {
+                break;
+            } else if (text->cos.s.type == ST_T_BEGIN) {
+                if (text->cos.s.style == ST_VERBATIM ||
+                        text->cos.s.style == ST_SPECIAL_CHAR) {
+                    break;
+                } else if (text->cos.s.style == ST_INITIAL) {
+                    for (; text; text = text->next_character) {
+                        if (!text->is_character && text->cos.s.type == ST_T_END
+                                && text->cos.s.style == ST_INITIAL) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        if (!text) {
+            fprintf(f, "\\GreForceHyphen{}");
+        }
+    }
 }
 
 /*

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -518,6 +518,20 @@
   \gresetclivisalignment{special}%
 }%
 
+\newif\ifgre@forceemptyfirstsyllablehyphen%
+\gre@forceemptyfirstsyllablehyphentrue%
+\def\gresetemptyfirstsyllablehyphen#1{%
+  \IfStrEq{#1}{auto}%
+    {\gre@forceemptyfirstsyllablehyphenfalse}%
+    {\IfStrEq{#1}{force}%
+      {\gre@forceemptyfirstsyllablehyphentrue}%
+      {\gre@error{Unrecognized option for \protect\gresetlyriccentering}}%
+    }%
+}%
+
+\newif\ifgre@forcehyphen%
+\def\GreForceHyphen{\gre@forcehyphentrue}
+
 %% general macro : it will typeset the syllable : arguments are :
 % #1 : macro setting the letters of this syllable
 % #2 : reserved (unused)
@@ -536,7 +550,9 @@
   \gre@debugmsg{general}{}%
   \gre@debugmsg{general}{New syllable: \expandafter\unexpanded{#1}}%
   \gre@debugmsg{general}{}%
+  \gre@forcehyphenfalse%
   #1%
+  \ifgre@forceemptyfirstsyllablehyphen\else\gre@forcehyphenfalse\fi%
   \gre@firstglyphtrue%
   \gre@dimen@bolextra = 0pt\relax%
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}% we first get the width between the alignment point and the end of the syllable
@@ -603,6 +619,9 @@
     %
     \gre@debugmsg{ifdim}{ temp@skip@one > maximumspacewithoutdash}%
     \ifdim\gre@skip@temp@one > \gre@dimen@maximumspacewithoutdash\relax%
+      \gre@forcehyphentrue%
+    \fi
+    \ifgre@forcehyphen\relax%
       % if it's the last syllable of line, the hyphen will be \GreHyph
       \ifnum\gre@lastoflinecount=1\relax %
         \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart#3{\GreHyph}\relax}{#6}}}%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -529,8 +529,8 @@
     }%
 }%
 
-\newif\ifgre@forcehyphen%
-\def\GreForceHyphen{\gre@forcehyphentrue}
+\newif\ifgre@showhyphenafterthissyllable%
+\def\GreForceHyphen{\gre@showhyphenafterthissyllabletrue}
 
 %% general macro : it will typeset the syllable : arguments are :
 % #1 : macro setting the letters of this syllable
@@ -550,9 +550,9 @@
   \gre@debugmsg{general}{}%
   \gre@debugmsg{general}{New syllable: \expandafter\unexpanded{#1}}%
   \gre@debugmsg{general}{}%
-  \gre@forcehyphenfalse%
+  \gre@showhyphenafterthissyllablefalse%
   #1%
-  \ifgre@forceemptyfirstsyllablehyphen\else\gre@forcehyphenfalse\fi%
+  \ifgre@forceemptyfirstsyllablehyphen\else\gre@showhyphenafterthissyllablefalse\fi%
   \gre@firstglyphtrue%
   \gre@dimen@bolextra = 0pt\relax%
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}% we first get the width between the alignment point and the end of the syllable
@@ -619,9 +619,9 @@
     %
     \gre@debugmsg{ifdim}{ temp@skip@one > maximumspacewithoutdash}%
     \ifdim\gre@skip@temp@one > \gre@dimen@maximumspacewithoutdash\relax%
-      \gre@forcehyphentrue%
+      \gre@showhyphenafterthissyllabletrue%
     \fi
-    \ifgre@forcehyphen\relax%
+    \ifgre@showhyphenafterthissyllable\relax%
       % if it's the last syllable of line, the hyphen will be \GreHyph
       \ifnum\gre@lastoflinecount=1\relax %
         \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart#3{\GreHyph}\relax}{#6}}}%


### PR DESCRIPTION
Fixes #653.

I changed the wording a bit from #656 since this is now part of 4.0.

Please review and merge if satisfactory.