### PR TITLE
Develop

### DIFF
--- a/.gregorio-version
+++ b/.gregorio-version
@@ -1,4 +1,4 @@
-4.0.0-rc2
+4.0.0
 
 *** Do not modify this file. ***
 Use VersionManager.py to change the version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,61 +14,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `biginitial` style, consolidated into the `initial` style.
 
 
-## [4.0.0-rc2] - 2015-11-05
-### Deprecated
-- `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.
-- `biginitial` style, consolidated into the `initial` style.
-
-
-## [Unreleased][unreleased]
-### Fixed
-- The spacing of manual in-line custos (`(f+)` in gabc) is now consistent with the spacing of automatic in-line custos (`(z0)` in gabc).  See [#642](https://github.com/gregorio-project/gregorio/issues/642).
-- Signs on the climacus praepunctis deminutus `(ghgf~)` neume are now positioned correctly.  See [#650](https://github.com/gregorio-project/gregorio/issues/650)
-- When using first letter lyric centering and big initials, the initial is no longer incorrectly included in the first syllable.  See [#648](https://github.com/gregorio-project/gregorio/issues/648).  This is a fix for a bug in a new 4.0.0 feature, so this changelog entry should be removed when the change log is merged for the 4.0.0 release.
-- Mac installer has been made SIP compliant (i.e. it now works on El Capitan).
-- Mac installer can now detect installations of TeXLive done with MacPorts or the command-line tool provided by TUG.
-- Windows executable has file version information attached correctly so that the installer can properly recognize and replace the binary during an upgrade process.
-
-### Added
-- The ability to force a hyphen after an empty first syllable, enabled by default since this was the behavior prior to 4.0.  Version 4.0 has an improved spacing algorithm which will eliminate the hyphen if the notes for the first syllable are too close to the second.  To switch to this behavior, use `\gresetemptyfirstsyllablehyphen{auto}`.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#653](https://github.com/gregorio-project/gregorio/issues/653)).
-- Shell scripts for configuring TeXShop and TeXworks on a Mac.
-
-### Removed
-- The TeXShop script for compiling gabc files.  Supplanted by the new autocompile feature of the package.
-- Spaces associated with chironomic signs (which were removed in 4.0.0-beta)
-
-### Deprecated
-- The meaningless `gabc-version` header in gabc (see [#664](https://github.com/gregorio-project/gregorio/issues/664)).
-
-
-## [4.0.0-rc1] - 2015-10-08
-### Fixed
-- Deactivating the end of line shifts now prevents lyrics from stretching under the custos at the end of the line.
-- All of the keywords for `\grescaledim` now work as described in the documentation.
-
-### Changed
-- `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scalable` and `fixed`) instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
-- `\grescaledim` now accepts `scalable` as a keyword to turn on scalable (in keeping with the above change)
-- Alterations are partially ignored when aligning lines on the notes (i.e. `\gresetbolshifts{enabled}`).  They are not allowed to get any closer to the clef than `beforealterationspace` and the lyrics are not allowed to get any closer to the left-hand margin than `minimalspaceatlinebeginning`, but other than that GregorioTeX will shift them left as much as possible to make the notes align `spaceafterlineclef` away from the clef.  Note that for the default values of these distances, only the natural is small enough to acheive true alignment.
-- `gregoriotex.sty` and `gregoriosyms.sty` now check to make sure that they are not both loaded.  If `gregoriotex` detects that `gregoriosyms` is loaded, then an error is raised.  If `gregoriosyms` detects that `gregoriotex` is loaded, then the loading of `gregoriosyms` is silently aborted and compilation proceeds.
-- Liquescence on a bistropha or tristropha will only appear on the note(s) marked by `<` in gabc, rather than on all notes in the figure.  This means that a figure like `(gsss<)` will only have a liquescent "tail" on the final note.  If you would like all notes to be liquescent for some reason, you can use a figure like `(gs<gs<gs<)` instead.
-
-### Added
-- New distance, `initialraise`, which will lift (or lower, if negative) the initial.
-- The first word of the score is now passed to a macro that allow it to be styled from TeX.  The first word is passed to `\GreFirstWord#1` and is styled by changing the `firstword` style.
-- A new type of lyric centering, enabled with `\gresetlyriccentering{firstletter}`, which aligns the neume with the first letter of each syllable.
-- `\greornamentation` allows access to the two ornamentation glyphs.  The ability to access these two glyphs via `{\gregoriosymbolfont \char 75}` was broken by the new interface to the glyphs in greextra.
-- The missing liquescent salicus glyphs.
-
-## [4.0.0-beta2] - 2015-08-26
-### Fixed
-- Corrected the rendering of explicit automatic and manual custos at the end of lines when the clef change that follows it is pushed to the next line (see [#569](https://github.com/gregorio-project/gregorio/issues/569)).
-- Distinguished between `eolshift` and `bolshift` giving each their own flag and user commmand for turning them on and off.  `\seteolshift{enable}` allows the lyric text to stretch under the custos at the end of the line.  `\setbolshift{enable}` aligns the beginning of each line on the notes instead of the text.  Both are on by default, but can be turned off with `\seteolshift{disable}` and `\setbolshift{disable}`.
-
-### Added
-- `\greillumination`: allows user to specify arbitrary content (usually an image) to be used as the initial.
-
-## [4.0.0-beta] - 2015-08-01
+## [4.0.0] - 2015-12-08
 ### Fixed
 - Handling of the first syllable in gabc is now more consistent with the all other syllables.  This centers the syllable correctly when using latin syllable centering (see [#42](https://github.com/gregorio-project/gregorio/issues/42)) and makes the use of styles less surprising in the first syllable (see [#135](https://github.com/gregorio-project/gregorio/issues/135)).
 - Handling of manually-placed custos is improved.  In particular, a manual custos at the end of the score should no longer be lost when the bar happens to be at the end of the line.
@@ -79,6 +25,14 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Gregorio will now try harder to select an appropriate pitch for an automatic custos (`z0`) on a clef change (see [#446](https://github.com/gregorio-project/gregorio/issues/446)).  If results are not satisfactory, use a manual custos (`+`) to select a pitch manually.
 - The centering of styled text under notes is now correct (See [#509](https://github.com/gregorio-project/gregorio/issues/509)).
 - Space for above lines text is now correctly added as needed, even at the beginning of a score (see [#533](https://github.com/gregorio-project/gregorio/issues/533)).
+- Corrected the rendering of explicit automatic and manual custos at the end of lines when the clef change that follows it is pushed to the next line (see [#569](https://github.com/gregorio-project/gregorio/issues/569)).
+- Distinguished between `eolshift` and `bolshift` giving each their own flag and user commmand for turning them on and off.  `\seteolshift{enable}` allows the lyric text to stretch under the custos at the end of the line.  `\setbolshift{enable}` aligns the beginning of each line on the notes instead of the text.  Both are on by default, but can be turned off with `\seteolshift{disable}` and `\setbolshift{disable}`.
+- The spacing of manual in-line custos (`(f+)` in gabc) is now consistent with the spacing of automatic in-line custos (`(z0)` in gabc).  See [#642](https://github.com/gregorio-project/gregorio/issues/642).
+- Signs on the climacus praepunctis deminutus `(ghgf~)` neume are now positioned correctly.  See [#650](https://github.com/gregorio-project/gregorio/issues/650)
+- Mac installer has been made SIP compliant (i.e. it now works on El Capitan).
+- Mac installer can now detect installations of TeXLive done with MacPorts or the command-line tool provided by TUG.
+- Windows executable has file version information attached correctly so that the installer can properly recognize and replace the binary during an upgrade process.
+- Spacing was too large when alteration begins a syllable, see [#663](https://github.com/gregorio-project/gregorio/issues/663).
 
 ### Changed
 - A new, more systematic naming scheme has been created for GregorioTeX macros.  The naming scheme should reduce the chances of naming conflicts with other packages and make it easier to identify what a particular macro is for and how to use it.  Most user functions have been renamed in order to bring them into line with this scheme.  Please see GregorioRef for a complete list of the new function names.  In general, old names will still work, but they will raise a deprecation warning and will be dropped from GregorioTeX in a future relase.
@@ -116,9 +70,14 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Style for score elements can now be changed via the `\grechangestyle` command.  This replaces the mixed system of styling commands which could be redefined for some elements and specialized commands for applying styles to others.  See GregorioRef for details.
 - Annotations with more than two lines are now supported (originally requested [on the user list](http://www.mail-archive.com/gregorio-users%40gna.org/msg00164.html) when two line annoations were made possible).  To build the annotation box use `\greannoataion`.  See GregorioRef for details.
 - The `annotation` header field in `gabc` now places its value(s) above the inital if no annotation is explicitly given by the user via `\greannotation` (see [#44](https://github.com/gregorio-project/gregorio/issues/44)).
-- `\grescaledim` now takes two arguments to bring it into line with the systemized naming scheme.  The second argument should be `yes`, `true`, or `on` if you want the distance to scale when the staff size changes.  Anything else will make the distance independent of the staff size.
+- `\grescaledim` now takes two arguments to bring it into line with the systemized naming scheme.  The second argument should be `scalable` if you want the distance to scale when the staff size changes, `fixed` if you don't.
 - Gregorio is now able to make individual lines of a score taller, when the position of the note require extra space, without affecting the rest of the lines.  This is the new default behavior.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#59](https://github.com/gregorio-project/gregorio/issues/59)).
 - Braces are now rendered using MetaPost by default.  This allows the line weight to remain more consistent when braces are stretched.  The old behavior (which uses the score font instead) can be restored using `\gresetbracerendering{font}`.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#535](https://github.com/gregorio-project/gregorio/issues/535)).
+- `\grecreatedim` and `\grechangedim` now take keywords for their third argument (`scalable` and `fixed`) instead of integers (`1` and `0`) to make the more in keeping with the overall user command conventions.
+- Alterations are partially ignored when aligning lines on the notes (i.e. `\gresetbolshifts{enabled}`).  They are not allowed to get any closer to the clef than `beforealterationspace` and the lyrics are not allowed to get any closer to the left-hand margin than `minimalspaceatlinebeginning`, but other than that GregorioTeX will shift them left as much as possible to make the notes align `spaceafterlineclef` away from the clef.  Note that for the default values of these distances, only the natural is small enough to acheive true alignment.
+- `gregoriotex.sty` and `gregoriosyms.sty` now check to make sure that they are not both loaded.  If `gregoriotex` detects that `gregoriosyms` is loaded, then an error is raised.  If `gregoriosyms` detects that `gregoriotex` is loaded, then the loading of `gregoriosyms` is silently aborted and compilation proceeds.
+- Liquescence on a bistropha or tristropha will only appear on the note(s) marked by `<` in gabc, rather than on all notes in the figure.  This means that a figure like `(gsss<)` will only have a liquescent "tail" on the final note.  If you would like all notes to be liquescent for some reason, you can use a figure like `(gs<gs<gs<)` instead.
+- `alterationspace` is now a fixed dimension, see [UPGRADE.md](UPGRADE.md) for details.
 
 ### Added
 - With thanks to Jakub Jelínek, St. Gallen style adiastematic notation is now handled through [nabc syntax](http://gregoriochant.org/dokuwiki/doku.php/language) (see GregorioNabcRef.pdf for details and [the new example](examples/FactusEst.gabc)). Only one line above the notes is currently handled. This is a preview, backward incompatible change are possible in future releases.
@@ -135,7 +94,7 @@ See GregorioRef.pdf for full details.
 - Added `--with-kpathsea` option to configure script, to check input and output file against `openout_any` and `openin_any` settings of texmf.cnf (TeXLive only). Necessary to be included in `shell_escape_commands` in TeXLive.
 - Support for `lualatex -recorder`.  Autocompiled gabc and gtex files will now be properly recorded so that programs like `latexmk -recorder` can detect the need to rebuild the PDF when a gabc file changes.
 - A vertical episema may now be forced to appear above or below a note.  In gabc, use `'0` for the vertical episema to appear below and `'1` for the vertical episema to appear above (see [#385](https://github.com/gregorio-project/gregorio/issues/385)).
-- The first syllable and first letter of the first syllable that is *not* interpreted as the initial of the score are now passed to macros that allow them to be styled from TeX.  The first syllable is passed to `\GreFirstSyllable#1` and the first letter of the first syllable is passed to `\GreFirstSyllableInitial#1`.
+- The first word, first syllable, and first letter of the first syllable that is *not* interpreted as the initial of the score can now be styled from TeX.  Use `\grechangestyle` to modify the `firstsyllableinitial`, `firstsyllable`, and `firstword` as desired.
 - The final line of a score may now be forced to be fully justified (rather than ragged) using `\gresetlastline{justified}` before including the score (see [#43](https://github.com/gregorio-project/gregorio/issues/43)).  Use `\gresetlastline{ragged}` to switch back to a ragged last line.
 - `\gresethyphen{force}` forces GregorioTeX to put a hyphen between each syllable in a polysyllabic word.  `\gresethyphen{auto}` restores behavior to normal.
 - Support for custom vowel centering rules.  Put a file called `gregorio-vowels.dat` into your project directory or into a directory accessible from TEXMF and add the header `language: name;` to your gabc file.  The `gregorio-vowels.dat` file describes how vowels are to be located in the *name* language.  See GregorioRef for details.
@@ -144,6 +103,13 @@ See GregorioRef.pdf for full details.
 - The ability to add LilyPond-like point-and-click textedit links into the PDF file to aid with debugging scores.  This must be explicitly enabled and **should be turned off** when producing files for distribution as it embeds path information into the output.  To enable this, you must pass the `-p` option to gregorio when compiling gabc files and add `\gresetpointandclick{on}` before including the score.  It may be toggled back off with `\gresetpointandclick{off}`.  See GregorioRef for details (for the change request, see [#528](https://github.com/gregorio-project/gregorio/issues/528)).
 - New score fonts with glyphs unique to Dominican chant.  These fonts replace the epiphonus and the augmented liquescents with corresponding figures from Dominican liturgical books.  To use the new fonts, pass the `[op]` option to the `\gresetgregoriofont` command (i.e., `\gresetgregoriofont[op]{greciliae}`).  See GregorioRef for details (for the change request, see [#1](https://github.com/gregorio-project/gregorio/issues/1)).
 - Support for "punctum cavum inclinatum" and "punctum cavum inclinatum auctus" figures.  The gabc for these are `(Gr)` and `(Gr<)`, where `G` is the capitalized pitch letter.
+- `\greillumination`: allows user to specify arbitrary content (usually an image) to be used as the initial.
+- New distance, `initialraise`, which will lift (or lower, if negative) the initial.
+- A new type of lyric centering, enabled with `\gresetlyriccentering{firstletter}`, which aligns the neume with the first letter of each syllable.
+- `\greornamentation` allows access to the two ornamentation glyphs.  The ability to access these two glyphs via `{\gregoriosymbolfont \char 75}` was broken by the new interface to the glyphs in greextra.
+- The missing liquescent salicus glyphs.
+- The ability to force a hyphen after an empty first syllable, enabled by default since this was the behavior prior to 4.0.  Version 4.0 has an improved spacing algorithm which will eliminate the hyphen if the notes for the first syllable are too close to the second.  To switch to this behavior, use `\gresetemptyfirstsyllablehyphen{auto}`.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#653](https://github.com/gregorio-project/gregorio/issues/653)).
+- Shell scripts for configuring TeXShop and TeXworks on a Mac.
 
 ### Deprecated
 - `\GreSetStaffLinesFormat`, supplanted by `\grechangeformat{normalstafflines}...`
@@ -153,9 +119,7 @@ See GregorioRef.pdf for full details.
 - `\greabovelinestextstyle`, if you were redefining this command, use `\grechangeformat{abovelinestext}...` instead
 - `\grelowchoralsignstyle`, if you were redefining this command, use `\grechangeformat{lowchoralsign}...` instead
 - `\grehighchoralsignstyle`, if you were redefining this command, use `\grechangeformat{highchoralsign}...` instead
-- `centering-scheme` gabc header, supplanted by `\grelyriccentering` in TeX.  See GregorioRef for syntax.
 - `\setaboveinitialseparation`, supplanted by `\grechangedim{annotationseparation}...`
-- `gregoriotex-font` gabc header, supplanted by `\gresetgregoriofont` in TeX.  See GregorioRef for syntax.
 - `\scorereference`, supplanted by `\grescorereference`
 - `\GreScoreReference`, supplanted by `\grescorereference`
 - `\commentary`, supplanted by `\grecommentary`
@@ -201,7 +165,9 @@ See GregorioRef.pdf for full details.
 - `\setspaceafterinitial`, supplanted by `\grechangedim{afterinitialshift}...`
 - `\setspacebeforeinitial`, supplanted by `\grechangedim{beforeinitialshift}...`
 - `\setinitialspacing`, supplanted by `\grechangedim{beforeinitialshift}...`, `\grechangedim{manualinitialwidth}...`, and `\grechangedime{afterinitialshift}...`
-
+- `centering-scheme` gabc header, supplanted by `\grelyriccentering` in TeX.  See GregorioRef for syntax.
+- `gregoriotex-font` gabc header, supplanted by `\gresetgregoriofont` in TeX.  See GregorioRef for syntax.
+- The meaningless `gabc-version` header in gabc (see [#664](https://github.com/gregorio-project/gregorio/issues/664)).
 
 ### Removed
 - GregorioXML and OpusTeX output
@@ -219,7 +185,10 @@ See GregorioRef.pdf for full details.
 - `\GreSetAboveInitialSeparation`, supplanted by `\grechangedim{annotationseparation}...`
 - `\gresetstafflinefactor`, supplanted by `\grechangestafflinethickness`
 - `greg-book` and `greg-lily-book` engines, supplanted by improved capabilities of `\gregorioscore` for compiling gabc files at time of document compilation.
+- The TeXShop script for compiling gabc files.  Supplanted by the new autocompile feature of the package.
 
+### Known Bugs
+- When beginning of line clefs are invisible and bol shifts are enabled, lyric text will stick out into the margin.  Further the notes on the first and subsequent lines do not align properly.  See [#683](https://github.com/gregorio-project/gregorio/issues/683).
 
 
 ## [3.0.3] - 2015-07-01
@@ -284,10 +253,10 @@ See GregorioRef.pdf for full details.
 - Clivis and pes quadratum alignment now follows Solesmes' conventions more closely (see [#10](https://github.com/gregorio-project/gregorio/issues/10)).
 
 ### Fixed
-- Reducing horizontal episemus width.
+- Reducing horizontal episema width.
 - Reducing flat stem length.
 - `mode` and `anotation-line` now do their job.
-- Low episemus (`_0`) under consecutive notes are now aligned correctly.
+- Low episema (`_0`) under consecutive notes are now aligned correctly.
 - Quilisma was melting too much with next note when in a second interval.
 - Fixed custo blocking possibility.
 - Fixing glyphs disapearing when importing into Illustrator.
@@ -319,7 +288,7 @@ See GregorioRef.pdf for full details.
 - adding requested features: Dominican bars, choral signs, text above staff lines
 - enabling comments in gabc files
 - adding ability to write verbatim TeX at {note, glyph, element} level
-- introducing horizontal episemus bridges
+- introducing horizontal episema bridges
 - default output is now utf8 directly; the `-O`  option allows old-style TeX output, i.e. `\char XXXX`
 - new static build system for packaged distributions
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,7 +48,7 @@ The `gregorio` executable now uses the `.gtex` extension by default (instead of 
 
 ### Custom spacings
 
-If you are using custom spacings, please update the values of `interwordspacetext`, `intersyllablespacenotes` and `interwordspacenotes` to match their new definitions (in the comments in `gsp-default.tex`).
+If you are using custom spacings, please update the values of `interwordspacetext`, `intersyllablespacenotes` and `interwordspacenotes` to match their new definitions (in the comments in `gsp-default.tex`). Also note that `alterationspace` is now fixed and cannot take `plus` or `minus` values.
 
 ### Euouae blocks
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,8 +16,8 @@ dnl
 dnl You should have received a copy of the GNU General Public License
 dnl along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
-AC_INIT([gregorio],[4.0.0-rc2],[gregorio-devel@gna.org])
-FILENAME_VERSION="4_0_0-rc2"
+AC_INIT([gregorio],[4.0.0],[gregorio-devel@gna.org])
+FILENAME_VERSION="4_0_0"
 AC_SUBST(FILENAME_VERSION)
 MK=""
 AC_SUBST(MK)

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -132,7 +132,7 @@ When called with the optional argument \texttt{[f]} Gregorio\TeX\ will
 compile the gabc file into a gtex file. This is similar to
 \texttt{[a]} except the gabc is compiled every time.
 
-\macroname{\textbackslash gresetcompilegabc}{\{\#1\}}{gregoriotex-main.tex} 
+\macroname{\textbackslash gresetcompilegabc}{\{\#1\}}{gregoriotex-main.tex}
 A macro to change the behavior of the way Gregorio\TeX\ includes scores.  This is similar to using the package options \verb=[forcecompile]=, \verb=[autocompile]=, and \verb=[nevercompile]=, but does not necessarly apply to the entire document.
 
 
@@ -509,7 +509,7 @@ simple version.
 For example:
 
 \medskip \begin{latexcode}
-  \gresimpledefbarglyph{A}{0.3em}
+  \gresimpledefbarredsymbol{A}{0.3em}
 \end{latexcode}
 
 Will define \texttt{\textbackslash Abar} to be a A with a bar shifted right
@@ -542,7 +542,7 @@ For example:
 \end{footnotesize}
 
 \gredefbarredsymbol{RBarBold}{\textbf{R}}{greRBarSmall}{13}{1.7mm}{0.1mm}
-Will define \texttt{\textbackslash RBarBold} to be a bold \textbf{R} with 
+Will define \texttt{\textbackslash RBarBold} to be a bold \textbf{R} with
 the bar made for small text (a bit bolder, named \texttt{RBarSmall} in greextra)
 , at 12pt, shifted right of \texttt{1.7mm} from the beginning of the glyph, and lowered down
 by \texttt{0.1mm}. The result is that \texttt{\textbackslash RBarBold} will typeset \RBarBold .
@@ -640,15 +640,15 @@ Examples:\par\medskip
 \begin{latexcode}
   % This one works for both PlainTeX and LaTeX this would make
   % the translations bold and italic
-  \grechangestyle{translation}{\it\bf} 
-  
-  % This one is LaTeX only, and would make the above lines 
+  \grechangestyle{translation}{\it\bf}
+
+  % This one is LaTeX only, and would make the above lines
   % text small and italic
   \grechangestyle{abovelinetext}{\begin{small}\begin{italic}}%
-    [\end{italic}\end{small}] 
-  
+    [\end{italic}\end{small}]
+
   % This would make the initial print in 36pt font.
-  \grechangestyle{initial}{\fontsize{36}{36}\selectfont} 
+  \grechangestyle{initial}{\fontsize{36}{36}\selectfont}
 \end{latexcode}
 
 \bigskip
@@ -888,57 +888,57 @@ While it may seem strange that many of these distances are defined to 5 decimal 
 \textbf{Nota Bene:} Because of the way Gregorio\TeX\ handles distances, these cannot be manipulated as if they were normal \TeX\ dimensions or skips.  As a result they should only be changed using the command defined by Gregorio\TeX\ for this purpose.
 
 \macroname{additionallineswidth}{}{gsp-default.tex}
-The additional width of the additional lines (\ie, the value added to the width of the glyph with which they're associated to get the width of the line).  
+The additional width of the additional lines (\ie, the value added to the width of the glyph with which they're associated to get the width of the line).
 
 Default: \unit[0.14584]{cm}
 
 \macroname{alterationspace}{}{gsp-default.tex}
-Space between an alteration (flat or natural) and the next glyph. 
+Space between an alteration (flat or natural) and the next glyph.
 
-Default: \unit[0.07747]{cm} plus \unit[0.01276]{cm} minus \unit[0.00455]{cm}
+Default: \unit[0.07747]{cm}
 
 \macroname{beforealterationspace}{}{gsp-default.tex}
 When beginning of line shifts (bolshifts) are enabled, minimum space between a clef at the beginning of the line and a leading alteration glyph.  This distance should be larger than \texttt{clefflatspace} so that a flatted clef can be distinguished from a flat which is part of the first glyph on a line, but also smaller than \texttt{spaceafterlineclef}, the distance from the clef to the first notes.
 
-Default: $\unit[-0.32816]{cm}$ plus \unit[0.01093]{cm} minus \unit[0.01093]{cm}
+Default: \unit[0.1]{cm}
 
 \macroname{beforelowchoralsignspace}{}{gsp-default.tex}
-Space before a low choral sign. 
+Space before a low choral sign.
 
 Default: \unit[0.04556]{cm} plus \unit[0.00638]{cm} minus \unit[0.00638]{cm}
 
 \macroname{clefflatspace}{}{gsp-default.tex}
-Space between a clef and a flat (for clefs with flat).  
+Space between a clef and a flat (for clefs with flat).
 
 Default: \unit[0.05469]{cm} plus \unit[0.00638]{cm} minus \unit[0.00638]{cm}
 
 \macroname{interglyphspace}{}{gsp-default.tex}
-Space between glyphs in the same element. 
+Space between glyphs in the same element.
 
 Default: \unit[0.06927]{cm} plus \unit[0.00363]{cm} minus \unit[0.00363]{cm}
 
 \macroname{zerowidthspace}{}{gsp-default.tex}
-Null space.  
+Null space.
 
 Default: \unit[0]{cm} plus \unit[0]{cm} minus \unit[0]{cm}
 
 \macroname{interelementspace}{}{gsp-default.tex}
-Space between elements.  
+Space between elements.
 
 Default: \unit[0.06927]{cm} plus \unit[0.00182]{cm} minus \unit[0.00363]{cm}
 
 \macroname{largerspace}{}{gsp-default.tex}
-Larger space between elements.  
+Larger space between elements.
 
 Default: \unit[0.10938]{cm} plus \unit[0.01822]{cm} minus \unit[0.00911]{cm}
 
 \macroname{glyphspace}{}{gsp-default.tex}
-Space between elements which has the size of a note.  
+Space between elements which has the size of a note.
 
 Default: \unit[0.21877]{cm} plus \unit[0.01822]{cm} minus \unit[0.01822]{cm}
 
 \macroname{intersyllablespacenotes}{}{gsp-default.tex}
-Minimum space between two notes of different syllables.  
+Minimum space between two notes of different syllables.
 
 Default: \unit[0.25523]{cm} plus \unit[0.31903]{cm} minus \unit[0]{cm}
 
@@ -953,142 +953,142 @@ Space before custos within a line.
 Default: \unit[0]{cm} plus \unit[0]{cm} minus \unit[0]{cm}
 
 \macroname{spacebeforesigns}{}{gsp-default.tex}
-Space before punctum mora and augmentum duplex.  
+Space before punctum mora and augmentum duplex.
 
 Default: \unit[0.05469]{cm} plus \unit[0.00455]{cm} minus \unit[0.00455]{cm}
 
 \macroname{spaceaftersigns}{}{gsp-default.tex}
-Space after punctum mora and augmentum duplex.  
+Space after punctum mora and augmentum duplex.
 
 Default: \unit[0.08203]{cm} plus \unit[0.0082]{cm} minus \unit[0.0082]{cm}
 
 \macroname{spaceafterlineclef}{}{gsp-default.tex}
-Space after a clef at the beginning of a line.  
+Space after a clef at the beginning of a line.
 
 Default: \unit[0.27345]{cm} plus \unit[0.14584]{cm} minus \unit[0.01367]{cm}
 
 \macroname{interwordspacenotes}{}{gsp-default.tex}
-Space after at the end of a word when the last written symbol is a note and the first is a note.  
+Space after at the end of a word when the last written symbol is a note and the first is a note.
 
 Default: \unit[0.29169]{cm} plus \unit[0.08751]{cm} minus \unit[0.05469]{cm}
 
 \macroname{interwordspacetext}{}{gsp-default.tex}
-Space after at the end of a word when the last written symbol is text and the first is text.  
+Space after at the end of a word when the last written symbol is text and the first is text.
 
 Default: \unit[0.22787]{cm} plus \unit[0.41019]{cm} minus \unit[0.07292]{cm}
 
 \macroname{interwordspacenotes@euouae}{}{gsp-default.tex}
-Space after at the end of a word when the last written symbol is a note and the first is a note in \texttt{euouae} blocks.  
+Space after at the end of a word when the last written symbol is a note and the first is a note in \texttt{euouae} blocks.
 
 Default: \unit[0.19]{cm} plus \unit[0.1]{cm} minus \unit[0.05]{cm}
 
 \macroname{interwordspacetext@euouae}{}{gsp-default.tex}
-Space after at the end of a word when the last written symbol is text and the first is text in \texttt{euouae} blocks.  
+Space after at the end of a word when the last written symbol is text and the first is text in \texttt{euouae} blocks.
 
 Default: \unit[0.27]{cm} plus \unit[0.1]{cm} minus \unit[0.05]{cm}
 
 \macroname{bitrivirspace}{}{gsp-default.tex}
-Space between notes of a bivirga or trivirga.  
+Space between notes of a bivirga or trivirga.
 
 Default: \unit[0.06927]{cm} plus \unit[0.00182]{cm} minus \unit[0.00546]{cm}
 
 \macroname{bitristrospace}{}{gsp-default.tex}
-Space between notes of a bistropha or tristrophae.  
+Space between notes of a bistropha or tristrophae.
 
 Default: \unit[0.06927]{cm} plus \unit[0.00182]{cm} minus \unit[0.00546]{cm}
 
 \macroname{punctuminclinatumshift}{}{gsp-default.tex}
-Space between two punctum inclinatum.  
+Space between two punctum inclinatum.
 
 Default: \unit[-0.03918]{cm} plus \unit[0.0009]{cm} minus \unit[0.0009]{cm}
 
 \macroname{beforepunctainclinatashift}{}{gsp-default.tex}
-Space before puncta inclinata.  
+Space before puncta inclinata.
 
 Default: \unit[0.05286]{cm} plus \unit[0.00728]{cm} minus \unit[0.00455]{cm}
 
 \macroname{punctuminclinatumanddebilisshift}{}{gsp-default.tex}
-Space between a punctum inclinatum and a punctum inclinatum deminutus.  
+Space between a punctum inclinatum and a punctum inclinatum deminutus.
 
 Default: \unit[-0.02278]{cm} plus \unit[0.0009]{cm} minus \unit[0.0009]{cm}
 
 \macroname{punctuminclinatumdebilisshift}{}{gsp-default.tex}
-Space between two punctum inclinatum deminutus.  
+Space between two punctum inclinatum deminutus.
 
 Default: \unit[-0.00728]{cm} plus \unit[0.0009]{cm} minus \unit[0.0009]{cm}
 
 \macroname{punctuminclinatumbigshift}{}{gsp-default.tex}
-Space between puncta inclinata, larger ambitus (range=3rd).  
+Space between puncta inclinata, larger ambitus (range=3rd).
 
 Default: \unit[0.07565]{cm} plus \unit[0.0009]{cm} minus \unit[0.0009]{cm}
 
 \macroname{punctuminclinatummaxshift}{}{gsp-default.tex}
-Space between puncta inclinata, larger ambitus (range=4th -or more?-).  
+Space between puncta inclinata, larger ambitus (range=4th -or more?-).
 
 Default: \unit[0.17865]{cm} plus \unit[0.0009]{cm} minus \unit[0.0009]{cm}
 
 \macroname{spacearoundsmallbar}{}{gsp-default.tex}
-Space around virgula and divisio minima.  
+Space around virgula and divisio minima.
 
 Default: \unit[0.1823]{cm} plus \unit[0.22787]{cm} minus \unit[0.05469]{cm}
 
 \macroname{spacearoundminor}{}{gsp-default.tex}
-Space around divisio minor.  
+Space around divisio minor.
 
 Default: \unit[0.1823]{cm} plus \unit[0.22787]{cm} minus \unit[0.05469]{cm}
 
 \macroname{spacearoundmaior}{}{gsp-default.tex}
-Space around divisio maior.  
+Space around divisio maior.
 
 Default: \unit[0.1823]{cm} plus \unit[0.22787]{cm} minus \unit[0.05469]{cm}
 
 \macroname{spacearoundfinalis}{}{gsp-default.tex}
-Space around divisio finalis.  
+Space around divisio finalis.
 
 Default: \unit[0.1823]{cm} plus \unit[0.1823]{cm} minus \unit[0.05469]{cm}
 
 \macroname{spacebeforefinalfinalis}{}{gsp-default.tex}
-A special space for finalis, for when it is the last glyph.  
+A special space for finalis, for when it is the last glyph.
 
 Default: \unit[0.29169]{cm} plus \unit[0.07292]{cm} minus \unit[0.27345]{cm}
 
 \macroname{spacearoundclefbars}{}{gsp-default.tex}
-Additional space that will appear around bars that are preceded by a custos and followed by a key.  
+Additional space that will appear around bars that are preceded by a custos and followed by a key.
 
 Default: \unit[0.03645]{cm} plus \unit[0.00455]{cm} minus \unit[0.0009]{cm}
 
 \macroname{textbartextspace}{}{gsp-default.tex}
-Space between the text and the text of the bar.  
+Space between the text and the text of the bar.
 
 Default: \unit[0.24611]{cm} plus \unit[0.13672]{cm} minus \unit[0.04921]{cm}
 
 \macroname{notebarspace}{}{gsp-default.tex}
-Minimal space between a note and a bar.  
+Minimal space between a note and a bar.
 
 Default: \unit[0.31903]{cm} plus \unit[0.27345]{cm} minus \unit[0.02824]{cm}
 
 \macroname{maximumspacewithoutdash}{}{gsp-default.tex}
-Maximal space between two syllables for which we consider a dash is not needed.  
+Maximal space between two syllables for which we consider a dash is not needed.
 
 Default: \unit[0.02005]{cm}
 
 \macroname{afterclefnospace}{}{gsp-default.tex}
-An extensible space for the beginning of lines.  
+An extensible space for the beginning of lines.
 
 Default: \unit[0]{cm} plus \unit[0.27345]{cm} minus \unit[0]{cm}
 
 \macroname{additionalcustoslineswidth}{}{gsp-default.tex}
-Width of the additional lines, used only for the custos.  The width is the one for the custos at end of lines, the line for custos in the middle of a score is the same multiplied by 2.  
+Width of the additional lines, used only for the custos.  The width is the one for the custos at end of lines, the line for custos in the middle of a score is the same multiplied by 2.
 
 Default: \unit[0.09114]{cm}
 
 \macroname{afterinitialshift}{}{gsp-default.tex}
-Space between the initial and the beginning of the score.  
+Space between the initial and the beginning of the score.
 
 Default: \unit[0.2457]{cm} plus \unit[0]{cm} minus \unit[0]{cm}
 
 \macroname{beforeinitialshift}{}{gsp-default.tex}
-Space between the initial and the beginning of the score.  
+Space between the initial and the beginning of the score.
 
 Default: \unit[0.2457]{cm} plus \unit[0]{cm} minus \unit[0]{cm}
 
@@ -1098,12 +1098,12 @@ Minimal space in front of the lyrics at the beginning of a line when \texttt{bol
 Default: \unit[1.7]{cm}
 
 \macroname{manualinitialwidth}{}{gsp-default.tex}
-Space to force the initial width to.  Ignored when 0.  
+Space to force the initial width to.  Ignored when 0.
 
 Default: \unit[0]{cm}
 
 \macroname{annotationseparation}{}{gsp-default.tex}
-This space is the one between lines in the annotation (text above the initial).  
+This space is the one between lines in the annotation (text above the initial).
 
 Default: \unit[0.85]{cm}
 
@@ -1113,7 +1113,7 @@ Amount to raise (positive) or lower (negative) the annotation from it's normal p
 Default: \unit[0]{cm}
 
 \macroname{noclefspace}{}{gsp-default.tex}
-Space at the beginning of the lines if there is no clef.  
+Space at the beginning of the lines if there is no clef.
 
 Default: \unit[0.1]{cm}
 
@@ -1139,42 +1139,42 @@ The distance to shift choral signs up.  The following choral signs are shifted u
 Default: \unit[0.04556]{cm}
 
 \macroname{translationheight}{}{gsp-default.tex}
-The space for the translation.  
+The space for the translation.
 
 Default: \unit[0.5]{cm}
 
 \macroname{spaceabovelines}{}{gsp-default.tex}
-The space above the lines.  
+The space above the lines.
 
 Default: \unit[0.45576]{cm} plus \unit[0.36461]{cm} minus \unit[0.09114]{cm}
 
 \macroname{spacelinestext}{}{gsp-default.tex}
-The space between the lines and the bottom of the text.  
+The space between the lines and the bottom of the text.
 
 Default: \unit[0.60617]{cm} plus \unit[0]{cm} minus \unit[0]{cm}
 
 \macroname{spacebeneathtext}{}{gsp-default.tex}
-The space beneath the text.  
+The space beneath the text.
 
 Default: \unit[0]{cm} plus \unit[0]{cm} minus \unit[0]{cm}
 
 \macroname{abovelinestextraise}{}{gsp-default.tex}
-Height of the text above the note line.  
+Height of the text above the note line.
 
 Default: \unit[1.7]{cm}
 
 \macroname{abovelinestextheight}{}{gsp-default.tex}
-Height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration).  
+Height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration).
 
 Default: \unit[0.3]{cm}
 
 \macroname{braceshift}{}{gsp-default.tex}
-An additional shift you can give to the brace above the bars.  
+An additional shift you can give to the brace above the bars.
 
 Default: \unit[0]{cm}
 
 \macroname{curlybraceaccentusshift}{}{gsp-default.tex}
-A shift you can give to the accentus above the curly brace.  
+A shift you can give to the accentus above the curly brace.
 
 Default: $\unit[-0.05]{cm}$
 

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -133,7 +133,7 @@
 
     \vspace{1cm}
 
-    \large Version \textbf{4.0.0-rc2}, 5 November 2015 %% PARSE_VERSION_DATE
+    \large Version \textbf{4.0.0}, 8 December 2015 %% PARSE_VERSION_DATE
 
     \vspace{1.5cm}
   \end{center}

--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -79,7 +79,7 @@ AMBITUS = {
     5: 'Five',
 }
 
-GREGORIO_VERSION = '4.0.0-rc2'
+GREGORIO_VERSION = '4.0.0'
 
 # The unicode character at which we start our numbering:
 # U+E000 is the start of the BMP Private Use Area

--- a/macosx/Gregorio.pkgproj
+++ b/macosx/Gregorio.pkgproj
@@ -564,7 +564,7 @@
 				<key>OVERWRITE_PERMISSIONS</key>
 				<false/>
 				<key>VERSION</key>
-				<string>4.0.0-rc2</string><!--GREGORIO_VERSION-->
+				<string>4.0.0</string><!--GREGORIO_VERSION-->
 			</dict>
 			<key>UUID</key>
 			<string>74692645-8112-42EB-8FFC-2CBE2CEDE9FB</string>

--- a/src/bool.h
+++ b/src/bool.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header provides a minimum of C11-like bool functionality.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 
  * This file is part of Gregorio.

--- a/src/characters.h
+++ b/src/characters.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the lyric handling data structures and entry points.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header wraps the generated config_.h to provide version macros.
+ *
  * Gregorio configuration headers.
  *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX.
+ * This file provides functions to dump out Gregorio structures.
+ *
  * Copyright (C) 2007-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX.
+ * This file provides functions for determining elements from notes.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file provides functions for determining glyphs from notes.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the note parser.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -211,7 +214,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ub:[01]\{\] {
@@ -226,7 +229,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreUnderBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     underbrace_var, char_for_brace, underbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocb:[01]\{\] {
@@ -242,7 +245,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{0}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocba:[01]\{\] {
@@ -258,7 +261,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{1}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ob:[01]\}\] {
@@ -277,7 +280,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ub:[01]\}\] {
@@ -291,7 +294,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", underbrace_var,
                     char_for_brace);
             underbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocb:[01]\}\] {
@@ -310,7 +313,7 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocba:[01]\}\] {
@@ -329,33 +332,33 @@ static __inline void add_alteration(const gregorio_type type) {
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[nm[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[3]-'0']) {
             gregorio_add_texverb_to_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[3]-'0']));
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[3]-'0']));
         } else error();
     }
 <INITIAL>\[gm[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[3]-'0']) {
             gregorio_add_texverb_as_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
             GRE_TEXVERB_GLYPH, &notes_lloc);
         } else error();
     }
 <INITIAL>\[em[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[3]-'0']) {
             gregorio_add_texverb_as_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[3]-'0']),
             GRE_TEXVERB_ELEMENT, &notes_lloc);
         } else error();
     }
 <INITIAL>\[altm[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[5]-'0']) {
             gregorio_add_texverb_as_note(&current_note,
-            strdup(notesmacros[gabc_notes_determination_text[5]-'0']),
+            gregorio_strdup(notesmacros[gabc_notes_determination_text[5]-'0']),
             GRE_TEXVERB_ELEMENT, &notes_lloc);
         } else error();
     }
@@ -381,63 +384,65 @@ static __inline void add_alteration(const gregorio_type type) {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <underbrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreUnderBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <overcurlybrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{0}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <overcurlyaccentusbrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{1}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, strdup(tempstr));
+        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
     }
 <choralsign>[^\]]+ {
         gregorio_add_cs_to_note(&current_note,
-                strdup(gabc_notes_determination_text), false);
+                gregorio_strdup(gabc_notes_determination_text), false);
     }
 <choralnabc>[^\]]+ {
         gregorio_add_cs_to_note(&current_note,
-                strdup(gabc_notes_determination_text), true);
+                gregorio_strdup(gabc_notes_determination_text), true);
     }
 <texverbnote>[^\]]+ {
         gregorio_add_texverb_to_note(&current_note,
-                strdup(gabc_notes_determination_text));
+                gregorio_strdup(gabc_notes_determination_text));
     }
 <texverbglyph>[^\]]+ {
         gregorio_add_texverb_as_note(&current_note,
-                strdup(gabc_notes_determination_text), GRE_TEXVERB_GLYPH,
-                &notes_lloc);
+                gregorio_strdup(gabc_notes_determination_text),
+                GRE_TEXVERB_GLYPH, &notes_lloc);
     }
 <texverbelement>[^\]]+ {
         gregorio_add_texverb_as_note(&current_note,
-                strdup(gabc_notes_determination_text), GRE_TEXVERB_ELEMENT,
-                &notes_lloc);
+                gregorio_strdup(gabc_notes_determination_text),
+                GRE_TEXVERB_ELEMENT, &notes_lloc);
     }
 <alt>[^\]]+ {
         gregorio_add_texverb_as_note(&current_note,
-                strdup(gabc_notes_determination_text), GRE_ALT, &notes_lloc);
+                gregorio_strdup(gabc_notes_determination_text), GRE_ALT,
+                &notes_lloc);
     }
 <texverbnote,texverbglyph,texverbelement,choralsign,choralnabc,alt,overcurlyaccentusbrace,overcurlybrace,overbrace,underbrace>\] {
         BEGIN(INITIAL);
     }
 \{  {
-        gregorio_add_texverb_as_note(&current_note, strdup("\\hbox to 0pt{"),
-                GRE_TEXVERB_ELEMENT, &notes_lloc);
+        gregorio_add_texverb_as_note(&current_note,
+                gregorio_strdup("\\hbox to 0pt{"), GRE_TEXVERB_ELEMENT,
+                &notes_lloc);
     }
 \}  {
         gregorio_add_texverb_as_note(&current_note,
-                strdup("\\hss%\n}%\n\\GreNoBreak\\relax "), GRE_TEXVERB_ELEMENT,
-                &notes_lloc);
+                gregorio_strdup("\\hss%\n}%\n\\GreNoBreak\\relax "),
+                GRE_TEXVERB_ELEMENT, &notes_lloc);
     }
 [a-m]\+ {
         gregorio_add_manual_custos_as_note(&current_note,

--- a/src/gabc/gabc-score-determination.h
+++ b/src/gabc/gabc-score-determination.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header shares definitions between the score parser and lexer.
+ *
  * Gregorio score determination in gabc input.
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the score lexer.
+ *
  * Gregorio score determination in gabc input.
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
@@ -26,6 +29,7 @@
 #include "struct.h"
 #include "messages.h"
 #include "bool.h"
+#include "support.h"
 
 #include "gabc.h"
 #include "gabc-score-determination.h"
@@ -122,7 +126,8 @@ semicolon. */
         return COLON;
     }
 <attribute>[^;\n\r]*(;[^;\n\r]+)*([\n\r]+[^;]*(;[^;]+)*)? {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return ATTRIBUTE;
     }
 <attribute>;(;|[\n\r]+) {
@@ -233,7 +238,8 @@ semicolon. */
                 gabc_score_determination_text[0]);
     }
 <score>[^\{\}\(\[\]<%]+ {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <score,style><i> {
@@ -327,7 +333,8 @@ semicolon. */
         return SP_END;
     }
 <style>[^<\{\}]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <score>\% {
@@ -352,11 +359,13 @@ semicolon. */
         return VERB_END;
     }
 <verb>[^<]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <verb,style,score,alt>< {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <score,style>\{ {
@@ -370,7 +379,8 @@ semicolon. */
         return ALT_BEGIN;
     }
 <alt>[^<]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
     }
 <alt><\/alt> {
@@ -397,7 +407,8 @@ semicolon. */
         return OPENING_BRACKET;
     }
 <notes>[^&|\)]* {
-        gabc_score_determination_lval.text = strdup(gabc_score_determination_text);
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
         return NOTES;
     }
 <notes>& {

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the score parser.
+ *
  * Gregorio score determination in gabc input.
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
@@ -35,6 +38,7 @@
 #include "unicode.h"
 #include "messages.h"
 #include "characters.h"
+#include "support.h"
 #include "sha1.h"
 #include "plugins.h"
 #include "gabc.h"
@@ -335,7 +339,7 @@ static void end_definitions(void)
     }
     /* voice is now voice-1, so that it can be the index of elements */
     voice = 0;
-    elements = (gregorio_element **) malloc(number_of_voices *
+    elements = (gregorio_element **) gregorio_malloc(number_of_voices *
             sizeof(gregorio_element *));
     for (i = 0; i < number_of_voices; i++) {
         elements[i] = NULL;
@@ -629,10 +633,10 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
                     "happen!"), "gabc_y_add_notes", VERBOSITY_FATAL, 0);
         }
         if (!current_element->nabc) {
-            current_element->nabc = (char **) calloc (nabc_lines,
+            current_element->nabc = (char **) gregorio_calloc (nabc_lines,
                     sizeof (char *));
         }
-        current_element->nabc[nabc_state-1] = strdup(notes);
+        current_element->nabc[nabc_state-1] = gregorio_strdup(notes);
         current_element->nabc_lines = nabc_state;
     }
 }

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file provides functions for writing gabc from Gregorio structures.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gabc/gabc.h
+++ b/src/gabc/gabc.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes gabc-format handling data structures and entry points.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains the logic for positioning signs on neumes.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -1135,15 +1138,25 @@ static __inline void end_h_episema(height_computation *const h,
                 h->height = proposed_height;
             }
         }
-        /* end->previous checks that it's within the same glyph */
-        if (end && end->type == GRE_NOTE && end->previous
-                && end->previous->type == GRE_NOTE
-                && is_connected_left(h->get_size(end))
-                && !has_space_to_left(end) && h->last_connected_note
-                && is_connected_right(h->get_size(h->last_connected_note))) {
-            proposed_height = end->u.note.pitch + h->vpos;
-            if (h->is_better_height(proposed_height, h->height)) {
-                h->height = proposed_height;
+        if (end && end->type == GRE_NOTE) {
+            gregorio_note *note;
+            /* this loop checks that it's within the same glyph */
+            for (note = end->previous; note; note = note->previous) {
+                if (note == h->start_note) {
+                    if (is_connected_left(h->get_size(end))
+                            && h->last_connected_note
+                            && h->last_connected_note->next
+                            && h->last_connected_note->next->type == GRE_NOTE
+                            && !has_space_to_left(h->last_connected_note->next)
+                            && is_connected_right(h->get_size(
+                                    h->last_connected_note))) {
+                        proposed_height = end->u.note.pitch + h->vpos;
+                        if (h->is_better_height(proposed_height, h->height)) {
+                            h->height = proposed_height;
+                        }
+                    }
+                    break;
+                }
             }
         }
 

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains functions for writing GregorioTeX from Gregorio structures.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/gregoriotex/gregoriotex.h
+++ b/src/gregoriotex/gregoriotex.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes GregorioTeX writing data structures and entry points.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/messages.c
+++ b/src/messages.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains functions for logging messages, warnings, and errors.
+ *
  * Copyright (C) 2009-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/messages.h
+++ b/src/messages.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the message logging functions.
+ *
  * Copyright (C) 2009-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -1,5 +1,6 @@
 /*
- * Gregorio format support headers.
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the "main" entry points for reading and writing data.
  *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 

--- a/src/struct.c
+++ b/src/struct.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the Gregorio data structures.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -45,19 +48,14 @@
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"
+#include "support.h"
 #include "characters.h"
 #include "support.h"
 
 static gregorio_note *create_and_link_note(gregorio_note **current_note,
         const gregorio_scanner_location *const loc)
 {
-    gregorio_note *note = calloc(1, sizeof(gregorio_note));
-    if (!note) {
-        gregorio_message(_("error in memory allocation"),
-                         "create_and_link_note", VERBOSITY_FATAL, 0);
-        return NULL;
-    }
-
+    gregorio_note *note = gregorio_calloc(1, sizeof(gregorio_note));
     note->previous = *current_note;
     note->next = NULL;
     if (*current_note) {
@@ -237,7 +235,7 @@ void gregorio_add_texverb_to_note(gregorio_note **current_note, char *str)
     if (*current_note) {
         if ((*current_note)->texverb) {
             len = strlen((*current_note)->texverb) + strlen(str) + 1;
-            res = malloc(len * sizeof(char));
+            res = gregorio_malloc(len * sizeof(char));
             strcpy(res, (*current_note)->texverb);
             strcat(res, str);
             free((*current_note)->texverb);
@@ -627,13 +625,7 @@ static void gregorio_free_notes(gregorio_note **note)
 
 static gregorio_glyph *create_and_link_glyph(gregorio_glyph **current_glyph)
 {
-    gregorio_glyph *glyph = calloc(1, sizeof(gregorio_glyph));
-    if (!glyph) {
-        gregorio_message(_("error in memory allocation"),
-                         "create_and_link_glyph", VERBOSITY_FATAL, 0);
-        return NULL;
-    }
-
+    gregorio_glyph *glyph = gregorio_calloc(1, sizeof(gregorio_glyph));
     glyph->previous = *current_glyph;
     glyph->next = NULL;
     if (*current_glyph) {
@@ -748,13 +740,7 @@ static void gregorio_free_glyphs(gregorio_glyph **glyph)
 static gregorio_element *create_and_link_element(gregorio_element
                                                  **current_element)
 {
-    gregorio_element *element = calloc(1, sizeof(gregorio_element));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "create_and_link_element", VERBOSITY_FATAL, 0);
-        return NULL;
-    }
-
+    gregorio_element *element = gregorio_calloc(1, sizeof(gregorio_element));
     element->previous = *current_element;
     element->next = NULL;
     if (*current_element) {
@@ -833,12 +819,7 @@ void gregorio_add_character(gregorio_character **current_character,
         grewchar wcharacter)
 {
     gregorio_character *element =
-        (gregorio_character *) calloc(1, sizeof(gregorio_character));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "gregorio_add_character", VERBOSITY_FATAL, 0);
-        return;
-    }
+        (gregorio_character *) gregorio_calloc(1, sizeof(gregorio_character));
     element->is_character = 1;
     element->cos.character = wcharacter;
     element->next_character = NULL;
@@ -884,12 +865,7 @@ void gregorio_begin_style(gregorio_character **current_character,
         grestyle_style style)
 {
     gregorio_character *element =
-        (gregorio_character *) calloc(1, sizeof(gregorio_character));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "add_note", VERBOSITY_FATAL, 0);
-        return;
-    }
+        (gregorio_character *) gregorio_calloc(1, sizeof(gregorio_character));
     element->is_character = 0;
     element->cos.s.type = ST_T_BEGIN;
     element->cos.s.style = style;
@@ -905,12 +881,7 @@ void gregorio_end_style(gregorio_character **current_character,
         grestyle_style style)
 {
     gregorio_character *element =
-        (gregorio_character *) calloc(1, sizeof(gregorio_character));
-    if (!element) {
-        gregorio_message(_("error in memory allocation"),
-                         "add_note", VERBOSITY_FATAL, 0);
-        return;
-    }
+        (gregorio_character *) gregorio_calloc(1, sizeof(gregorio_character));
     element->is_character = 0;
     element->cos.s.type = ST_T_END;
     element->cos.s.style = style;
@@ -968,12 +939,7 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
                 0);
         return;
     }
-    next = calloc(1, sizeof(gregorio_syllable));
-    if (!next) {
-        gregorio_message(_("error in memory allocation"), "add_syllable",
-                VERBOSITY_FATAL, 0);
-        return;
-    }
+    next = gregorio_calloc(1, sizeof(gregorio_syllable));
     next->type = GRE_SYLLABLE;
     next->special_sign = _NO_SIGN;
     next->position = position;
@@ -991,8 +957,8 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
     }
     next->next_syllable = NULL;
     next->previous_syllable = *current_syllable;
-    tab = (gregorio_element **) malloc(number_of_voices *
-                                       sizeof(gregorio_element *));
+    tab = (gregorio_element **) gregorio_malloc(number_of_voices *
+            sizeof(gregorio_element *));
     if (elements) {
         for (i = 0; i < number_of_voices; i++) {
             tab[i] = elements[i];
@@ -1064,7 +1030,7 @@ static void gregorio_source_info_init(source_info *si)
 gregorio_score *gregorio_new_score(void)
 {
     int annotation_num;
-    gregorio_score *new_score = calloc(1, sizeof(gregorio_score));
+    gregorio_score *new_score = gregorio_calloc(1, sizeof(gregorio_score));
     new_score->first_syllable = NULL;
     new_score->number_of_voices = 1;
     new_score->name = NULL;
@@ -1265,7 +1231,7 @@ void gregorio_set_score_user_notes(gregorio_score *score, char *user_notes)
 
 void gregorio_add_voice_info(gregorio_voice_info **current_voice_info)
 {
-    gregorio_voice_info *next = calloc(1, sizeof(gregorio_voice_info));
+    gregorio_voice_info *next = gregorio_calloc(1, sizeof(gregorio_voice_info));
     next->initial_key = NO_KEY;
     next->flatted_key = false;
     next->style = NULL;

--- a/src/struct.h
+++ b/src/struct.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header defines the Gregorio data structures and functions.
+ *
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/support.c
+++ b/src/support.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains miscellaneous support functions.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 
  * This file is part of Gregorio.
@@ -21,7 +24,9 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <string.h>
 #include "support.h"
+#include "messages.h"
 
 /* Our version of snprintf; this is NOT semantically the same as C99's
  * snprintf; rather, it's a "lowest common denominator" implementation
@@ -41,4 +46,48 @@ void gregorio_snprintf(char *s, size_t size, const char *format, ...)
     vsnprintf(s, size, format, args);
 #endif
     va_end(args);
+}
+
+void *gregorio_malloc(size_t size)
+{
+    void *result = malloc(size);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_malloc", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
+}
+
+void *gregorio_calloc(size_t nmemb, size_t size)
+{
+    void *result = calloc(nmemb, size);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_calloc", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
+}
+
+void *gregorio_realloc(void *ptr, size_t size)
+{
+    void *result = realloc(ptr, size);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_realloc", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
+}
+
+char *gregorio_strdup(const char *s)
+{
+    char *result = strdup(s);
+    if (!result) {
+        gregorio_message(_("error in memory allocation"),
+                "gregorio_strdup", VERBOSITY_FATAL, 0);
+        exit(1);
+    }
+    return result;
 }

--- a/src/support.h
+++ b/src/support.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the miscellaneous support functions.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  * 
  * This file is part of Gregorio.
@@ -24,5 +27,9 @@
 
 void gregorio_snprintf(char *s, size_t size, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 3, 4)));
+void *gregorio_malloc(size_t size);
+void *gregorio_calloc(size_t nmemb, size_t size);
+void *gregorio_realloc(void *ptr, size_t size);
+char *gregorio_strdup(const char *s);
 
 #endif

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file contains functions providing UTF-8 support.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -24,6 +27,7 @@
 #include "struct.h"
 #include "unicode.h"
 #include "messages.h"
+#include "support.h"
 
 /*
  * 
@@ -109,7 +113,7 @@ grewchar *gregorio_build_grewchar_string_from_buf(const char *const buf)
         return NULL;
     }
     len = strlen(buf); /* to get the length of the syllable in ASCII */
-    gwstring = (grewchar *) malloc((len + 1) * sizeof(grewchar));
+    gwstring = (grewchar *) gregorio_malloc((len + 1) * sizeof(grewchar));
     gregorio_mbstowcs(gwstring, buf, len); /* converting into wchar_t */
     return gwstring;
 }
@@ -147,7 +151,7 @@ unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf)
         return 1;
     }
     len = strlen(buf); /* to get the length of the syllable in ASCII */
-    gwbuf = (grewchar *) malloc((len + 1) * sizeof(grewchar));
+    gwbuf = (grewchar *) gregorio_malloc((len + 1) * sizeof(grewchar));
     gregorio_mbstowcs(gwbuf, buf, len); /* converting into wchar_t */
     /* we add the corresponding characters in the list of gregorio_characters */
     while (gwbuf[i] && wstr[i]) {

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the UTF-8 support functions.
+ *
  * Copyright (C) 2008-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/utf8strings.h.in
+++ b/src/utf8strings.h.in
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header file contains UTF-8 encoded strings used by Gregorio
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/vowel/vowel-rules.h
+++ b/src/vowel/vowel-rules.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header shares definitions between the vowel parser and lexer.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/src/vowel/vowel-rules.l
+++ b/src/vowel/vowel-rules.l
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the vowel rule lexer.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -24,6 +27,7 @@
 #include <string.h>
 #include "struct.h"
 #include "messages.h"
+#include "support.h"
 
 #include "vowel.h"
 
@@ -35,7 +39,7 @@
 static __inline void save_lval(void)
 {
     gregorio_vowel_rulefile_lval =
-            malloc((gregorio_vowel_rulefile_leng + 1) * sizeof(char));
+            gregorio_malloc((gregorio_vowel_rulefile_leng + 1) * sizeof(char));
     strncpy(gregorio_vowel_rulefile_lval, gregorio_vowel_rulefile_text,
             gregorio_vowel_rulefile_leng);
     gregorio_vowel_rulefile_lval[gregorio_vowel_rulefile_leng] = '\0';

--- a/src/vowel/vowel-rules.y
+++ b/src/vowel/vowel-rules.y
@@ -1,5 +1,8 @@
 %{
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements the vowel rule parser.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This program is free software: you can redistribute it and/or modify it

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This file implements vowel rule handling (aside from parsing).
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
@@ -30,6 +33,7 @@
 #include "vowel.h"
 #include "unicode.h"
 #include "messages.h"
+#include "support.h"
 
 typedef struct character_set {
     grewchar *table;
@@ -42,21 +46,15 @@ typedef struct character_set {
 
 static character_set *character_set_new(const bool alloc_next)
 {
-    character_set *set = (character_set *)calloc(1, sizeof(character_set));
+    character_set *set =
+        (character_set *)gregorio_calloc(1, sizeof(character_set));
     set->mask = 0x0f;
     set->bins = 16;
     set->size = 0;
-    set->table = (grewchar *)calloc(set->bins, sizeof(grewchar));
-    if (!set->table) {
-        gregorio_message(_("unable to allocate memory"),
-                "character_set_new", VERBOSITY_FATAL, 0);
-    }
+    set->table = (grewchar *)gregorio_calloc(set->bins, sizeof(grewchar));
     if (alloc_next) {
-        set->next = (character_set **)calloc(set->bins, sizeof(character_set *));
-        if (!set->next) {
-            gregorio_message(_("unable to allocate memory"),
-                    "character_set_new", VERBOSITY_FATAL, 0);
-        }
+        set->next = (character_set **)gregorio_calloc(set->bins,
+                sizeof(character_set *));
     }
     return set;
 }
@@ -144,9 +142,9 @@ static __inline void character_set_grow(character_set *const set) {
 
     set->bins <<= 1;
     set->mask = (set->mask << 1) | 0x01;
-    set->table = calloc(set->bins, sizeof(grewchar));
+    set->table = gregorio_calloc(set->bins, sizeof(grewchar));
     if (old_next) {
-        set->table = calloc(set->bins, sizeof(character_set *));
+        set->table = gregorio_calloc(set->bins, sizeof(character_set *));
     }
     for (i = 0; i < old_bins; ++i) {
         if (old_table[i]) {
@@ -208,19 +206,12 @@ extern FILE *gregorio_vowel_rulefile_in;
 
 static void prefix_buffer_grow(size_t required_size)
 {
-    grewchar *newbuffer;
-
     while (required_size > prefix_buffer_size) {
         prefix_buffer_size <<= 1;
         prefix_buffer_mask = (prefix_buffer_mask << 1) | 0x01;
     }
-    newbuffer = realloc(prefix_buffer, prefix_buffer_size * sizeof(grewchar));
-    if (newbuffer) {
-        prefix_buffer = newbuffer;
-    } else {
-        gregorio_message(_("unable to allocate memory"), "prefix_buffer_grow",
-                VERBOSITY_FATAL, 0);
-    }
+    prefix_buffer = gregorio_realloc(prefix_buffer,
+            prefix_buffer_size * sizeof(grewchar));
 }
 
 void gregorio_vowel_tables_init(void)
@@ -238,12 +229,8 @@ void gregorio_vowel_tables_init(void)
 
         prefix_buffer_size = 16;
         prefix_buffer_mask = 0x0f;
-        prefix_buffer = (grewchar *)malloc(
+        prefix_buffer = (grewchar *)gregorio_malloc(
                 prefix_buffer_size * sizeof(grewchar));
-        if (!prefix_buffer) {
-            gregorio_message(_("unable to allocate memory"),
-                    "gregorio_vowel_tables_init", VERBOSITY_FATAL, 0);
-        }
     }
 }
 

--- a/src/vowel/vowel.h
+++ b/src/vowel/vowel.h
@@ -1,4 +1,7 @@
 /*
+ * Gregorio is a program that translates gabc files to GregorioTeX
+ * This header prototypes the vowel handling data structures and entry points.
+ *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.

--- a/tex/gregoriosyms.sty
+++ b/tex/gregoriosyms.sty
@@ -19,7 +19,7 @@
 
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{gregoriosyms}
-    [2015/11/05 v4.0.0-rc2 GregorioTeX symbols only.]% PARSE_VERSION_DATE_LTX
+    [2015/12/08 v4.0.0 GregorioTeX symbols only.]% PARSE_VERSION_DATE_LTX
 
 % If gregoriotex has been loaded, then we need to abort the loading process of this package here in order to avoid some conflicts.
 \ifcsname gregoriotex@symbols@loaded\endcsname\endinput\fi%
@@ -38,7 +38,7 @@
 
 % The version of gregorio. All gregoriotex*.tex files must have the same.
 % All gtex files must also have the same version.
-\xdef\gre@gregorioversion{4.0.0-rc2}% GREGORIO_VERSION - VersionManager.py
+\xdef\gre@gregorioversion{4.0.0}% GREGORIO_VERSION - VersionManager.py
 
 \providecommand{\gre@declarefileversion}[2]{\relax}
 

--- a/tex/gregoriotex-chars.tex
+++ b/tex/gregoriotex-chars.tex
@@ -17,7 +17,7 @@
 % You should have received a copy of the GNU General Public License
 % along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
-\gre@declarefileversion{gregoriotex-chars.tex}{4.0.0-rc2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-chars.tex}{4.0.0}% GREGORIO_VERSION
 
 \def\gre@char@fuse@punctum@one{\GreFuseTwo{\GreCPLeadingPunctumOne}{\GreCPPunctum}}%
 \def\gre@char@fuse@quilisma@one{\GreFuseTwo{\GreCPLeadingQuilismaOne}{\GreCPPunctum}}%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -106,7 +106,7 @@
 
 % The version of gregorio. All gregoriotex*.tex files must have the same.
 % All gtex files must also have the same version.
-\xdef\gre@gregorioversion{4.0.0-rc2}% GREGORIO_VERSION - VersionManager.py
+\xdef\gre@gregorioversion{4.0.0}% GREGORIO_VERSION - VersionManager.py
 
 % first some macros to allow checks for version:
 % Tests that all gregoriotex files are of the same version.
@@ -1172,8 +1172,8 @@
       \fi %
     \fi %
   \fi %
-  %\gre@penalty{\greendafterbarpenalty }\relax 
-  %\global\gre@dimen@enddifference=0pt 
+  %\gre@penalty{\greendafterbarpenalty }\relax
+  %\global\gre@dimen@enddifference=0pt
   \relax %
 }%
 
@@ -1310,7 +1310,7 @@
   \or% case 1
     \gre@skip@temp@four = \gre@dimen@zerowidthspace\relax%
   \or% case 2
-    \gre@skip@temp@four = \gre@skip@alterationspace\relax%
+    \gre@skip@temp@four = \gre@dimen@alterationspace\relax%
   \or% case 3
     \gre@skip@temp@four = \gre@skip@punctuminclinatumshift\relax%
   \or% case 4
@@ -1758,9 +1758,9 @@
 % macro to force hyphenation of all syllables.
 \def\gresethyphen#1{%
   \IfStrEq{#1}{force}%
-    {\global\grechangedim{maximumspacewithoutdash}{-16383.99999pt}{0}}%
+    {\global\grechangedim{maximumspacewithoutdash}{-16383.99999pt}{fixed}}%
     {\IfStrEq{#1}{auto}%
-      {\global\grechangedim{maximumspacewithoutdash}{0.02 cm}{1}}%
+      {\global\grechangedim{maximumspacewithoutdash}{0.02 cm}{scalable}}%
       {\gre@error{Unrecognized option in \protect\gresethyphen}}%
     }%
 }%

--- a/tex/gregoriotex-nabc.lua
+++ b/tex/gregoriotex-nabc.lua
@@ -209,7 +209,7 @@ local add_ls = function(base, pre, ls, position, glyphbox, lsbox, baseraise, lwi
     if position == 2 then
       raise = glyphbox.height + lsbox.depth + baseraise
     else
-      raise = -glyphbox.depth - lsbox.height + baseraise 
+      raise = -glyphbox.depth - lsbox.height + baseraise
     end
     local kern1 = -math.max(glyphbox.width, lwidths[11])/2 - lwidths[position]/2 + curlwidths[position]
     curlwidths[position] = curlwidths[position] + lsbox.width

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -22,7 +22,7 @@
 
 \def\grebarbracewidth{.58879}%
 
-\gre@declarefileversion{gregoriotex-signs.tex}{4.0.0-rc2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-signs.tex}{4.0.0}% GREGORIO_VERSION
 
 \def\gre@usestylecommon{%
   \ifgre@usestylefont\else %
@@ -37,7 +37,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% macros for discretionaries
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% 
+%
 % In order to avoid clef change at beginning or end of line, we use discretionaries
 % for clef change, or even with more complex data (z0::c3 for instance). The problem
 % with discretionaries is that:
@@ -154,7 +154,7 @@
 }%
 
 % macro that typesets the key
-% arguments are : 
+% arguments are :
 %% #1: the type of the key : c or f
 %% #2: the line of the key (1 is the lowest)
 %% #3: if we must use small key characters (inside a line) or not 0: if not inside, 1 if inside
@@ -1674,14 +1674,13 @@
   \ifnum#4=0\relax %
     % we try to avoid line breaking after a flat or a natural
     \GreNoBreak %
-    \gre@skip@temp@four = \gre@skip@alterationspace\relax%
+    \gre@skip@temp@four = \gre@dimen@alterationspace\relax%
     \ifgre@firstglyph%
       \gre@debugmsg{bolshift}{making adjustments for leading alteration}%
       \global\advance\gre@dimen@notesaligncenter by \wd\gre@box@temp@width %
       \global\advance\gre@dimen@notesaligncenter by \dimexpr\gre@skip@temp@four\relax %
       \kern\gre@skip@temp@four %
       \global\gre@dimen@bolextra = \wd\gre@box@temp@width%
-      \gre@skip@temp@four = \gre@skip@alterationspace\relax%
       \global\advance\gre@dimen@bolextra by \dimexpr\gre@skip@temp@four\relax%
       \gre@debugmsg{bolshift}{bolextra: \the\gre@dimen@bolextra}%
     \else %
@@ -1740,7 +1739,7 @@
       }%
       {\gre@error{Unrecognized option for \protect\gresetpunctumcavum}}%
     }%
-}%	
+}%
 
 
 \def\UseAlternatePunctumCavum{%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -19,7 +19,7 @@
 
 % this file contains definitions of spaces
 
-\gre@declarefileversion{gregoriotex-spaces.tex}{4.0.0-rc2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-spaces.tex}{4.0.0}% GREGORIO_VERSION
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% macros for tuning penalties
@@ -218,7 +218,7 @@
 %% @uses \gre@dimen@enddifference
 %% @uses \gre@dimen@nextbegindifference
 %%
-%% Pseudo-code: 
+%% Pseudo-code:
 %%  min_text_dist = same_word ? 0 : space_inter_words
 %%  if (no_txt_under_prev) :
 %%     tmp = cur_end_diff > 0 ? 0 : -cur_end_diff
@@ -346,12 +346,12 @@
     % no additional shift is needed if the notes start before the text
     \global\gre@dimen@bolshift = \gre@skip@temp@three\relax%
   \else%
-    % as the \gre@dimen@bolshift is computed from skips, we compute it in 
+    % as the \gre@dimen@bolshift is computed from skips, we compute it in
     % a skip temp registry, and then "cast" it into a dimen
     % basic value for bolshift needs to incorporate -begindifference
     \advance\gre@skip@temp@three by -#1\relax%
     % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
-    % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef) 
+    % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef)
     % or that the lyrics are closer than minimalspaceatlinebeginning
     \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
     \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
@@ -497,7 +497,7 @@
   \global\multiply\gre@dimen@glyphraisevalue by \the\gre@factor %
   \global\multiply\gre@dimen@glyphraisevalue by \the\gre@count@temp@three %
   \gre@dimen@addedraisevalue= 0 sp%
-  \ifcase#2 % 
+  \ifcase#2 %
   \or\or\or%3: if it is a vertical episema on a line, we shift it a bit higher, so that it's more beautiful
     \ifgre@isonaline%
       \gre@dimen@addedraisevalue=7250 sp%
@@ -513,7 +513,7 @@
       \gre@dimen@addedraisevalue=-6900 sp%
       \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
       \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
-    \else % 
+    \else %
       \gre@dimen@addedraisevalue=-2200 sp%
       \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
       \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
@@ -796,7 +796,7 @@
 \def\grecreatedim#1#2#3{%
   \gre@dimension{#1}{#2}
   \csname newif\expandafter\endcsname\csname ifgre@scale@#1\endcsname%
-  \IfStrEq{#3}{1}%	
+  \IfStrEq{#3}{1}%
     {\gre@deprecated{A numerical (1) last argument for \protect\grecreatedim}{'scalable'}%
     \grescaledim{#1}{true}}%
     {\IfStrEq{#3}{0}%
@@ -951,6 +951,7 @@
   \IfStrEq{#1}{curlybraceaccentusshift}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{initialraise}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{beforealterationspace}{\gre@rubberfalse}{\relax}%
+  \IfStrEq{#1}{alterationspace}{\gre@rubberfalse}{\relax}%
 }%
 
 %% an aux function adapting the value #1 from the factor #2 to the factor #3

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -19,7 +19,7 @@
 
 % this file contains definitions of the glyphs and the syllables
 
-\gre@declarefileversion{gregoriotex-syllable.tex}{4.0.0-rc2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-syllable.tex}{4.0.0}% GREGORIO_VERSION
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% macros for the typesetting of the different glyphs
@@ -133,7 +133,7 @@
     \global\gre@firstglyphfalse%
   \fi%
   %\gre@dimen@lastglyphwidth=\gre@dimen@temp@three
-  %#5\relax 
+  %#5\relax
   #6\relax %
   \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \relax%
@@ -261,7 +261,7 @@
   \relax %
 }%
 
-% this is the function that we call when we try to determine the next aligncenter of the notes. In this case we call this function with normal arguments if there is no flat nor natural ; we call it with argument + 20 if there is a flat and argument + 40 if there is a natural... I know this is dirty... but... this is TeX...
+% this is the function that we call when we try to determine the next aligncenter of the notes. In this case we call this function with normal arguments if there is no flat nor natural ; we call it with argument + 20 if there is a flat and argument + 40 if there is a natural, +60 with a sharp
 \def\gre@calculate@nextnotesaligncenter#1{%
   \ifnum#1<20\relax %
     \gre@calculate@simplenotesaligncenter{#1}{1}%
@@ -292,6 +292,7 @@
       \fi%
     \fi %
     \advance\gre@dimen@temp@five by \wd\gre@box@temp@width %
+    \advance\gre@dimen@temp@five by \gre@dimen@alterationspace %
     \global\gre@dimen@notesaligncenter=\gre@dimen@temp@five %
   \fi %
   \relax %
@@ -340,9 +341,9 @@
 \newif\ifgre@boxing%
 \gre@boxingfalse%
 
-% 
+%
 % Helper macros for fixing text in rare cases
-% 
+%
 
 % the macro we call with all normal text
 \def\gre@textnormal#1{%
@@ -540,7 +541,7 @@
 % TODO: find another system for the end syllable
 % #9 : glyphs : all the notes
 % the three next parameters are to put an hyphen if necessary, they can be empty for end of words
-% #5 : macros setting next syllable letters of the next syllable 
+% #5 : macros setting next syllable letters of the next syllable
 % #6 : the line:char:column for a textedit link
 % #7 : alignment type of the first next glyph
 % #8 : other macros (translation, double text, etc.) that don't fit in the limitation of the number of arguments
@@ -578,7 +579,7 @@
     \ifgre@beginningofscore%
       \gre@beginningofscorefalse%
     \else%
-      % we don't want to shift right inside a discretionary 
+      % we don't want to shift right inside a discretionary
       \ifnum\gre@insidediscretionary=0\relax%
         \kern\gre@dimen@bolshift\relax%
       \fi%
@@ -777,7 +778,7 @@
   \gre@debugmsg{ifdim}{ wd(gre@box@syllabletext) = 0pt}%
   \ifdim\wd\gre@box@syllabletext = 0 pt\relax %
     % the most difficult case : when there is nothing to write
-    % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces : 
+    % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces :
     %% 1/ the minimal space between a note and the bar + the width of the bar + the minimal space between the bar and the note (that's the global idea, in fact there are nuances) : we assign skip@temp@three to it
     %% 2/ enddifference + begindifference + space between notes and word : we assign skip@temp@two to it
     \gre@skip@temp@three=\gre@skip@notebarspace\relax%
@@ -852,14 +853,14 @@
         \gre@debugmsg{ifdim}{ temp@skip@two > -wd(gre@box@syllablenotes)}%
         \ifdim\gre@skip@temp@two > -\wd\gre@box@syllablenotes %
           \kern\gre@skip@temp@two %
-        \else % \ifdim\gre@dimen@temp@five > -\wd\gre@box@syllablenotes 
+        \else % \ifdim\gre@dimen@temp@five > -\wd\gre@box@syllablenotes
           \gre@skip@temp@one = -\wd\gre@box@syllablenotes %
           \gre@hskip\gre@skip@temp@one %
         \fi %
       \fi %
     \fi %
   % then the most simple : the case where there is something to write under the bar. We just need to adjust the spaces.
-  \else %ifdim\wd\gre@box@syllabletext = 0 pt 
+  \else %ifdim\wd\gre@box@syllabletext = 0 pt
     #8\relax %
     \raise\gre@dimen@textlower \copy\gre@box@syllabletext %
     \ifgre@mustdotranslationcenterend%

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -22,7 +22,7 @@
 \ifcsname gregoriotex@symbols@loaded\endcsname\endinput\fi%
 \def\gregoriotex@symbols@loaded{}%
 
-\gre@declarefileversion{gregoriotex-symbols.tex}{4.0.0-rc2}% GREGORIO_VERSION
+\gre@declarefileversion{gregoriotex-symbols.tex}{4.0.0}% GREGORIO_VERSION
 
 \RequireLuaModule{gregoriotex}%
 

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -24,13 +24,13 @@ local hpack, traverse, traverse_id, has_attribute, count, remove, insert_after, 
 gregoriotex = gregoriotex or {}
 local gregoriotex = gregoriotex
 
-local internalversion = '4.0.0-rc2' -- GREGORIO_VERSION (comment used by VersionManager.py)
+local internalversion = '4.0.0' -- GREGORIO_VERSION (comment used by VersionManager.py)
 
 local err, warn, info, log = luatexbase.provides_module({
     name               = "gregoriotex",
-    version            = '4.0.0-rc2', -- GREGORIO_VERSION
+    version            = '4.0.0', -- GREGORIO_VERSION
     greinternalversion = internalversion,
-    date               = "2015/11/05", -- GREGORIO_DATE_LTX
+    date               = "2015/12/08", -- GREGORIO_DATE_LTX
     description        = "GregorioTeX module.",
     author             = "The Gregorio Project (see CONTRIBUTORS.md)",
     copyright          = "2008-2015 - The Gregorio Project",

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -19,7 +19,7 @@
 
 \NeedsTeXFormat{LaTeX2e}%
 \ProvidesPackage{gregoriotex}%
-    [2015/11/05 v4.0.0-rc2 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
+    [2015/12/08 v4.0.0 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
 
 % If gregoriosyms has been loaded then there are going to be some conflicts in the definitions made in that package and this one.  In order to provide for a more informative error message, we check for that conflict right away
 \ifcsname gregoriotex@symbols@loaded\endcsname\gre@error{Loading gregoriotex after\MessageBreak gregoriosyms is not supported.  Please remove the\MessageBreak loading of gregoriosyms (its contents are loaded\MessageBreak by gregoriotex)}\fi%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -21,7 +21,7 @@
 
 
 % This file needs to be marked with the version number.  For now I've done this with the following comment, but we should check to see if PlainTeX has something similar to the version declaration of LaTeX and use that if it does.
-% 		[2015/11/05 v4.0.0-rc2 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
+% 		[2015/12/08 v4.0.0 GregorioTeX system.]% PARSE_VERSION_DATE_LTX
 
 
 \edef\greoldcatcode{\the\catcode`@}

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -52,7 +52,7 @@
 % Workaround for bug 842 (http://tracker.luatex.org/view.php?id=842)
 % see http://tug.org/pipermail/luatex/2013-July/004516.html
 % The idea is that we use discretionaries (explicit hyphens, though more than hyphens in our case) for clef changes, and we need to give them a special penalty, which is not taken into account if pretolerance is > -1 on LuaTeX < 0.80. For a more detailed explanation see http://tug.org/pipermail/luatex/2013-July/004516.html.
-\ifnum\the\luatexversion < 78\relax % 
+\ifnum\the\luatexversion < 78\relax %
   \global\def\grepretolerance{-1}%
 \else %
   \global\def\grepretolerance{\pretolerance}%
@@ -87,7 +87,7 @@
 % space between glyphs in the same element
 \grecreatedim{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between an alteration (flat or natural) and the next glyph
-\grecreatedim{alterationspace}{0.07747 cm plus 0.01276 cm minus 0.00455 cm}{scalable}%
+\grecreatedim{alterationspace}{0.07747 cm}{scalable}%
 % space between a clef and a flat (for clefs with flat)
 \grecreatedim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
 % space before a choral sign

--- a/windows/gregorio-resources.rc
+++ b/windows/gregorio-resources.rc
@@ -1,7 +1,7 @@
 IDI_ICON1 ICON DISCARDABLE "gregorio.ico"
 1 VERSIONINFO
-FILEVERSION     4,0,0,22
-PRODUCTVERSION  4,0,0,22
+FILEVERSION     4,0,0,30
+PRODUCTVERSION  4,0,0,30
 BEGIN
   BLOCK "StringFileInfo"
   BEGIN
@@ -9,12 +9,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "Gregorio project"
       VALUE "FileDescription", "Gregorio"
-      VALUE "FileVersion", "4.0.0-rc2"
+      VALUE "FileVersion", "4.0.0"
       VALUE "InternalName", "gregorio"
       VALUE "LegalCopyright", "See COPYING in the installation directory."
       VALUE "OriginalFilename", "gregorio.exe"
       VALUE "ProductName", "Gregorio"
-      VALUE "ProductVersion", "4.0.0-rc2"
+      VALUE "ProductVersion", "4.0.0"
     END
   END
 

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=gregorio
-AppVersion=4.0.0-rc2
+AppVersion=4.0.0
 DefaultDirName={pf}\gregorio
 DefaultGroupName=gregorio
 SetupIconFile=gregorio.ico
@@ -53,9 +53,9 @@ Source: "../README.md"; DestDir: "{app}";
 Source: "../CONTRIBUTORS.md"; DestDir: "{app}";
 Source: "../UPGRADE.md"; DestDir: "{app}";
 ; PARSE_VERSION_FILE_NEXTLINE
-Source: "../doc/GregorioRef-4_0_0-rc2.pdf"; DestDir: "{app}";
+Source: "../doc/GregorioRef-4_0_0.pdf"; DestDir: "{app}";
 ; PARSE_VERSION_FILE_NEXTLINE
-Source: "../doc/GregorioNabcRef-4_0_0-rc2.pdf"; DestDir: "{app}";
+Source: "../doc/GregorioNabcRef-4_0_0.pdf"; DestDir: "{app}";
 Source: "../COPYING.md"; DestDir: "{app}";
 Source: "../contrib/900_gregorio.xml"; DestDir: "{app}\contrib";
 Source: "../contrib/system-setup.bat"; DestDir: "{app}";


### PR DESCRIPTION
There were two conflicts: CHANGELOG.md and src/gabc/gabc-score-determination.l

Please double check my reconciliations (especially on the latter).

gabc-gabc/glyphs/horizontal_episemus.gabc fails, but this appears to be because the gabc source was modified in b5a78b0 but the gabc-gabc expectation was not updated (though the gabc-dump and gabc-output expectations were).  All other tests pass.