### PR TITLE
Fixed incorrect detection of note-in-same-glyph for episema height adjustment.

### DIFF
--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -1114,15 +1114,25 @@ static __inline void end_h_episema(height_computation *const h,
                 h->height = proposed_height;
             }
         }
-        /* end->previous checks that it's within the same glyph */
-        if (end && end->type == GRE_NOTE && end->previous
-                && end->previous->type == GRE_NOTE
-                && is_connected_left(h->get_size(end))
-                && !has_space_to_left(end) && h->last_connected_note
-                && is_connected_right(h->get_size(h->last_connected_note))) {
-            proposed_height = end->u.note.pitch + h->vpos;
-            if (h->is_better_height(proposed_height, h->height)) {
-                h->height = proposed_height;
+        if (end && end->type == GRE_NOTE) {
+            gregorio_note *note;
+            /* this loop checks that it's within the same glyph */
+            for (note = end->previous; note; note = note->previous) {
+                if (note == h->start_note) {
+                    if (is_connected_left(h->get_size(end))
+                            && h->last_connected_note
+                            && h->last_connected_note->next
+                            && h->last_connected_note->next->type == GRE_NOTE
+                            && !has_space_to_left(h->last_connected_note->next)
+                            && is_connected_right(h->get_size(
+                                    h->last_connected_note))) {
+                        proposed_height = end->u.note.pitch + h->vpos;
+                        if (h->is_better_height(proposed_height, h->height)) {
+                            h->height = proposed_height;
+                        }
+                    }
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #693.

Please review and merge if satisfactory.  If this doesn't make the 4.0.0 release, it is ready for the 4.0.1 release.

Current tests pass, but I added some tests to exercise this change.