### PR TITLE
Applied fixes suggested by Karl Berry for integration into TeX Live.

### DIFF
--- a/src/bool.h
+++ b/src/bool.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header provides a minimum of C11-like bool functionality.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 
  * This file is part of Gregorio.

--- a/src/characters.c
+++ b/src/characters.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX.
+ * This file contains functions that deal with lyrics and styles.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -42,6 +45,7 @@
 #include "unicode.h"
 #include "characters.h"
 #include "messages.h"
+#include "support.h"
 #include "utf8strings.h"
 #include "vowel/vowel.h"
 
@@ -84,11 +88,7 @@ static bool read_vowel_rules(char *const lang) {
     char buf[PATH_MAX];
     size_t capacity = 16, size = 0;
     
-    if (!(filenames = malloc(capacity * sizeof(char *)))) {
-        gregorio_messagef("read_patterns", VERBOSITY_FATAL, 0,
-                _("unable to allocate memory"));
-        return false;
-    }
+    filenames = gregorio_malloc(capacity * sizeof(char *));
 
     file = popen("kpsewhich " VOWEL_FILE, "r");
     if (!file) {
@@ -100,15 +100,11 @@ static bool read_vowel_rules(char *const lang) {
     while (!feof(file) && !ferror(file) && fgets(buf, PATH_MAX, file)) {
         rtrim(buf);
         if (strlen(buf) > 0) {
-            filenames[size++] = strdup(buf);
+            filenames[size++] = gregorio_strdup(buf);
             if (size >= capacity) {
                 capacity <<= 1;
-                if (!(filenames = realloc(filenames,
-                                capacity * sizeof(char *)))) {
-                    gregorio_messagef("read_patterns", VERBOSITY_FATAL, 0,
-                            _("unable to allocate memory"));
-                    return false;
-                }
+                filenames = gregorio_realloc(filenames,
+                                capacity * sizeof(char *));
             }
         } else {
             gregorio_messagef("read_patterns", VERBOSITY_WARNING, 0,
@@ -216,7 +212,7 @@ static void determine_center(gregorio_character *character, int *start,
     if (count == 0) {
         return;
     }
-    subject = (grewchar *)malloc((count + 1) * sizeof(grewchar));
+    subject = (grewchar *)gregorio_malloc((count + 1) * sizeof(grewchar));
     for (count = 0, ch = character; ch; ch = ch->next_character) {
         if (ch->is_character) {
             subject[count ++] = ch->cos.character;
@@ -268,7 +264,7 @@ static void style_push(det_style **current_style, unsigned char style)
     if (!current_style) {
         return;
     }
-    element = (det_style *) malloc(sizeof(det_style));
+    element = (det_style *) gregorio_malloc(sizeof(det_style));
     element->style = style;
     element->previous_style = NULL;
     element->next_style = (*current_style);
@@ -359,7 +355,7 @@ static __inline void verb_or_sp(gregorio_character **ptr_character,
         ptr_character = &current_character;
         return;
     }
-    text = (grewchar *) malloc((i + 1) * sizeof(grewchar));
+    text = (grewchar *) gregorio_malloc((i + 1) * sizeof(grewchar));
     current_character = begin_character;
     while (j < i) {
         if (current_character->is_character) {
@@ -708,7 +704,7 @@ static void insert_style_before(unsigned char type,
         unsigned char style, gregorio_character *current_character)
 {
     gregorio_character *element =
-            (gregorio_character *) malloc(sizeof(gregorio_character));
+            (gregorio_character *) gregorio_malloc(sizeof(gregorio_character));
     element->is_character = 0;
     element->cos.s.type = type;
     element->cos.s.style = style;
@@ -732,7 +728,7 @@ static void insert_style_after(unsigned char type, unsigned char style,
         gregorio_character **current_character)
 {
     gregorio_character *element =
-            (gregorio_character *) malloc(sizeof(gregorio_character));
+            (gregorio_character *) gregorio_malloc(sizeof(gregorio_character));
     element->is_character = 0;
     element->cos.s.type = type;
     element->cos.s.style = style;
@@ -750,7 +746,7 @@ static void insert_char_after(grewchar c,
         gregorio_character **current_character)
 {
     gregorio_character *element =
-            (gregorio_character *) malloc(sizeof(gregorio_character));
+            (gregorio_character *) gregorio_malloc(sizeof(gregorio_character));
     element->is_character = 1;
     element->cos.character = c;
     element->next_character = (*current_character)->next_character;

--- a/src/characters.h
+++ b/src/characters.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the lyric handling data structures and entry points.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header wraps the generated config_.h to provide version macros.
+ *
  * Gregorio configuration headers.
  *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX.
+ * This file provides functions to dump out Gregorio structures.
+ *
  * Copyright (C) 2007-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX.
+ * This file provides functions for determining elements from notes.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file provides functions for determining glyphs from notes.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -214,7 +214,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ub:[01]\{\] {
@@ -229,7 +229,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreUnderBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     underbrace_var, char_for_brace, underbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocb:[01]\{\] {
@@ -245,7 +245,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{0}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocba:[01]\{\] {
@@ -261,7 +261,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{1}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ob:[01]\}\] {
@@ -280,7 +280,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ub:[01]\}\] {
@@ -294,7 +294,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", underbrace_var,
                     char_for_brace);
             underbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocb:[01]\}\] {
@@ -313,7 +313,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocba:[01]\}\] {
@@ -332,33 +332,33 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[nm[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[3]-'0']) {
             gregorio_add_texverb_to_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[3]-'0']));
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[3]-'0']));
         } else error();
     }
 <INITIAL>\[gm[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[3]-'0']) {
             gregorio_add_texverb_as_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
             GRE_TEXVERB_GLYPH, &notes_lloc);
         } else error();
     }
 <INITIAL>\[em[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[3]-'0']) {
             gregorio_add_texverb_as_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
             GRE_TEXVERB_ELEMENT, &notes_lloc);
         } else error();
     }
 <INITIAL>\[altm[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[5]-'0']) {
             gregorio_add_texverb_as_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[5]-'0']),
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[5]-'0']),
             GRE_TEXVERB_ELEMENT, &notes_lloc);
         } else error();
     }
@@ -384,63 +384,65 @@ static __inline void add_alteration(const gregorio_type type) {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <underbrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreUnderBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <overcurlybrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{0}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <overcurlyaccentusbrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{1}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <choralsign>[^\]]+ {
         gregorio_add_cs_to_note(&current_note,
-                strdup(gabc_notes_determination_text), false);
+                gregorio_strdup(gabc_notes_determination_text), false);
     }
 <choralnabc>[^\]]+ {
         gregorio_add_cs_to_note(&current_note,
-                strdup(gabc_notes_determination_text), true);
+                gregorio_strdup(gabc_notes_determination_text), true);
     }
 <texverbnote>[^\]]+ {
         gregorio_add_texverb_to_note(&current_note,
-                strdup(gabc_notes_determination_text));
+                gregorio_strdup(gabc_notes_determination_text));
     }
 <texverbglyph>[^\]]+ {
         gregorio_add_texverb_as_note(&current_note,
-                strdup(gabc_notes_determination_text), GRE_TEXVERB_GLYPH,
-                &notes_lloc);
+                gregorio_strdup(gabc_notes_determination_text),
+                GRE_TEXVERB_GLYPH, &notes_lloc);
     }
 <texverbelement>[^\]]+ {
         gregorio_add_texverb_as_note(&current_note,
-                strdup(gabc_notes_determination_text), GRE_TEXVERB_ELEMENT,
-                &notes_lloc);
+                gregorio_strdup(gabc_notes_determination_text),
+                GRE_TEXVERB_ELEMENT, &notes_lloc);
     }
 <alt>[^\]]+ {
         gregorio_add_texverb_as_note(&current_note,
-                strdup(gabc_notes_determination_text), GRE_ALT, &notes_lloc);
+                gregorio_strdup(gabc_notes_determination_text), GRE_ALT,
+                &notes_lloc);
     }
 <texverbnote,texverbglyph,texverbelement,choralsign,choralnabc,alt,overcurlyaccentusbrace,overcurlybrace,overbrace,underbrace>\] {
         BEGIN(INITIAL);
     }
 \{  {
-        gregorio_add_texverb_as_note(&current_note, strdup("\\hbox to 0pt{"),
-                GRE_TEXVERB_ELEMENT, &notes_lloc);
+        gregorio_add_texverb_as_note(&current_note,
+                gregorio_strdup("\\hbox to 0pt{"), GRE_TEXVERB_ELEMENT,
+                &notes_lloc);
     }
 \}  {
         gregorio_add_texverb_as_note(&current_note,
-                strdup("\\hss%\n}%\n\\GreNoBreak\\relax "), GRE_TEXVERB_ELEMENT,
-                &notes_lloc);
+                gregorio_strdup("\\hss%\n}%\n\\GreNoBreak\\relax "),
+                GRE_TEXVERB_ELEMENT, &notes_lloc);
     }
 [a-m]\+ {
         gregorio_add_manual_custos_as_note(&current_note,

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the note parser.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc-score-determination.h
+++ b/src/gabc/gabc-score-determination.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header shares definitions between the score parser and lexer.
+ *
  * Gregorio score determination in gabc input.
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the score lexer.
+ *
  * Gregorio score determination in gabc input.
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "struct.h"
 #include "messages.h"
+#include "support.h"
 
 #include "gabc.h"
 #include "gabc-score-determination.h"
@@ -123,7 +124,8 @@ semicolon. */
         return COLON;
     }
 <attribute>[^;\n\r]*(;[^;\n\r]+)*([\n\r]+[^;]*(;[^;]+)*)? {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return ATTRIBUTE;
     }
 <attribute>;(;|[\n\r]+) {
@@ -234,7 +236,8 @@ semicolon. */
                 gabc_score_determination_text[0]);
     }
 <score>[^\{\}\(\[\]<%]+ {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <score,style><i> {
@@ -328,7 +331,8 @@ semicolon. */
         return SP_END;
     }
 <style>[^<\{\}]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <score>\% {
@@ -353,11 +357,13 @@ semicolon. */
         return VERB_END;
     }
 <verb>[^<]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <verb,style,score,alt>< {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <score,style>\{ {
@@ -371,7 +377,8 @@ semicolon. */
         return ALT_BEGIN;
     }
 <alt>[^<]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <alt><\/alt> {
@@ -398,7 +405,8 @@ semicolon. */
         return OPENING_BRACKET;
     }
 <notes>[^&|\)]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return NOTES;
     }
 <notes>& {

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -637,7 +637,7 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
             current_element->nabc = (char **) gregorio_calloc (nabc_lines,
                     sizeof (char *));
         }
-        current_element->nabc[nabc_state-1] = strdup(notes);
+        current_element->nabc[nabc_state-1] = gregorio_strdup(notes);
         current_element->nabc_lines = nabc_state;
     }
 }

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the score parser.
+ *
  * Gregorio score determination in gabc input.
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
@@ -35,6 +38,7 @@
 #include "unicode.h"
 #include "messages.h"
 #include "characters.h"
+#include "support.h"
 #include "sha1.h"
 #include "plugins.h"
 #include "gabc.h"
@@ -335,7 +339,7 @@ static void end_definitions(void)
     }
     /* voice is now voice-1, so that it can be the index of elements */
     voice = 0;
-    elements = (gregorio_element **) malloc(number_of_voices *
+    elements = (gregorio_element **) gregorio_malloc(number_of_voices *
             sizeof(gregorio_element *));
     for (i = 0; i < number_of_voices; i++) {
         elements[i] = NULL;
@@ -630,7 +634,7 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
                     "happen!"), "gabc_y_add_notes", VERBOSITY_FATAL, 0);
         }
         if (!current_element->nabc) {
-            current_element->nabc = (char **) calloc (nabc_lines,
+            current_element->nabc = (char **) gregorio_calloc (nabc_lines,
                     sizeof (char *));
         }
         current_element->nabc[nabc_state-1] = strdup(notes);

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file provides functions for writing gabc from Gregorio structures.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc.h
+++ b/src/gabc/gabc.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes gabc-format handling data structures and entry points.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains the logic for positioning signs on neumes.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains functions for writing GregorioTeX from Gregorio structures.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gregoriotex/gregoriotex.h
+++ b/src/gregoriotex/gregoriotex.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes GregorioTeX writing data structures and entry points.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/messages.c
+++ b/src/messages.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains functions for logging messages, warnings, and errors.
+ *
  * Copyright (C) 2009-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/messages.h
+++ b/src/messages.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the message logging functions.
+ *
  * Copyright (C) 2009-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -1,5 +1,6 @@
 /*
- * Gregorio format support headers.
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the "main" entry points for reading and writing data.
  *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 

--- a/src/struct.c
+++ b/src/struct.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the Gregorio data structures.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -45,18 +48,13 @@
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"
+#include "support.h"
 #include "characters.h"
 
 static gregorio_note *create_and_link_note(gregorio_note **current_note,
         const gregorio_scanner_location *const loc)
 {
-    gregorio_note *note = calloc(1, sizeof(gregorio_note));
-    if (!note) {
-        gregorio_message(_("error in memory allocation"),
-                         "create_and_link_note", VERBOSITY_FATAL, 0);
-        return NULL;
-    }
-
+    gregorio_note *note = gregorio_calloc(1, sizeof(gregorio_note));
     note->previous = *current_note;
     note->next = NULL;
     if (*current_note) {
@@ -236,7 +234,7 @@ void gregorio_add_texverb_to_note(gregorio_note **current_note, char *str)
     if (*current_note) {
         if ((*current_note)->texverb) {
             len = strlen((*current_note)->texverb) + strlen(str) + 1;
-            res = malloc(len * sizeof(char));
+            res = gregorio_malloc(len * sizeof(char));
             strcpy(res, (*current_note)->texverb);
             strcat(res, str);
             free((*current_note)->texverb);
@@ -626,13 +624,7 @@ static void gregorio_free_notes(gregorio_note **note)
 
 static gregorio_glyph *create_and_link_glyph(gregorio_glyph **current_glyph)
 {
-    gregorio_glyph *glyph = calloc(1, sizeof(gregorio_glyph));
-    if (!glyph) {
-        gregorio_message(_("error in memory allocation"),
-                         "create_and_link_glyph", VERBOSITY_FATAL, 0);
-        return NULL;
-    }
-
+    gregorio_glyph *glyph = gregorio_calloc(1, sizeof(gregorio_glyph));
     glyph->previous = *current_glyph;
     glyph->next = NULL;
     if (*current_glyph) {
@@ -747,13 +739,7 @@ static void gregorio_free_glyphs(gregorio_glyph **glyph)
 static gregorio_element *create_and_link_element(gregorio_element
                                                  **current_element)
 {
-    gregorio_element *element = calloc(1, sizeof(gregorio_element));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "create_and_link_element", VERBOSITY_FATAL, 0);
-        return NULL;
-    }
-
+    gregorio_element *element = gregorio_calloc(1, sizeof(gregorio_element));
     element->previous = *current_element;
     element->next = NULL;
     if (*current_element) {
@@ -832,12 +818,7 @@ void gregorio_add_character(gregorio_character **current_character,
         grewchar wcharacter)
 {
     gregorio_character *element =
-        (gregorio_character *) calloc(1, sizeof(gregorio_character));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "gregorio_add_character", VERBOSITY_FATAL, 0);
-        return;
-    }
+        (gregorio_character *) gregorio_calloc(1, sizeof(gregorio_character));
     element->is_character = 1;
     element->cos.character = wcharacter;
     element->next_character = NULL;
@@ -883,12 +864,7 @@ void gregorio_begin_style(gregorio_character **current_character,
         grestyle_style style)
 {
     gregorio_character *element =
-        (gregorio_character *) calloc(1, sizeof(gregorio_character));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "add_note", VERBOSITY_FATAL, 0);
-        return;
-    }
+        (gregorio_character *) gregorio_calloc(1, sizeof(gregorio_character));
     element->is_character = 0;
     element->cos.s.type = ST_T_BEGIN;
     element->cos.s.style = style;
@@ -904,12 +880,7 @@ void gregorio_end_style(gregorio_character **current_character,
         grestyle_style style)
 {
     gregorio_character *element =
-        (gregorio_character *) calloc(1, sizeof(gregorio_character));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "add_note", VERBOSITY_FATAL, 0);
-        return;
-    }
+        (gregorio_character *) gregorio_calloc(1, sizeof(gregorio_character));
     element->is_character = 0;
     element->cos.s.type = ST_T_END;
     element->cos.s.style = style;
@@ -938,12 +909,7 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
                 0);
         return;
     }
-    next = calloc(1, sizeof(gregorio_syllable));
-    if (!next) {
-        gregorio_message(_("error in memory allocation"), "add_syllable",
-                VERBOSITY_FATAL, 0);
-        return;
-    }
+    next = gregorio_calloc(1, sizeof(gregorio_syllable));
     next->type = GRE_SYLLABLE;
     next->special_sign = _NO_SIGN;
     next->position = position;
@@ -961,8 +927,8 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
     }
     next->next_syllable = NULL;
     next->previous_syllable = *current_syllable;
-    tab = (gregorio_element **) malloc(number_of_voices *
-                                       sizeof(gregorio_element *));
+    tab = (gregorio_element **) gregorio_malloc(number_of_voices *
+            sizeof(gregorio_element *));
     if (elements) {
         for (i = 0; i < number_of_voices; i++) {
             tab[i] = elements[i];
@@ -1034,7 +1000,7 @@ static void gregorio_source_info_init(source_info *si)
 gregorio_score *gregorio_new_score(void)
 {
     int annotation_num;
-    gregorio_score *new_score = calloc(1, sizeof(gregorio_score));
+    gregorio_score *new_score = gregorio_calloc(1, sizeof(gregorio_score));
     new_score->first_syllable = NULL;
     new_score->number_of_voices = 1;
     new_score->name = NULL;
@@ -1222,7 +1188,7 @@ void gregorio_set_score_user_notes(gregorio_score *score, char *user_notes)
 
 void gregorio_add_voice_info(gregorio_voice_info **current_voice_info)
 {
-    gregorio_voice_info *next = calloc(1, sizeof(gregorio_voice_info));
+    gregorio_voice_info *next = gregorio_calloc(1, sizeof(gregorio_voice_info));
     next->initial_key = NO_KEY;
     next->flatted_key = false;
     next->style = NULL;

--- a/src/struct.h
+++ b/src/struct.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header defines the Gregorio data structures and functions.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/support.c
+++ b/src/support.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains miscellaneous support functions.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 
  * This file is part of Gregorio.
@@ -21,7 +24,9 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <string.h>
 #include "support.h"
+#include "messages.h"
 
 /* Our version of snprintf; this is NOT semantically the same as C99's
  * snprintf; rather, it's a "lowest common denominator" implementation
@@ -41,4 +46,48 @@ void gregorio_snprintf(char *s, size_t size, const char *format, ...)
     vsnprintf(s, size, format, args);
 #endif
     va_end(args);
+}
+
+void *gregorio_malloc(size_t size)
+{
+    void *result = malloc(size);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_malloc", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
+}
+
+void *gregorio_calloc(size_t nmemb, size_t size)
+{
+    void *result = calloc(nmemb, size);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_calloc", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
+}
+
+void *gregorio_realloc(void *ptr, size_t size)
+{
+    void *result = realloc(ptr, size);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_realloc", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
+}
+
+char *gregorio_strdup(const char *s)
+{
+    char *result = strdup(s);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_strdup", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
 }

--- a/src/support.h
+++ b/src/support.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the miscellaneous support functions.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 
  * This file is part of Gregorio.
@@ -24,5 +27,9 @@
 
 void gregorio_snprintf(char *s, size_t size, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 3, 4)));
+void *gregorio_malloc(size_t size);
+void *gregorio_calloc(size_t nmemb, size_t size);
+void *gregorio_realloc(void *ptr, size_t size);
+char *gregorio_strdup(const char *s);
 
 #endif

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains functions providing UTF-8 support.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -24,6 +27,7 @@
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"
+#include "support.h"
 
 /*
  * 
@@ -109,7 +113,7 @@ grewchar *gregorio_build_grewchar_string_from_buf(const char *const buf)
         return NULL;
     }
     len = strlen(buf); /* to get the length of the syllable in ASCII */
-    gwstring = (grewchar *) malloc((len + 1) * sizeof(grewchar));
+    gwstring = (grewchar *) gregorio_malloc((len + 1) * sizeof(grewchar));
     gregorio_mbstowcs(gwstring, buf, len); /* converting into wchar_t */
     return gwstring;
 }
@@ -147,7 +151,7 @@ unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf)
         return 1;
     }
     len = strlen(buf); /* to get the length of the syllable in ASCII */
-    gwbuf = (grewchar *) malloc((len + 1) * sizeof(grewchar));
+    gwbuf = (grewchar *) gregorio_malloc((len + 1) * sizeof(grewchar));
     gregorio_mbstowcs(gwbuf, buf, len); /* converting into wchar_t */
     /* we add the corresponding characters in the list of gregorio_characters */
     while (gwbuf[i] && wstr[i]) {

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the UTF-8 support functions.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/utf8strings.h.in
+++ b/src/utf8strings.h.in
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header file contains UTF-8 encoded strings used by Gregorio
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/vowel/vowel-rules.h
+++ b/src/vowel/vowel-rules.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header shares definitions between the vowel parser and lexer.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/vowel/vowel-rules.l
+++ b/src/vowel/vowel-rules.l
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the vowel rule lexer.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -24,6 +27,7 @@
 #include <string.h>
 #include "struct.h"
 #include "messages.h"
+#include "support.h"
 
 #include "vowel.h"
 
@@ -35,7 +39,7 @@
 static __inline void save_lval(void)
 {
     gregorio_vowel_rulefile_lval =
-            malloc((gregorio_vowel_rulefile_leng + 1) * sizeof(char));
+            gregorio_malloc((gregorio_vowel_rulefile_leng + 1) * sizeof(char));
     strncpy(gregorio_vowel_rulefile_lval, gregorio_vowel_rulefile_text,
             gregorio_vowel_rulefile_leng);
     gregorio_vowel_rulefile_lval[gregorio_vowel_rulefile_leng] = '\0';

--- a/src/vowel/vowel-rules.y
+++ b/src/vowel/vowel-rules.y
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the vowel rule parser.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This program is free software: you can redistribute it and/or modify it

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements vowel rule handling (aside from parsing).
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -30,6 +33,7 @@
 #include "vowel.h"
 #include "unicode.h"
 #include "messages.h"
+#include "support.h"
 
 typedef struct character_set {
     grewchar *table;
@@ -42,21 +46,15 @@ typedef struct character_set {
 
 static character_set *character_set_new(const bool alloc_next)
 {
-    character_set *set = (character_set *)calloc(1, sizeof(character_set));
+    character_set *set =
+        (character_set *)gregorio_calloc(1, sizeof(character_set));
     set->mask = 0x0f;
     set->bins = 16;
     set->size = 0;
-    set->table = (grewchar *)calloc(set->bins, sizeof(grewchar));
-    if (!set->table) {
-        gregorio_message(_("unable to allocate memory"),
-                "character_set_new", VERBOSITY_FATAL, 0);
-    }
+    set->table = (grewchar *)gregorio_calloc(set->bins, sizeof(grewchar));
     if (alloc_next) {
-        set->next = (character_set **)calloc(set->bins, sizeof(character_set *));
-        if (!set->next) {
-            gregorio_message(_("unable to allocate memory"),
-                    "character_set_new", VERBOSITY_FATAL, 0);
-        }
+        set->next = (character_set **)gregorio_calloc(set->bins,
+                sizeof(character_set *));
     }
     return set;
 }
@@ -144,9 +142,9 @@ static __inline void character_set_grow(character_set *const set) {
 
     set->bins <<= 1;
     set->mask = (set->mask << 1) | 0x01;
-    set->table = calloc(set->bins, sizeof(grewchar));
+    set->table = gregorio_calloc(set->bins, sizeof(grewchar));
     if (old_next) {
-        set->table = calloc(set->bins, sizeof(character_set *));
+        set->table = gregorio_calloc(set->bins, sizeof(character_set *));
     }
     for (i = 0; i < old_bins; ++i) {
         if (old_table[i]) {
@@ -208,19 +206,12 @@ extern FILE *gregorio_vowel_rulefile_in;
 
 static void prefix_buffer_grow(size_t required_size)
 {
-    grewchar *newbuffer;
-
     while (required_size > prefix_buffer_size) {
         prefix_buffer_size <<= 1;
         prefix_buffer_mask = (prefix_buffer_mask << 1) | 0x01;
     }
-    newbuffer = realloc(prefix_buffer, prefix_buffer_size * sizeof(grewchar));
-    if (newbuffer) {
-        prefix_buffer = newbuffer;
-    } else {
-        gregorio_message(_("unable to allocate memory"), "prefix_buffer_grow",
-                VERBOSITY_FATAL, 0);
-    }
+    prefix_buffer = gregorio_realloc(prefix_buffer,
+            prefix_buffer_size * sizeof(grewchar));
 }
 
 void gregorio_vowel_tables_init(void)
@@ -238,12 +229,8 @@ void gregorio_vowel_tables_init(void)
 
         prefix_buffer_size = 16;
         prefix_buffer_mask = 0x0f;
-        prefix_buffer = (grewchar *)malloc(
+        prefix_buffer = (grewchar *)gregorio_malloc(
                 prefix_buffer_size * sizeof(grewchar));
-        if (!prefix_buffer) {
-            gregorio_message(_("unable to allocate memory"),
-                    "gregorio_vowel_tables_init", VERBOSITY_FATAL, 0);
-        }
     }
 }
 

--- a/src/vowel/vowel.h
+++ b/src/vowel/vowel.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the vowel handling data structures and entry points.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.


### PR DESCRIPTION
Karl Berry's email:
```
    https://github.com/gregorio-project/gregorio/blob/release-4.0/src/gregorio-utils.c

Thanks for the url.  From looking at the first page of the file:

0) A comment on define_path saying what it is supposed to do would be
nice, though not a security issue :).  (And a one-liner at the top of
the file with the 10000m description of the whole program.)

1) you must always check the return status of malloc/realloc/whatever.
I imagine you don't want to depend on kpse/gnu xmalloc/xrealloc/whatever
being available, but you should make your own trivial wrappers.

2) I don't think exit(-1) is a good idea.  exit(1) is simpler and more
reliable to mean "just an error".  That's what I do in kpse and what
pretty much everything else does, as far as I've noticed.  (Unless
you're worried about VMS :), which is the only system where 1=success, afaik.)

3) Allocating something the size of PATH_MAX is also not a good idea.
That can be huge, or conversely, not enough.  (One of rms's first
explicit technical goals for GNU was to place no limit on file name
length.)  It is better to (x)malloc the actual sizes that are needed.

4) In particular, the very first strcpy is, as far as I can see, a
security risk:
  char temp_name[PATH_MAX];
  ...
  strcpy(temp_name, string);

I see nothing guaranteeing that strlen(string) < PATH_MAX at that
point.  Therefore you're potentially overwriting the stack.

Better to follow the pattern as in your get_output_filename:
1) find length that is needed;
2) xmalloc that length;
3) strcpy the bytes.

Enough for today ...

Happy hacking,
Karl
```

0) I added the comment for define_path and file-descriptive comments to all the source files.
1) I created gregorio_malloc, gregorio_calloc, gregorio_realloc, and gregorio_strdup as wrappers to the allocation functions; these log a fatal error and exit the program if any allocation attempt fails.
2) I changed all exit(-1) to exit(1)
3) I eliminated some dependencies on PATH_MAX, but there are still two instances where it's used.  In one case, we pass such a variable to fgets, which doesn't do allocation. In the second case, we pass it to getcwd, which if we are sticking to POSIX (as opposed to GNU), does not allocate a buffer.
4) I implemented as specified

I also ran the code through valgrind and found an unclosed file (error_file), so I fixed that as well.

Please review this and merge if satisfactory.  I am also open to suggestions for eliminating the final two uses for item 3.