### PR TITLE
Workaround for @eroux's compiler warning noted in #723.

### DIFF
--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -764,7 +764,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
     /* a char representing the liquescentia of the current glyph */
     gregorio_liquescentia liquescentia = L_NO_LIQUESCENTIA;
     gregorio_liquescentia head_liquescentia;
-    bool autofuse = false, first_autofused_note;
+    bool autofuse = false, first_autofused_note = false;
 
     if (current_note == NULL) {
         return NULL;


### PR DESCRIPTION
The warning is a false positive because (in the flow of the loop) autofuse
will never be made true without also setting first_autofused_note to true.