### PR TITLE
Modified to index code point tables when needed for iteration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Fixed
 - `\greseteolcustos` now retains its setting across multiple score inclusions (see [#703](https://github.com/gregorio-project/gregorio/issues/703)).
+- Gregorio now works against luaotfload 2.6 (see [#717](https://github.com/gregorio-project/gregorio/issues/717)).
 
 
 ## [Unreleased][unreleased]


### PR DESCRIPTION
Fixes #717.

Many thanks to @phi-gamma for the help.

I tested this under TeX Live 2015 with luaotfload 2.5 and luaotfload 2.6.  It passes all the tests.

Please review and merge if satisfactory.