### PR TITLE
Corrected end-of-word detection when there is no whitespace at end-of-file.

### DIFF
--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -25,12 +25,14 @@
 #include <string.h>
 #include "struct.h"
 #include "messages.h"
+#include "bool.h"
 
 #include "gabc.h"
 #include "gabc-score-determination.h"
 #include "gabc-score-determination-y.h"
 
 static unsigned char style_stack = 0;
+static bool eof_found = false;
 
 #define YY_NO_INPUT
 
@@ -411,6 +413,14 @@ semicolon. */
 <notes>\)(\ |\t|\n|\r)+ {
         BEGIN(score);
         return CLOSING_BRACKET_WITH_SPACE;
+    }
+<<EOF>> {
+        if (!eof_found) {
+            eof_found = true;
+            return END_OF_FILE;
+        } else {
+            yyterminate();
+        }
     }
 %%
 

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -660,7 +660,7 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
 %token GABC_COPYRIGHT SCORE_COPYRIGHT OCCASION METER COMMENTARY ARRANGER
 %token GABC_VERSION USER_NOTES DEF_MACRO ALT_BEGIN ALT_END CENTERING_SCHEME
 %token TRANSLATION_CENTER_END BNLBA ENLBA EUOUAE_B EUOUAE_E NABC_CUT NABC_LINES
-%token LANGUAGE
+%token LANGUAGE END_OF_FILE
 
 %%
 
@@ -1004,7 +1004,7 @@ note:
         voice=0;
         nabc_state=0;
     }
-    | NOTES CLOSING_BRACKET_WITH_SPACE {
+    | NOTES closing_bracket_with_space {
         if (voice<number_of_voices) {
             gabc_y_add_notes($1.text, @1);
             free($1.text);
@@ -1058,12 +1058,18 @@ note:
         voice=0;
         nabc_state=0;
     }
-    | CLOSING_BRACKET_WITH_SPACE {
+    | closing_bracket_with_space {
         elements[voice]=NULL;
         voice=0;
         nabc_state=0;
         update_position_with_space();
     }
+    ;
+
+closing_bracket_with_space:
+    CLOSING_BRACKET_WITH_SPACE
+    | CLOSING_BRACKET_WITH_SPACE END_OF_FILE
+    | CLOSING_BRACKET END_OF_FILE
     ;
 
 style_beginning:


### PR DESCRIPTION
Fixes #675.

Tests pass once the affected test expectation is updated.
 
Please review and merge if satisfactory.