### PR TITLE
Fixing bol problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Fixed
 - `\greseteolcustos` now retains its setting across multiple score inclusions (see [#703](https://github.com/gregorio-project/gregorio/issues/703)).
+- When beginning of line clefs are invisible and bol shifts are enabled, lyric text will no longer stick out into the margin.  Further the notes on the first and subsequent lines now align properly.  See [#683](https://github.com/gregorio-project/gregorio/issues/683).
 
 
 ## [4.0.0] - 2015-12-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,7 +181,7 @@ See GregorioRef.pdf for full details.
 - `greg-book` and `greg-lily-book` engines, supplanted by improved capabilities of `\gregorioscore` for compiling gabc files at time of document compilation.
 - The TeXShop script for compiling gabc files.  Supplanted by the new autocompile feature of the package.
 
-### Known Bugs
+### Known Bugs - FIXED IN 4.0.1
 - When beginning of line clefs are invisible and bol shifts are enabled, lyric text will stick out into the margin.  Further the notes on the first and subsequent lines do not align properly.  See [#683](https://github.com/gregorio-project/gregorio/issues/683).
 
 

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -210,6 +210,9 @@
   \gre@calculate@clefnum{#1}{#2}{#3}%
   \ifgre@showclef%
     \gre@typekey{#1}{#2}{0}{1}{#3}%
+  \else%
+    \gre@skip@temp@four = \gre@dimen@noclefspace\relax%
+    \hbox{\kern\gre@skip@temp@four}%
   \fi %
   \GreSetLinesClef{#1}{#2}{1}{#3}%
   % if the initial is big, then we adjust the second line

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -573,21 +573,35 @@
   % we will have shifted right and left, thus cancelling... Very easy trick, but
   % took me years to find it!
   \gre@debugmsg{bolshift}{Current glyph: \the\gre@attr@glyph@id}%
-  \ifgre@bolshiftsenabled%
-    \gre@calculate@bolshift{\gre@dimen@begindifference}%
-    % we don't want to shift right on the first syllable of the score because the printing of the initial clef, initial, and/or the staff lines will have already broken TeX's ignorance of spaces.
-    \ifgre@beginningofscore%
-      \gre@beginningofscorefalse%
-    \else%
-      % we don't want to shift right inside a discretionary
-      \ifnum\gre@insidediscretionary=0\relax%
-        \kern\gre@dimen@bolshift\relax%
+  % we only want to execute these shifts if the clef is being shown
+  % if no clef is being shown, then there is no space under the clef for the
+  % lyrics to invade
+  \ifgre@showclef%
+    \ifgre@bolshiftsenabled%
+      \gre@calculate@bolshift{\gre@dimen@begindifference}%
+      % we don't want to shift right on the first syllable of the score 
+      % because the printing of the initial clef, initial, and/or the staff lines 
+      % will have already broken TeX's ignorance of spaces.
+      \ifgre@beginningofscore%
+        \gre@beginningofscorefalse%
+      \else%
+        % we don't want to shift right inside a discretionary
+        \ifnum\gre@insidediscretionary=0\relax%
+          \kern\gre@dimen@bolshift\relax%
+        \fi%
       \fi%
+      \GreNoBreak %
+      \hbox to 0pt{}%
+      \GreNoBreak %
+      \kern-\gre@dimen@bolshift\relax%
     \fi%
+  \else%
+    % if there is no clef, we still need to break TeX's ignorance of spaces at
+    % the beginning of a line so that the alterations, which would otherwise be
+    % ignored in positioning the syllable, don't stick out into margin
     \GreNoBreak %
     \hbox to 0pt{}%
     \GreNoBreak %
-    \kern-\gre@dimen@bolshift\relax%
   \fi %
   % by default, gre@attr@dash will be 2
   \gre@attr@dash=2\relax %


### PR DESCRIPTION
`noclefspace` is now applied to the first line of the score, bringing it into line with the rest of the score
`bolshift` is disabled when there are no beginning of line clefs

Fixes #683 as a patch release for 4.0