### PR TITLE
Fix 683 bolnoclef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+### Fixed
+- When beginning of line clefs are invisible and bol shifts are enabled, lyric text will no longer stick out into the margin.  Further the notes on the first and subsequent lines now align properly.  See [#683](https://github.com/gregorio-project/gregorio/issues/683).
+
 ### Changed
 - Initial handling has been simplified.  The initial style should now be specified from TeX by using the `\gresetinitiallines` command, rather than from a gabc header.  Big initials and normal initials are now governed by a single `initial` style, meant to be changed between scores as appropriate.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#632](https://github.com/gregorio-project/gregorio/issues/632)).  Deprecations for this change are listed in the Deprecation section, below.
 - `\gresethyphen` no longer manipulates `maximumspacewithoutdash`, allowing for restoration of consistent behavior after this distance has been modified.  See [#705](https://github.com/gregorio-project/gregorio/issues/705).

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -208,6 +208,9 @@
   \gre@calculate@clefnum{#1}{#2}{#3}%
   \ifgre@showclef%
     \gre@typekey{#1}{#2}{0}{1}{#3}%
+  \else%
+    \gre@skip@temp@four = \gre@dimen@noclefspace\relax%
+    \hbox{\kern\gre@skip@temp@four}%
   \fi %
   \GreSetLinesClef{#1}{#2}{1}{#3}%
   % if the initial is big, then we adjust the second line

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -335,32 +335,37 @@
   % bolextra is the space taken up by a leading alteration (it's 0 if there is no leading alteration)
   % it's allowed to invade spaceafterlineclef, so long as it leaves at least beforealterationspace between itself and the clef
   % and minimalspaceatlinebeginning between the lyrics and the beginning of the line
-  \gre@skip@temp@one = \gre@skip@spaceafterlineclef\relax%
-  \advance\gre@skip@temp@one by -\gre@dimen@beforealterationspace\relax%
-  \ifdim\gre@dimen@bolextra>\gre@skip@temp@one\relax%
-    \global\advance\gre@skip@temp@three by \gre@skip@temp@one\relax%
-  \else%
-    \global\advance\gre@skip@temp@three by \gre@dimen@bolextra\relax%
-  \fi%
-  \ifdim#1>0pt\relax%
-    % no additional shift is needed if the notes start before the text
-    \global\gre@dimen@bolshift = \gre@skip@temp@three\relax%
-  \else%
-    % as the \gre@dimen@bolshift is computed from skips, we compute it in
-    % a skip temp registry, and then "cast" it into a dimen
-    % basic value for bolshift needs to incorporate -begindifference
-    \advance\gre@skip@temp@three by -#1\relax%
-    % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
-    % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef)
-    % or that the lyrics are closer than minimalspaceatlinebeginning
-    \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
-    \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
-    \advance\gre@skip@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
-    \ifdim\gre@skip@temp@three < \gre@skip@temp@one %
-      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@three\relax%
+  % Of course, is there is no clef, then there is no space to invade, so we start by checking for the presence of a clef
+  \ifgre@showclef%
+    \gre@skip@temp@one = \gre@skip@spaceafterlineclef\relax%
+    \advance\gre@skip@temp@one by -\gre@dimen@beforealterationspace\relax%
+    \ifdim\gre@dimen@bolextra>\gre@skip@temp@one\relax%
+      \global\advance\gre@skip@temp@three by \gre@skip@temp@one\relax%
     \else%
-      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@one\relax%
-    \fi %
+      \global\advance\gre@skip@temp@three by \gre@dimen@bolextra\relax%
+    \fi%
+    \ifdim#1>0pt\relax%
+      % no additional shift is needed if the notes start before the text
+      \global\gre@dimen@bolshift = \gre@skip@temp@three\relax%
+    \else%
+      % as the \gre@dimen@bolshift is computed from skips, we compute it in
+      % a skip temp registry, and then "cast" it into a dimen
+      % basic value for bolshift needs to incorporate -begindifference
+      \advance\gre@skip@temp@three by -#1\relax%
+      % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
+      % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef)
+      % or that the lyrics are closer than minimalspaceatlinebeginning
+      \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
+      \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
+      \advance\gre@skip@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
+      \ifdim\gre@skip@temp@three < \gre@skip@temp@one %
+        \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@three\relax%
+      \else%
+        \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@one\relax%
+      \fi %
+    \fi%
+  \else%
+    \global\gre@dimen@bolshift = 0pt\relax%
   \fi%
   \gre@debugmsg{bolshift}{ bolshift = \the\gre@dimen@bolshift}%
   \relax %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -330,37 +330,32 @@
   % bolextra is the space taken up by a leading alteration (it's 0 if there is no leading alteration)
   % it's allowed to invade spaceafterlineclef, so long as it leaves at least beforealterationspace between itself and the clef
   % and minimalspaceatlinebeginning between the lyrics and the beginning of the line
-  % Of course, is there is no clef, then there is no space to invade, so we start by checking for the presence of a clef
-  \ifgre@showclef%
-    \gre@skip@temp@one = \gre@skip@spaceafterlineclef\relax%
-    \advance\gre@skip@temp@one by -\gre@dimen@beforealterationspace\relax%
-    \ifdim\gre@dimen@bolextra>\gre@skip@temp@one\relax%
-      \global\advance\gre@skip@temp@three by \gre@skip@temp@one\relax%
-    \else%
-      \global\advance\gre@skip@temp@three by \gre@dimen@bolextra\relax%
-    \fi%
-    \ifdim#1>0pt\relax%
-      % no additional shift is needed if the notes start before the text
-      \global\gre@dimen@bolshift = \gre@skip@temp@three\relax%
-    \else%
-      % as the \gre@dimen@bolshift is computed from skips, we compute it in
-      % a skip temp registry, and then "cast" it into a dimen
-      % basic value for bolshift needs to incorporate -begindifference
-      \advance\gre@skip@temp@three by -#1\relax%
-      % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
-      % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef)
-      % or that the lyrics are closer than minimalspaceatlinebeginning
-      \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
-      \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
-      \advance\gre@skip@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
-      \ifdim\gre@skip@temp@three < \gre@skip@temp@one %
-        \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@three\relax%
-      \else%
-        \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@one\relax%
-      \fi %
-    \fi%
+  \gre@skip@temp@one = \gre@skip@spaceafterlineclef\relax%
+  \advance\gre@skip@temp@one by -\gre@dimen@beforealterationspace\relax%
+  \ifdim\gre@dimen@bolextra>\gre@skip@temp@one\relax%
+    \global\advance\gre@skip@temp@three by \gre@skip@temp@one\relax%
   \else%
-    \global\gre@dimen@bolshift = 0pt\relax%
+    \global\advance\gre@skip@temp@three by \gre@dimen@bolextra\relax%
+  \fi%
+  \ifdim#1>0pt\relax%
+    % no additional shift is needed if the notes start before the text
+    \global\gre@dimen@bolshift = \gre@skip@temp@three\relax%
+  \else%
+    % as the \gre@dimen@bolshift is computed from skips, we compute it in
+    % a skip temp registry, and then "cast" it into a dimen
+    % basic value for bolshift needs to incorporate -begindifference
+    \advance\gre@skip@temp@three by -#1\relax%
+    % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
+    % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef)
+    % or that the lyrics are closer than minimalspaceatlinebeginning
+    \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
+    \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
+    \advance\gre@skip@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
+    \ifdim\gre@skip@temp@three < \gre@skip@temp@one %
+      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@three\relax%
+    \else%
+      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@one\relax%
+    \fi %
   \fi%
   \gre@debugmsg{bolshift}{ bolshift = \the\gre@dimen@bolshift}%
   \relax %

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -574,11 +574,11 @@
   % we will have shifted right and left, thus cancelling... Very easy trick, but
   % took me years to find it!
   \gre@debugmsg{bolshift}{Current glyph: \the\gre@attr@glyph@id}%
-  \ifgre@bolshiftsenabled%
-    % we only want to execute these shifts if the clef is being shown
-    % if no clef is being shown, then there is no space under the clef for the
-    % lyrics to invade
-    \ifgre@showclef%
+  % we only want to execute these shifts if the clef is being shown
+  % if no clef is being shown, then there is no space under the clef for the
+  % lyrics to invade
+  \ifgre@showclef%
+    \ifgre@bolshiftsenabled%
       \gre@calculate@bolshift{\gre@dimen@begindifference}%
       % we don't want to shift right on the first syllable of the score 
       % because the printing of the initial clef, initial, and/or the staff lines 
@@ -596,6 +596,13 @@
       \GreNoBreak %
       \kern-\gre@dimen@bolshift\relax%
     \fi%
+  \else%
+    % if there is no clef, we still need to break TeX's ignorance of spaces at
+    % the beginning of a line so that the alterations, which would otherwise be
+    % ignored in positioning the syllable, don't stick out into margin
+    \GreNoBreak %
+    \hbox to 0pt{}%
+    \GreNoBreak %
   \fi %
   % by default, gre@attr@dash will be 2
   \gre@attr@dash=2\relax %

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -575,20 +575,27 @@
   % took me years to find it!
   \gre@debugmsg{bolshift}{Current glyph: \the\gre@attr@glyph@id}%
   \ifgre@bolshiftsenabled%
-    \gre@calculate@bolshift{\gre@dimen@begindifference}%
-    % we don't want to shift right on the first syllable of the score because the printing of the initial clef, initial, and/or the staff lines will have already broken TeX's ignorance of spaces.
-    \ifgre@beginningofscore%
-      \gre@beginningofscorefalse%
-    \else%
-      % we don't want to shift right inside a discretionary
-      \ifnum\gre@insidediscretionary=0\relax%
-        \kern\gre@dimen@bolshift\relax%
+    % we only want to execute these shifts if the clef is being shown
+    % if no clef is being shown, then there is no space under the clef for the
+    % lyrics to invade
+    \ifgre@showclef%
+      \gre@calculate@bolshift{\gre@dimen@begindifference}%
+      % we don't want to shift right on the first syllable of the score 
+      % because the printing of the initial clef, initial, and/or the staff lines 
+      % will have already broken TeX's ignorance of spaces.
+      \ifgre@beginningofscore%
+        \gre@beginningofscorefalse%
+      \else%
+        % we don't want to shift right inside a discretionary
+        \ifnum\gre@insidediscretionary=0\relax%
+          \kern\gre@dimen@bolshift\relax%
+        \fi%
       \fi%
+      \GreNoBreak %
+      \hbox to 0pt{}%
+      \GreNoBreak %
+      \kern-\gre@dimen@bolshift\relax%
     \fi%
-    \GreNoBreak %
-    \hbox to 0pt{}%
-    \GreNoBreak %
-    \kern-\gre@dimen@bolshift\relax%
   \fi %
   % by default, gre@attr@dash will be 2
   \gre@attr@dash=2\relax %


### PR DESCRIPTION
This fixes #683.  Now, when there are no beginning of line clefs, there is a gap of `noclefspace` at the beginning of the line and then the syllable will start immediately (either lyrics or notes, which ever sticks out to the left further).

This PR is against develop, because that's where I branched from in my repository when starting this work.  However, looking back, we had originally discussed this as a bug in 4.0.  Should I take the time to shift these changes over to build off that branch?