### PR TITLE
Added support for external headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Salicus flexus glyphs (See [#631](https://github.com/gregorio-project/gregorio/issues/631)).
 - Neume fusion, activated in gabc by `@`.  Use `@` before a clivis or a porrectus to get an unstemmed figure.  Use `@` between two notes to fuse them explicitly.  Enclose a set of notes within `@[` and `]` to automatically guess their fusion.  See GregorioRef for details (for the channge requests, see [#679](https://github.com/gregorio-project/gregorio/issues/679), [#687](https://github.com/gregorio-project/gregorio/issues/687), and [#692](https://github.com/gregorio-project/gregorio/issues/692)).
 - Hollow version of the oriscus, called by adding the `r` modifier to an oriscus, as in `gor` or `gor<` (See [#724](https://github.com/gregorio-project/gregorio/issues/724)).
+- Support for arbitrary external gabc headers starting with `x-`.  These are simply accepted by gregorio.
 
 ### Deprecated
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.
@@ -80,10 +81,6 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Fixed
 - `\greseteolcustos` now retains its setting across multiple score inclusions (see [#703](https://github.com/gregorio-project/gregorio/issues/703)).
-
-
-## [Unreleased][unreleased]
-### Fixed
 - When beginning of line clefs are invisible and bol shifts are enabled, lyric text will no longer stick out into the margin.  Further the notes on the first and subsequent lines now align properly.  See [#683](https://github.com/gregorio-project/gregorio/issues/683).
 - `\grecross` and `\grealtcross` now print the correct glyphs (see [#713](https://github.com/gregorio-project/gregorio/issues/713)).
 

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -113,6 +113,11 @@ Here is a detailed description of each header field:
   If the user already defined annotation(s) in the main \TeX\ file via
   \verb=\greannotation= then the \texttt{annotation} header field will not
   overwrite that definition.
+\item[x-\textit{external}] External headers start with \texttt{x-} and may
+  have any name composed of ASCII letters and numbers, optionally separated
+  by dashes.  These headers are blindly captured by gregorio without any
+  further error checking.  They may be useful for external applications to
+  use as metadata.
 
 \end{description}
 

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -104,6 +104,7 @@ void dump_write_score(FILE *f, gregorio_score *score)
     int i;
     int annotation_num;
     gregorio_syllable *syllable;
+    gregorio_external_header *header;
 
     if (!f) {
         gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
@@ -180,6 +181,9 @@ void dump_write_score(FILE *f, gregorio_score *score)
     }
     if (score->user_notes) {
         fprintf(f, "   user_notes                %s\n", score->user_notes);
+    }
+    for (header = score->external_headers; header; header = header->next) {
+        fprintf(f, "   %-25s %s\n", header->name, header->value);
     }
     fprintf(f, "\n\n"
             "=====================================================================\n"

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -225,6 +225,11 @@ semicolon. */
 <INITIAL>user-notes {
         return USER_NOTES;
     }
+<INITIAL>x-[A-Za-z0-9_]+(-[A-Za-z0-9_]+)* {
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
+        return EXTERNAL_HEADER;
+    }
 <INITIAL>--(.*) {
        return VOICE_CHANGE;
     }

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -663,7 +663,7 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
 %token GABC_COPYRIGHT SCORE_COPYRIGHT OCCASION METER COMMENTARY ARRANGER
 %token GABC_VERSION USER_NOTES DEF_MACRO ALT_BEGIN ALT_END CENTERING_SCHEME
 %token TRANSLATION_CENTER_END BNLBA ENLBA EUOUAE_B EUOUAE_E NABC_CUT NABC_LINES
-%token LANGUAGE HYPHEN END_OF_FILE
+%token LANGUAGE HYPHEN EXTERNAL_HEADER END_OF_FILE
 
 %%
 
@@ -938,6 +938,12 @@ user_notes_definition:
     }
     ;
 
+external_header_definition:
+    EXTERNAL_HEADER attribute {
+        gregorio_add_score_external_header(score, $1.text, $2.text);
+    }
+    ;
+
 attribute:
     COLON ATTRIBUTE SEMICOLON {
         $$.text = $2.text;
@@ -979,6 +985,7 @@ definition:
     | user_notes_definition
     | centering_scheme_definition
     | language_definition
+    | external_header_definition
     | VOICE_CHANGE {
         next_voice_info();
     }

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -827,6 +827,7 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     int line;
     gregorio_syllable *syllable;
     int annotation_num;
+    gregorio_external_header *header;
 
     if (!f) {
         gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
@@ -872,6 +873,9 @@ void gabc_write_score(FILE *f, gregorio_score *score)
         }
     }
     gabc_write_str_attribute(f, "user-notes", score->user_notes);
+    for (header = score->external_headers; header; header = header->next) {
+        gabc_write_str_attribute(f, header->name, header->value);
+    }
     if (score->number_of_voices == 0) {
         gregorio_message(_("gregorio_score seems to be empty"),
                 "gabc_write_score", VERBOSITY_ERROR, 0);

--- a/src/struct.c
+++ b/src/struct.c
@@ -1034,7 +1034,7 @@ static void gregorio_free_syllables(gregorio_syllable **syllable,
     }
 }
 
-static void gregorio_source_info_init(source_info *si)
+static void gregorio_source_info_init(gregorio_source_info *si)
 {
     si->author = NULL;
     si->date = NULL;
@@ -1073,7 +1073,7 @@ gregorio_score *gregorio_new_score(void)
     return new_score;
 }
 
-static void gregorio_free_source_info(source_info *si)
+static void gregorio_free_source_info(gregorio_source_info *si)
 {
     free(si->date);
     free(si->author);
@@ -1113,6 +1113,15 @@ static void gregorio_free_score_infos(gregorio_score *score)
     }
 }
 
+static void free_external_headers(gregorio_score *score) {
+    gregorio_external_header *header = score->external_headers;
+    while (header) {
+        gregorio_external_header *next = header->next;
+        free(header);
+        header = next;
+    }
+}
+
 void gregorio_free_score(gregorio_score *score)
 {
     if (!score) {
@@ -1122,6 +1131,7 @@ void gregorio_free_score(gregorio_score *score)
     }
     gregorio_free_syllables(&(score->first_syllable), score->number_of_voices);
     gregorio_free_score_infos(score);
+    free_external_headers(score);
     free(score);
 }
 
@@ -1395,6 +1405,28 @@ void gregorio_set_score_transcription_date(gregorio_score *score,
     }
     free(score->si.transcription_date);
     score->si.transcription_date = transcription_date;
+}
+
+void gregorio_add_score_external_header(gregorio_score *score, char *name,
+        char *value)
+{
+    gregorio_external_header *header;
+    if (!score) {
+        gregorio_message(_("function called with NULL argument"),
+                "gregorio_add_score_external_header", VERBOSITY_WARNING, 0);
+        return;
+    }
+    header = (gregorio_external_header *)
+            gregorio_malloc(sizeof(gregorio_external_header));
+    header->name = name;
+    header->value = value;
+    header->next = NULL;
+    if (score->last_external_header) {
+        score->last_external_header->next = header;
+    } else {
+        score->external_headers = header;
+    }
+    score->last_external_header = header;
 }
 
 void gregorio_set_voice_style(gregorio_voice_info *voice_info, char *style)

--- a/src/struct.c
+++ b/src/struct.c
@@ -1117,6 +1117,8 @@ static void free_external_headers(gregorio_score *score) {
     gregorio_external_header *header = score->external_headers;
     while (header) {
         gregorio_external_header *next = header->next;
+        free(header->name);
+        free(header->value);
         free(header);
         header = next;
     }

--- a/src/struct.h
+++ b/src/struct.h
@@ -634,7 +634,7 @@ typedef struct gregorio_syllable {
  * case the different voices would naturally have different source
  * info.  However, this enhancement to gregorio is not yet planned,
  * and so this structure is made part of gregorio_score. */
-typedef struct source_info {
+typedef struct gregorio_source_info {
     char *author;
     char *date;
     char *manuscript;
@@ -643,7 +643,14 @@ typedef struct source_info {
     char *book;
     char *transcriber;
     char *transcription_date;
-} source_info;
+} gregorio_source_info;
+
+/* Stores an external header in a singly-linked list */
+typedef struct gregorio_external_header {
+    char *name;
+    char *value;
+    struct gregorio_external_header *next;
+} gregorio_external_header;
 
 /*
  * 
@@ -674,7 +681,7 @@ typedef struct gregorio_score {
     char *commentary;
     char *arranger;
     char *language;
-    struct source_info si;
+    struct gregorio_source_info si;
     /* the mode of a song is between 1 and 8 */
     char mode;
     /* There is one annotation for each line above the initial letter */
@@ -691,6 +698,8 @@ typedef struct gregorio_score {
     /* then, as there are some metadata that are voice-specific, we add a
      * pointer to the first voice_info. (see comments below) */
     struct gregorio_voice_info *first_voice_info;
+    struct gregorio_external_header *external_headers;
+    struct gregorio_external_header *last_external_header;
     gregorio_lyric_centering centering;
 } gregorio_score;
 
@@ -873,6 +882,8 @@ void gregorio_set_score_transcriber(gregorio_score *score, char *transcriber);
 void gregorio_set_score_transcription_date(gregorio_score *score,
         char *transcription_date);
 void gregorio_set_score_user_notes(gregorio_score *score, char *user_notes);
+void gregorio_add_score_external_header(gregorio_score *score, char *name,
+        char *value);
 void gregorio_set_voice_style(gregorio_voice_info *voice_info, char *style);
 void gregorio_set_voice_virgula_position(gregorio_voice_info *voice_info,
         char *virgula_position);


### PR DESCRIPTION
As discussed on gregorio-devel.  External headers start with `x-` and have names composed of letters and numbers, optionally separated by dashes (i.e., `x-my-header3` is a valid name).

This is ready for review and merge if satisfactory.  I have extended `test_all_headers` to cover external headers.