### PR TITLE
Eliminated dependency on PATH_MAX.

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -49,12 +49,6 @@
 #include "utf8strings.h"
 #include "vowel/vowel.h"
 
-#ifdef _WIN32
-#ifndef PATH_MAX
-#define PATH_MAX _MAX_PATH
-#endif
-#endif
-
 #define VOWEL_FILE "gregorio-vowels.dat"
 
 #ifndef USE_KPSE
@@ -85,7 +79,8 @@ static bool read_vowel_rules(char *const lang) {
     }
 #else
     FILE *file;
-    char buf[PATH_MAX];
+    int bufsize = 128;
+    char *buf = gregorio_malloc(bufsize * sizeof(char));
     size_t capacity = 16, size = 0;
     
     filenames = gregorio_malloc(capacity * sizeof(char *));
@@ -97,7 +92,17 @@ static bool read_vowel_rules(char *const lang) {
                 strerror(errno));
         return false;
     }
-    while (!feof(file) && !ferror(file) && fgets(buf, PATH_MAX, file)) {
+    for (buf[bufsize - 2] = '\n';
+            !feof(file) && !ferror(file) && fgets(buf, bufsize, file);
+            buf[bufsize - 2] = '\n') {
+        while (!feof(file) && !ferror(file) && buf[bufsize - 2] != '\n'
+                && bufsize < MAX_BUF_GROWTH) {
+            int oldsize = bufsize;
+            bufsize <<= 1;
+            buf = (char *)gregorio_realloc(buf, bufsize * sizeof(char));
+            buf[bufsize - 2] = '\n';
+            fgets(buf + oldsize - 1, oldsize + 1, file);
+        }
         rtrim(buf);
         if (strlen(buf) > 0) {
             filenames[size++] = gregorio_strdup(buf);
@@ -111,6 +116,7 @@ static bool read_vowel_rules(char *const lang) {
                     _("kpsewhich returned bad value for %s"), VOWEL_FILE);
         }
     }
+    free(buf);
     filenames[size] = NULL;
     pclose(file);
 #endif

--- a/src/characters.c
+++ b/src/characters.c
@@ -79,8 +79,8 @@ static bool read_vowel_rules(char *const lang) {
     }
 #else
     FILE *file;
-    int bufsize = 128;
-    char *buf = gregorio_malloc(bufsize * sizeof(char));
+    size_t bufsize = 0;
+    char *buf = NULL;
     size_t capacity = 16, size = 0;
     
     filenames = gregorio_malloc(capacity * sizeof(char *));
@@ -92,17 +92,7 @@ static bool read_vowel_rules(char *const lang) {
                 strerror(errno));
         return false;
     }
-    for (buf[bufsize - 2] = '\n';
-            !feof(file) && !ferror(file) && fgets(buf, bufsize, file);
-            buf[bufsize - 2] = '\n') {
-        while (!feof(file) && !ferror(file) && buf[bufsize - 2] != '\n'
-                && bufsize < MAX_BUF_GROWTH) {
-            int oldsize = bufsize;
-            bufsize <<= 1;
-            buf = (char *)gregorio_realloc(buf, bufsize * sizeof(char));
-            buf[bufsize - 2] = '\n';
-            fgets(buf + oldsize - 1, oldsize + 1, file);
-        }
+    while (gregorio_readline(&buf, &bufsize, file)) {
         rtrim(buf);
         if (strlen(buf) > 0) {
             filenames[size++] = gregorio_strdup(buf);

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -64,6 +64,9 @@ typedef enum gregorio_file_format {
 
 /* realpath is not in mingw32 */
 #ifdef _WIN32
+/* _MAX_PATH is being passed for the maxLength (third) argument of _fullpath,
+ * but we are always passing NULL for the absPath (first) argument, so it will
+ * be ignored per the MSDN documentation */
 #define realpath(path,resolved_path) _fullpath(resolved_path, path, _MAX_PATH)
 #endif
 
@@ -128,7 +131,7 @@ static char *get_base_filename(char *fbasename)
         return NULL;
     }
     l = strlen(fbasename) - strlen(p);
-    ret = (char *) gregorio_malloc((l + 1) * sizeof(char));
+    ret = (char *) gregorio_malloc(l + 1);
     gregorio_snprintf(ret, l + 1, "%s", fbasename);
     ret[l] = '\0';
     return ret;
@@ -139,8 +142,7 @@ static char *get_output_filename(char *fbasename, const char *extension)
 {
     char *output_filename = NULL;
     output_filename =
-        (char *) gregorio_malloc(sizeof(char) *
-                        (strlen(extension) + strlen(fbasename) + 2));
+        (char *) gregorio_malloc((strlen(extension) + strlen(fbasename) + 2));
     output_filename = strcpy(output_filename, fbasename);
     output_filename = strcat(output_filename, ".");
     output_filename = strcat(output_filename, extension);
@@ -202,13 +204,13 @@ static void check_input_clobber(char *input_file_name, char *output_file_name)
         char *absolute_output_file_name;
         char *current_directory;
         int file_cmp;
-        int bufsize = 128;
-        char *buf = gregorio_malloc(bufsize * sizeof(char));
+        size_t bufsize = 128;
+        char *buf = gregorio_malloc(bufsize);
         while ((current_directory = getcwd(buf, bufsize)) == NULL
                 && errno == ERANGE && bufsize < MAX_BUF_GROWTH) {
             free(buf);
             bufsize <<= 1;
-            buf = gregorio_malloc(bufsize * sizeof(char));
+            buf = gregorio_malloc(bufsize);
         }
         if (current_directory == NULL) {
             fprintf(stderr, _("can't determine current directory"));
@@ -243,7 +245,7 @@ static char *encode_point_and_click_filename(char *input_file_name)
     }
 
     /* 2 extra characters for a possible leading slash and final NUL */
-    r = result = gregorio_malloc((strlen(filename) * 4 + 2) * sizeof(char));
+    r = result = gregorio_malloc(strlen(filename) * 4 + 2);
 
 #ifdef _WIN32
     *(r++) = '/';

--- a/src/struct.c
+++ b/src/struct.c
@@ -234,7 +234,7 @@ void gregorio_add_texverb_to_note(gregorio_note **current_note, char *str)
     if (*current_note) {
         if ((*current_note)->texverb) {
             len = strlen((*current_note)->texverb) + strlen(str) + 1;
-            res = gregorio_malloc(len * sizeof(char));
+            res = gregorio_malloc(len);
             strcpy(res, (*current_note)->texverb);
             strcat(res, str);
             free((*current_note)->texverb);

--- a/src/support.h
+++ b/src/support.h
@@ -24,10 +24,13 @@
 #define SUPPORT_H
 
 #include <stdlib.h>
+#include <limits.h>
 #include "bool.h"
 
-/* realistically, we shouldn't need to support really huge buffers */
-#define MAX_BUF_GROWTH ((size_t)(1 << 15))
+#define SIZE_T_MAX (~((size_t)0))
+#define MAX_BUF_GROWTH ((size_t)( \
+            (((INT_MAX < SIZE_T_MAX)? INT_MAX : SIZE_T_MAX) >> 1) + 1 \
+        ))
 
 void gregorio_snprintf(char *s, size_t size, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 3, 4)));

--- a/src/support.h
+++ b/src/support.h
@@ -27,10 +27,9 @@
 #include <limits.h>
 #include "bool.h"
 
-#define SIZE_T_MAX (~((size_t)0))
-#define MAX_BUF_GROWTH ((size_t)( \
-            (((INT_MAX < SIZE_T_MAX)? INT_MAX : SIZE_T_MAX) >> 1) + 1 \
-        ))
+#define GREGORIO_SZ_MAX (~((size_t)0))
+#define MAX_BUF_GROWTH \
+    ((size_t)((((INT_MAX < GREGORIO_SZ_MAX)? INT_MAX : GREGORIO_SZ_MAX) >> 1) + 1))
 
 void gregorio_snprintf(char *s, size_t size, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 3, 4)));

--- a/src/support.h
+++ b/src/support.h
@@ -24,6 +24,9 @@
 #define SUPPORT_H
 
 #include <stdlib.h>
+#include <limits.h>
+
+#define MAX_BUF_GROWTH ((INT_MAX >> 1) + 1)
 
 void gregorio_snprintf(char *s, size_t size, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 3, 4)));

--- a/src/support.h
+++ b/src/support.h
@@ -24,9 +24,10 @@
 #define SUPPORT_H
 
 #include <stdlib.h>
-#include <limits.h>
+#include "bool.h"
 
-#define MAX_BUF_GROWTH ((INT_MAX >> 1) + 1)
+/* realistically, we shouldn't need to support really huge buffers */
+#define MAX_BUF_GROWTH ((size_t)(1 << 15))
 
 void gregorio_snprintf(char *s, size_t size, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 3, 4)));
@@ -34,5 +35,6 @@ void *gregorio_malloc(size_t size);
 void *gregorio_calloc(size_t nmemb, size_t size);
 void *gregorio_realloc(void *ptr, size_t size);
 char *gregorio_strdup(const char *s);
+bool gregorio_readline(char **bufptr, size_t *bufsize, FILE *file);
 
 #endif

--- a/src/vowel/vowel-rules.l
+++ b/src/vowel/vowel-rules.l
@@ -39,7 +39,7 @@
 static __inline void save_lval(void)
 {
     gregorio_vowel_rulefile_lval =
-            gregorio_malloc((gregorio_vowel_rulefile_leng + 1) * sizeof(char));
+            gregorio_malloc(gregorio_vowel_rulefile_leng + 1);
     strncpy(gregorio_vowel_rulefile_lval, gregorio_vowel_rulefile_text,
             gregorio_vowel_rulefile_leng);
     gregorio_vowel_rulefile_lval[gregorio_vowel_rulefile_leng] = '\0';


### PR DESCRIPTION
For #697.

This is implemented according to @jakubjelinek's suggestion in #696 (growing buffers).

There is still a dependency on _MAX_PATH, because something needs to be passed for the *maxLength* argument for the Win32 **_fullpath** call.

However, quoting https://msdn.microsoft.com/en-us/library/506720ff(v=vs.100).aspx:

If the *absPath* buffer is **NULL**, **_fullpath** calls **malloc** to allocate a buffer and ignores the *maxLength* argument.  (All our usages of this will pass **NULL** as *absPath*)

Note: I re-created the release-4.0 branch from the v4.0.0 tag to be used for 4.0.x releases.

All tests pass.  Valgrind detects no leaks against gabc-gtex and gabc-dump tests (gabc-gabc tests don't exist in 4.0), and everything allocated is freed at the end.  Please review and merge if satisfactory.