### PR TITLE
Reversed the naming of the patty cross ("Maltese") and the patonce cross

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Fixed
 - `\greseteolcustos` now retains its setting across multiple score inclusions (see [#703](https://github.com/gregorio-project/gregorio/issues/703)).
 - When beginning of line clefs are invisible and bol shifts are enabled, lyric text will no longer stick out into the margin.  Further the notes on the first and subsequent lines now align properly.  See [#683](https://github.com/gregorio-project/gregorio/issues/683).
+- `\grecross` and `\grealtcross` now print the correct glyphs (see [#713](https://github.com/gregorio-project/gregorio/issues/713)).
 
 
 ## [4.0.0] - 2015-12-08

--- a/fonts/greextra.sfd
+++ b/fonts/greextra.sfd
@@ -79,12 +79,13 @@ EndShort
 LangName: 1033 "" "" "Medium" "FontForge 2.0 : greextra : 22-4-2015" 
 GaspTable: 1 65535 2 0
 Encoding: UnicodeBmp
+Compacted: 1
 UnicodeInterp: none
 NameList: Adobe Glyph List
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 57361 19 8
+WinInfo: 0 16 4
 BeginChars: 65539 83
 
 StartChar: .notdef
@@ -1511,7 +1512,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: Cross.alt
+StartChar: Cross
 Encoding: 57388 57388 41
 Width: 732
 Flags: W
@@ -4457,7 +4458,7 @@ SplineSet
 EndSplineSet
 EndChar
 
-StartChar: Cross
+StartChar: Cross.alt
 Encoding: 57400 57400 53
 Width: 848
 Flags: W


### PR DESCRIPTION
Fixes #713.

All tests pass, but I modified one to include `\grecross` and `\grealtcross`.  Please review and merge if satisfactory.