### PR TITLE
Fixed lost "endgroup" for first letter centering of empty syllables.

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -533,6 +533,10 @@ void gregorio_write_first_letter_alignment_text(const bool skip_initial,
             break;
         }
 
+        if (!current_character->next_character && first_letter_open) {
+            close_first_letter = first_letter_open;
+        }
+
         if (close_first_letter) {
             first_letter_open = false;
 


### PR DESCRIPTION
This is an edge case where the first syllable is empty (or has only the initial when initials are enabled).  The fifth argument to `\GreSetThisSyllable` was lost.  This corrects that bug.

Please review and merge if satisfactory.