### PR TITLE
Hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Changed
 - Initial handling has been simplified.  The initial style should now be specified from TeX by using the `\gresetinitiallines` command, rather than from a gabc header.  Big initials and normal initials are now governed by a single `initial` style, meant to be changed between scores as appropriate.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#632](https://github.com/gregorio-project/gregorio/issues/632)).  Deprecations for this change are listed in the Deprecation section, below.
+- `\gresethyphen` no long manipulates `maximumspacewithoutdash`, allowing for restoration of consistent behavior after this distance has been modified.
 
 ### Added
 - Salicus flexus glyphs (See [#631](https://github.com/gregorio-project/gregorio/issues/631)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Changed
 - Initial handling has been simplified.  The initial style should now be specified from TeX by using the `\gresetinitiallines` command, rather than from a gabc header.  Big initials and normal initials are now governed by a single `initial` style, meant to be changed between scores as appropriate.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#632](https://github.com/gregorio-project/gregorio/issues/632)).  Deprecations for this change are listed in the Deprecation section, below.
-- `\gresethyphen` no long manipulates `maximumspacewithoutdash`, allowing for restoration of consistent behavior after this distance has been modified.  See [#705](https://github.com/gregorio-project/gregorio/issues/705).
+- `\gresethyphen` no longer manipulates `maximumspacewithoutdash`, allowing for restoration of consistent behavior after this distance has been modified.  See [#705](https://github.com/gregorio-project/gregorio/issues/705).
 
 ### Added
 - Salicus flexus glyphs (See [#631](https://github.com/gregorio-project/gregorio/issues/631)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Changed
 - Initial handling has been simplified.  The initial style should now be specified from TeX by using the `\gresetinitiallines` command, rather than from a gabc header.  Big initials and normal initials are now governed by a single `initial` style, meant to be changed between scores as appropriate.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#632](https://github.com/gregorio-project/gregorio/issues/632)).  Deprecations for this change are listed in the Deprecation section, below.
-- `\gresethyphen` no long manipulates `maximumspacewithoutdash`, allowing for restoration of consistent behavior after this distance has been modified.
+- `\gresethyphen` no long manipulates `maximumspacewithoutdash`, allowing for restoration of consistent behavior after this distance has been modified.  See [#705](https://github.com/gregorio-project/gregorio/issues/705).
 
 ### Added
 - Salicus flexus glyphs (See [#631](https://github.com/gregorio-project/gregorio/issues/631)).

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -791,14 +791,12 @@ Macro to determine whether the last line of the score should be justified or not
 \subsubsection{Hyphenation}
 
 \macroname{\textbackslash gresethyphen}{\{\#1\}}{gregoriotex-main.tex}
-Tells Gregorio\TeX\ how to place a hyphen between syllables in polysyllabic words in a score.  This is done by overriding \texttt{maximumspacewithoutdash} so subsequent changes to this dimension will override this command.
+Tells Gregorio\TeX\ how to place a hyphen between syllables in polysyllabic words in a score.
 
 \begin{argtable}
   \#1 & \texttt{force} & Hyphens will appear between all syllables in polysyllabic words.\\
   & \texttt{auto} & Hyphens will appear based on the setting of \texttt{maximumspacewithoutdash} (default)
 \end{argtable}
-
-\textbf{Nota Bene:} \verb=\gresethyphen{auto}= restores \texttt{maximumspacewithoutdash} to the value found in \textit{gsp-default.tex}.  If you have changed your score size, you may need to change this distance to a more appropriate value using \verb=\grechangedim=.
 
 \macroname{\textbackslash gresetemptyfirstsyllablehyphen}{\{\#1\}}{gregoriotex-syllable.tex}
 Tells Gregorio\TeX\ how to place a hyphen after an empty first syllable (\ie, when the first syllable consists only of the big initial).

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1103,6 +1103,9 @@ All distances in \nameref{distances} and \texttt{stafflinefactor} have a boolean
 indicates if the distance should scale when the staff size changes (true)
 or not (false).
 
+\macroname{\textbackslash ifgre@forcehyphen}{}{gregoriotex-main.tex}
+Boolean used to indicate if hyphens should be forced between all syllables in a polysyllabic word.
+
 \macroname{\textbackslash ifgre@checklength}{}{gregoriotex-spaces.tex}
 Boolean used in \verb=\gresetdim= to indicate if we are attempting to set a rubber length.
 

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -237,10 +237,13 @@ semicolon. */
                 _("unrecognized character: \"%c\" in definition part"),
                 gabc_score_determination_text[0]);
     }
-<score>[^\{\}\(\[\]<%]+ {
+<score>[^-\{\}\(\[\]<%]+ {
         gabc_score_determination_lval.text =
                 gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
+    }
+<score>- {
+        return HYPHEN;
     }
 <score,style><i> {
         BEGIN(style);

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -663,7 +663,7 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
 %token GABC_COPYRIGHT SCORE_COPYRIGHT OCCASION METER COMMENTARY ARRANGER
 %token GABC_VERSION USER_NOTES DEF_MACRO ALT_BEGIN ALT_END CENTERING_SCHEME
 %token TRANSLATION_CENTER_END BNLBA ENLBA EUOUAE_B EUOUAE_E NABC_CUT NABC_LINES
-%token LANGUAGE END_OF_FILE
+%token LANGUAGE HYPHEN END_OF_FILE
 
 %%
 
@@ -1174,8 +1174,18 @@ character:
     | euouae
     ;
 
+text_hyphen:
+    HYPHEN {
+        gregorio_gabc_add_text(gregorio_strdup("-"));
+    }
+    | text_hyphen HYPHEN {
+        gregorio_gabc_add_text(gregorio_strdup("-"));
+    }
+    ;
+
 text:
     | text character
+    | text text_hyphen character
     ;
 
 translation_beginning:
@@ -1205,7 +1215,21 @@ syllable_with_notes:
         first_text_character = current_character;
         close_syllable(&@1);
     }
+    | text HYPHEN OPENING_BRACKET notes {
+        gregorio_gabc_add_style(ST_VERBATIM);
+        gregorio_gabc_add_text(gregorio_strdup("\\GreForceHyphen"));
+        gregorio_gabc_end_style(ST_VERBATIM);
+        rebuild_characters();
+        first_text_character = current_character;
+        close_syllable(&@1);
+    }
     | text translation OPENING_BRACKET notes {
+        close_syllable(&@1);
+    }
+    | text HYPHEN translation OPENING_BRACKET notes {
+        gregorio_gabc_add_style(ST_VERBATIM);
+        gregorio_gabc_add_text(gregorio_strdup("\\GreForceHyphen"));
+        gregorio_gabc_end_style(ST_VERBATIM);
         close_syllable(&@1);
     }
     ;

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1684,11 +1684,12 @@
 }%
 
 % macro to force hyphenation of all syllables.
+\newif\ifgre@forcehyphen\gre@forcehyphenfalse%
 \def\gresethyphen#1{%
   \IfStrEq{#1}{force}%
-    {\global\grechangedim{maximumspacewithoutdash}{-16383.99999pt}{fixed}}%
+    {\gre@forcehyphentrue}%
     {\IfStrEq{#1}{auto}%
-      {\global\grechangedim{maximumspacewithoutdash}{0.02 cm}{scalable}}%
+      {\gre@forcehyphenfalse}%
       {\gre@error{Unrecognized option in \protect\gresethyphen}}%
     }%
 }%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -526,7 +526,7 @@
 }%
 
 \newif\ifgre@showhyphenafterthissyllable%
-\def\GreForceHyphen{\gre@showhyphenafterthissyllabletrue}
+\def\GreForceHyphen{\global\gre@showhyphenafterthissyllabletrue\gre@debugmsg{hyphen}{Forcing hyphen in gabc}}
 
 %% general macro : it will typeset the syllable : arguments are :
 % #1 : macro setting the letters of this syllable
@@ -547,12 +547,14 @@
   \gre@debugmsg{general}{New syllable: \expandafter\unexpanded{#1}}%
   \gre@debugmsg{general}{}%
   \ifgre@forcehyphen%
+    \gre@debugmsg{hyphen}{Forcing hyphen}%
     \gre@showhyphenafterthissyllabletrue%
   \else%
+    \gre@debugmsg{hyphen}{not forcing hyphen}%
     \gre@showhyphenafterthissyllablefalse%
   \fi%
   #1%
-  \ifgre@forceemptyfirstsyllablehyphen\else\gre@showhyphenafterthissyllablefalse\fi%
+  \ifgre@forceemptyfirstsyllablehyphen\else\gre@showhyphenafterthissyllablefalse\gre@debugmsg{hyphen}{Getting rid of hyphen}\fi%
   \gre@firstglyphtrue%
   \gre@dimen@bolextra = 0pt\relax%
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}% we first get the width between the alignment point and the end of the syllable
@@ -619,9 +621,11 @@
     %
     \gre@debugmsg{ifdim}{ temp@skip@one > maximumspacewithoutdash}%
     \ifdim\gre@skip@temp@one > \gre@dimen@maximumspacewithoutdash\relax%
+      \gre@debugmsg{hyphen}{spacing requires hyphen}%
       \gre@showhyphenafterthissyllabletrue%
     \fi
     \ifgre@showhyphenafterthissyllable\relax%
+      \gre@debugmsg{hyphen}{Showing the hyphen}%
       % if it's the last syllable of line, the hyphen will be \GreHyph
       \ifnum\gre@lastoflinecount=1\relax %
         \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart#3{\GreHyph}\relax}{#6}}}%
@@ -632,6 +636,7 @@
       \gre@calculate@enddifference{\wd\gre@box@syllablenotes}{\wd\gre@box@syllabletext}{\gre@dimen@textaligncenter}{\gre@dimen@notesaligncenter}{0}%
       \gre@calculate@syllablefinalskip{0}{0}%
     \else %
+      \gre@debugmsg{hyphen}{No hyphen}%
       \gre@attr@dash=1\relax % in this particular case where it is not the end of a word and we haven't put a dash, we set potentital dash to 1
       % we rebuild this box, in order it to have the attribute
       \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart}{#6}}}%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -546,7 +546,11 @@
   \gre@debugmsg{general}{}%
   \gre@debugmsg{general}{New syllable: \expandafter\unexpanded{#1}}%
   \gre@debugmsg{general}{}%
-  \gre@showhyphenafterthissyllablefalse%
+  \ifgre@forcehyphen%
+    \gre@showhyphenafterthissyllabletrue%
+  \else%
+    \gre@showhyphenafterthissyllablefalse%
+  \fi%
   #1%
   \ifgre@forceemptyfirstsyllablehyphen\else\gre@showhyphenafterthissyllablefalse\fi%
   \gre@firstglyphtrue%


### PR DESCRIPTION
This fixes two issues with hyphenation:

1. An explicit hyphen in the gabc will no longer end up as a double hyphen when the GregorioTeX calculates that a hyphen is needed.
2. `\gresethyphen{force}` no longer changes `maximumspacewithoutdash`.  As a result, turning it off with `\gresethyphen{auto}` will restore previous behavior, even when using the staff size or `maximumspacewithoutdash` has been changed away from the default.

I've created this PR as an enhancement, and hence it's against develop, not as a bugfix (which would go against release-4.0).