### PR TITLE
attempt to fix 663

### DIFF
--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1135,8 +1135,8 @@
       \fi %
     \fi %
   \fi %
-  %\gre@penalty{\greendafterbarpenalty }\relax 
-  %\global\gre@dimen@enddifference=0pt 
+  %\gre@penalty{\greendafterbarpenalty }\relax
+  %\global\gre@dimen@enddifference=0pt
   \relax %
 }%
 
@@ -1273,7 +1273,7 @@
   \or% case 1
     \gre@skip@temp@four = \gre@dimen@zerowidthspace\relax%
   \or% case 2
-    \gre@skip@temp@four = \gre@skip@alterationspace\relax%
+    \gre@skip@temp@four = \gre@dimen@alterationspace\relax%
   \or% case 3
     \gre@skip@temp@four = \gre@skip@punctuminclinatumshift\relax%
   \or% case 4

--- a/tex/gregoriotex-nabc.lua
+++ b/tex/gregoriotex-nabc.lua
@@ -209,7 +209,7 @@ local add_ls = function(base, pre, ls, position, glyphbox, lsbox, baseraise, lwi
     if position == 2 then
       raise = glyphbox.height + lsbox.depth + baseraise
     else
-      raise = -glyphbox.depth - lsbox.height + baseraise 
+      raise = -glyphbox.depth - lsbox.height + baseraise
     end
     local kern1 = -math.max(glyphbox.width, lwidths[11])/2 - lwidths[position]/2 + curlwidths[position]
     curlwidths[position] = curlwidths[position] + lsbox.width

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -37,7 +37,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% macros for discretionaries
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% 
+%
 % In order to avoid clef change at beginning or end of line, we use discretionaries
 % for clef change, or even with more complex data (z0::c3 for instance). The problem
 % with discretionaries is that:
@@ -154,7 +154,7 @@
 }%
 
 % macro that typesets the key
-% arguments are : 
+% arguments are :
 %% #1: the type of the key : c or f
 %% #2: the line of the key (1 is the lowest)
 %% #3: if we must use small key characters (inside a line) or not 0: if not inside, 1 if inside
@@ -1664,14 +1664,14 @@
   \ifnum#4=0\relax %
     % we try to avoid line breaking after a flat or a natural
     \GreNoBreak %
-    \gre@skip@temp@four = \gre@skip@alterationspace\relax%
+    \gre@skip@temp@four = \gre@dimen@alterationspace\relax%
     \ifgre@firstglyph%
       \gre@debugmsg{bolshift}{making adjustments for leading alteration}%
       \global\advance\gre@dimen@notesaligncenter by \wd\gre@box@temp@width %
       \global\advance\gre@dimen@notesaligncenter by \dimexpr\gre@skip@temp@four\relax %
       \kern\gre@skip@temp@four %
       \global\gre@dimen@bolextra = \wd\gre@box@temp@width%
-      \gre@skip@temp@four = \gre@skip@alterationspace\relax%
+      \gre@skip@temp@four = \gre@dimen@alterationspace\relax%
       \global\advance\gre@dimen@bolextra by \dimexpr\gre@skip@temp@four\relax%
       \gre@debugmsg{bolshift}{bolextra: \the\gre@dimen@bolextra}%
     \else %
@@ -1730,7 +1730,7 @@
       }%
       {\gre@error{Unrecognized option for \protect\gresetpunctumcavum}}%
     }%
-}%	
+}%
 
 
 \def\UseAlternatePunctumCavum{%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -218,7 +218,7 @@
 %% @uses \gre@dimen@enddifference
 %% @uses \gre@dimen@nextbegindifference
 %%
-%% Pseudo-code: 
+%% Pseudo-code:
 %%  min_text_dist = same_word ? 0 : space_inter_words
 %%  if (no_txt_under_prev) :
 %%     tmp = cur_end_diff > 0 ? 0 : -cur_end_diff
@@ -346,12 +346,12 @@
     % no additional shift is needed if the notes start before the text
     \global\gre@dimen@bolshift = \gre@skip@temp@three\relax%
   \else%
-    % as the \gre@dimen@bolshift is computed from skips, we compute it in 
+    % as the \gre@dimen@bolshift is computed from skips, we compute it in
     % a skip temp registry, and then "cast" it into a dimen
     % basic value for bolshift needs to incorporate -begindifference
     \advance\gre@skip@temp@three by -#1\relax%
     % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
-    % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef) 
+    % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef)
     % or that the lyrics are closer than minimalspaceatlinebeginning
     \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
     \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
@@ -497,7 +497,7 @@
   \global\multiply\gre@dimen@glyphraisevalue by \the\gre@factor %
   \global\multiply\gre@dimen@glyphraisevalue by \the\gre@count@temp@three %
   \gre@dimen@addedraisevalue= 0 sp%
-  \ifcase#2 % 
+  \ifcase#2 %
   \or\or\or%3: if it is a vertical episema on a line, we shift it a bit higher, so that it's more beautiful
     \ifgre@isonaline%
       \gre@dimen@addedraisevalue=7250 sp%
@@ -513,7 +513,7 @@
       \gre@dimen@addedraisevalue=-6900 sp%
       \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
       \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
-    \else % 
+    \else %
       \gre@dimen@addedraisevalue=-2200 sp%
       \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
       \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
@@ -796,7 +796,7 @@
 \def\grecreatedim#1#2#3{%
   \gre@dimension{#1}{#2}
   \csname newif\expandafter\endcsname\csname ifgre@scale@#1\endcsname%
-  \IfStrEq{#3}{1}%	
+  \IfStrEq{#3}{1}%
     {\gre@deprecated{A numerical (1) last argument for \protect\grecreatedim}{'scalable'}%
     \grescaledim{#1}{true}}%
     {\IfStrEq{#3}{0}%
@@ -951,6 +951,7 @@
   \IfStrEq{#1}{curlybraceaccentusshift}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{initialraise}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{beforealterationspace}{\gre@rubberfalse}{\relax}%
+  \IfStrEq{#1}{alterationspace}{\gre@rubberfalse}{\relax}%
 }%
 
 %% an aux function adapting the value #1 from the factor #2 to the factor #3

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -133,7 +133,7 @@
     \global\gre@firstglyphfalse%
   \fi%
   %\gre@dimen@lastglyphwidth=\gre@dimen@temp@three
-  %#5\relax 
+  %#5\relax
   #6\relax %
   \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \relax%
@@ -261,7 +261,7 @@
   \relax %
 }%
 
-% this is the function that we call when we try to determine the next aligncenter of the notes. In this case we call this function with normal arguments if there is no flat nor natural ; we call it with argument + 20 if there is a flat and argument + 40 if there is a natural... I know this is dirty... but... this is TeX...
+% this is the function that we call when we try to determine the next aligncenter of the notes. In this case we call this function with normal arguments if there is no flat nor natural ; we call it with argument + 20 if there is a flat and argument + 40 if there is a natural, +60 with a sharp
 \def\gre@calculate@nextnotesaligncenter#1{%
   \ifnum#1<20\relax %
     \gre@calculate@simplenotesaligncenter{#1}{1}%
@@ -292,6 +292,7 @@
       \fi%
     \fi %
     \advance\gre@dimen@temp@five by \wd\gre@box@temp@width %
+    \advance\gre@dimen@temp@five by \gre@dimen@alterationspace %
     \global\gre@dimen@notesaligncenter=\gre@dimen@temp@five %
   \fi %
   \relax %
@@ -340,9 +341,9 @@
 \newif\ifgre@boxing%
 \gre@boxingfalse%
 
-% 
+%
 % Helper macros for fixing text in rare cases
-% 
+%
 
 % the macro we call with all normal text
 \def\gre@textnormal#1{%
@@ -540,7 +541,7 @@
 % TODO: find another system for the end syllable
 % #9 : glyphs : all the notes
 % the three next parameters are to put an hyphen if necessary, they can be empty for end of words
-% #5 : macros setting next syllable letters of the next syllable 
+% #5 : macros setting next syllable letters of the next syllable
 % #6 : the line:char:column for a textedit link
 % #7 : alignment type of the first next glyph
 % #8 : other macros (translation, double text, etc.) that don't fit in the limitation of the number of arguments
@@ -578,7 +579,7 @@
     \ifgre@beginningofscore%
       \gre@beginningofscorefalse%
     \else%
-      % we don't want to shift right inside a discretionary 
+      % we don't want to shift right inside a discretionary
       \ifnum\gre@insidediscretionary=0\relax%
         \kern\gre@dimen@bolshift\relax%
       \fi%
@@ -777,7 +778,7 @@
   \gre@debugmsg{ifdim}{ wd(gre@box@syllabletext) = 0pt}%
   \ifdim\wd\gre@box@syllabletext = 0 pt\relax %
     % the most difficult case : when there is nothing to write
-    % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces : 
+    % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces :
     %% 1/ the minimal space between a note and the bar + the width of the bar + the minimal space between the bar and the note (that's the global idea, in fact there are nuances) : we assign skip@temp@three to it
     %% 2/ enddifference + begindifference + space between notes and word : we assign skip@temp@two to it
     \gre@skip@temp@three=\gre@skip@notebarspace\relax%
@@ -852,14 +853,14 @@
         \gre@debugmsg{ifdim}{ temp@skip@two > -wd(gre@box@syllablenotes)}%
         \ifdim\gre@skip@temp@two > -\wd\gre@box@syllablenotes %
           \kern\gre@skip@temp@two %
-        \else % \ifdim\gre@dimen@temp@five > -\wd\gre@box@syllablenotes 
+        \else % \ifdim\gre@dimen@temp@five > -\wd\gre@box@syllablenotes
           \gre@skip@temp@one = -\wd\gre@box@syllablenotes %
           \gre@hskip\gre@skip@temp@one %
         \fi %
       \fi %
     \fi %
   % then the most simple : the case where there is something to write under the bar. We just need to adjust the spaces.
-  \else %ifdim\wd\gre@box@syllabletext = 0 pt 
+  \else %ifdim\wd\gre@box@syllabletext = 0 pt
     #8\relax %
     \raise\gre@dimen@textlower \copy\gre@box@syllabletext %
     \ifgre@mustdotranslationcenterend%

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -52,7 +52,7 @@
 % Workaround for bug 842 (http://tracker.luatex.org/view.php?id=842)
 % see http://tug.org/pipermail/luatex/2013-July/004516.html
 % The idea is that we use discretionaries (explicit hyphens, though more than hyphens in our case) for clef changes, and we need to give them a special penalty, which is not taken into account if pretolerance is > -1 on LuaTeX < 0.80. For a more detailed explanation see http://tug.org/pipermail/luatex/2013-July/004516.html.
-\ifnum\the\luatexversion < 78\relax % 
+\ifnum\the\luatexversion < 78\relax %
   \global\def\grepretolerance{-1}%
 \else %
   \global\def\grepretolerance{\pretolerance}%
@@ -87,7 +87,7 @@
 % space between glyphs in the same element
 \grecreatedim{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between an alteration (flat or natural) and the next glyph
-\grecreatedim{alterationspace}{0.07747 cm plus 0.01276 cm minus 0.00455 cm}{scalable}%
+\grecreatedim{alterationspace}{0.07747 cm}{scalable}%
 % space between a clef and a flat (for clefs with flat)
 \grecreatedim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
 % space before a choral sign


### PR DESCRIPTION
#663 is clearly a bug to me, this is an attempt at fixing it. Before going further, I'd like to know your opinion on two points:

- I think it should be fixed for 4.0, the core of the fix (line 295 of gregoriotex-syllable.tex) is quite small
- I changed alterationspace to be a dimen instead of a skip, as I think everything involved in nextbegin different should be a dimen: if a skip gets much tighter than expected, the result will be quite bad in terms of spacing of the text of two syllables of the same word: if they are close, they might even sometimes collapse a little, but this change may be more relevant in 4.1...

Also, the diff is not really readable due to my text editor automatically removing some spurious spaces, sorry!