### PR TITLE
Deprecated the gabc-version header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Removed
 - The TeXShop script for compiling gabc files.  Supplanted by the new autocompile feature of the package.
 
+### Deprecated
+- The meaningless `gabc-version` header in gabc (see [#664](https://github.com/gregorio-project/gregorio/issues/664)).
+
 
 ## [4.0.0-rc1] - 2015-10-08
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -174,6 +174,10 @@ In order to be more consistent, making a bistropha or tristropha liquescent by a
 
 Prior to version 4.0, GregorioTeX would put a hyphen below an empty first syllable (which happens when the first syllable consists only of the initial).  The spacing algorithm is improved in 4.0, but that eliminates the hyphen if there is not enough space between the note of the first syllable and the next syllable.  The `\gresetemptyfirstsyllablehyphen` command controls this behavior.  It defaults to `force`, which restores the pre-4.0 behavior, but may be changed to `auto` (i.e., `\gresetemptyfirstsyllablehyphen{auto}`) if you prefer the space-based behavior.
 
+### gabc-version header
+
+The gabc-version header has become meaningless.  It is now deprecated.  Please remove it from your gabc files if you had been using it.
+
 ## 3.0
 ### TeX Live 2013
 

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -786,14 +786,10 @@ arranger_definition:
 
 gabc_version_definition:
     GABC_VERSION attribute {
-        /* So far this handling of the version is rudimentary.  When
-         * we start supporting multiple input versions, it will become
-         * more complex.  For the moment, just issue a warning. */
-        if (strcmp ($2.text, GABC_CURRENT_VERSION) != 0) {
-            gregorio_message(_("gabc-version is not the current one "
-                    GABC_CURRENT_VERSION " ; there may be problems"),
-                    "det_score", VERBOSITY_WARNING, 0);
-        }
+        /* Deprecated */
+        gregorio_message("\"gabc-version\" header is deprecated and will be "
+                "ignored.", "gabc_score_determination_parse",
+                VERBOSITY_DEPRECATION, 0);
         free($2.text);
     }
     ;


### PR DESCRIPTION
Fixes #664.

No tests change.

Please review and merge if satisfactory.