### PR TITLE
Implemented heuristics for reducing note-episema space at ledger lines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Initial handling has been simplified.  The initial style should now be specified from TeX by using the `\gresetinitiallines` command, rather than from a gabc header.  Big initials and normal initials are now governed by a single `initial` style, meant to be changed between scores as appropriate.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#632](https://github.com/gregorio-project/gregorio/issues/632)).  Deprecations for this change are listed in the Deprecation section, below.
 - `\gresethyphen` no longer manipulates `maximumspacewithoutdash`, allowing for restoration of consistent behavior after this distance has been modified.  See [#705](https://github.com/gregorio-project/gregorio/issues/705).
 - The oriscus-based shapes in the greciliae font are more consistent.  The shape of a scandicus with a second ambitus of two is more consistent across all score fonts.
-- minimal space between notes of different syllables (or words) has been reduced when the second syllable starts with an alteration
+- Minimal space between notes of different syllables (or words) has been reduced when the second syllable starts with an alteration.
+- The space between note and horizontal episema has been tightened for notes at the `c` or `k` height when there is no ledger line.  Due to the intricacies of measurement, the system tries to make a best guess as to the existence of the ledger line.  If the guess is wrong, you may use the `[hl:n]` and `[ll:n]` notations in gabc to override the guess.  See [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#716](https://github.com/gregorio-project/gregorio/issues/716)).
 
 ### Added
 - Salicus flexus glyphs (See [#631](https://github.com/gregorio-project/gregorio/issues/631)).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,16 @@ Since the `biginitial` style will disappear with Gregorio 5.0, please consider d
 
 When the next syllable starts with an alteration, the minimal space between notes of the current syllable and notes of the current syllable is handled by the new spaces `intersyllablespacenotes@alteration` and `interwordspacenotes@alteration`. Set them in your custom spacings file if needed.
 
+### Horizontal episemata on high and low notes
+
+Prior to version 4.1, Gregorio reserved space between notes at the `c` and `k` heights and their horizontal episemata for a "ledger line" that might appear between them.  However, if the ledger line did not appear, the episema would appear to be too far from the note.
+
+Starting with version 4.1, Gregorio attempts to reduce the space between the note and its episema if it doesn't think there is a "ledger line" there.  However, due to the intricacies of distances and measurement in TeX, Gregorio might guess wrong.  In this case, you can override the guess by using the `[hl:n]` (for a line above the staff) and `[ll:n]` (for a line below the staff) notations in gabc.  If you put a `0` for `n`, Gregorio will assume there is no ledger line, and if you put a `1` for `n`, Gregorio will assume there is a ledger line.  This notation will have to be placed after every note which should be thus modified.
+
+Note: Using `[hl:n]` and `[ll:n]` **will not** add a ledger line if it doesn't exist or remove one if it does.  It simply affects whether Gregorio will act as if one is there or not.
+
+If you prefer the old behavior, you may switch this off by issuing `\gresetledgerlineheuristic{disable}` in your TeX document.  You may switch it back on with `\gresetledgerlineheuristic{enable}`.
+
 ## 4.0
 
 ### Font changes

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -320,6 +320,30 @@ necessary.
 \end{framed}
 \end{small}
 
+\macroname{\textbackslash gresetledgerlineheuristic}{\{\#1\}}{gregoriotex-spaces.tex}
+Macro which enables or disables ledger line heuristics.  Currently, ledger
+line heuristics allow Gregorio to reduce the space between a note and a
+horizontal episema that surround a line on which a ledger line may appear
+when the ledger line \textit{does not} appear.
+
+\begin{argtable}
+    \#1 & \texttt{enable}  & Ledger line heuristics will be used in placing
+                             the horizontal episema \\
+        & \texttt{disable} & Ledger line heuristics will not be used in
+                             placing the horizontal episema \\
+\end{argtable}
+
+Because of the complexity of computing distances exactly, the heuristic may
+guess incorrectly, causing the horizontal episema to be placed incorrectly.
+This may be overridden on a note-by-note basic by using the
+\texttt{[hl:\textit{n}]} and \texttt{[ll:\textit{n}]} gabc directives.  The
+\texttt{hl} directive sets an explicit high ledger line (above the staff),
+and the \texttt{ll} directive sets an explicit low ledger line (below the
+staff).  The \texttt{\textit{n}} should be set to indicate whether the
+system should act as if the ledger line exists (\texttt{1}) or not
+(\texttt{0}).
+
+
 \subsubsection{Staff Lines}
 
 \macroname{\textbackslash gresetlinecolor}{\{\#1\}}{gregoriotex.sty \textup{and} gregoriotex.tex}

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -372,7 +372,7 @@ therefore compatible with the score.
   \#1 & string & Version number for Gregorio\TeX.\\
 \end{argtable}
 
-\macroname{\textbackslash GreHEpisema}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreHEpisema}{\#1\#2\#3\#4\#5\#6\#7}{gregoriotex-signs.tex}
 Macro to typeset an horizontal episema.
 
 \begin{argtable}
@@ -390,9 +390,10 @@ Macro to typeset an horizontal episema.
   & \texttt{c} & a small episema aligned center\\
   & \texttt{r} & a small episema aligned right\\
   \#6 & integer & Replacement for \#1 if a bridge causes a height substitution.\\
+  \#7 & \TeX\ code & code that sets heuristics\\
 \end{argtable}
 
-\macroname{\textbackslash GreHEpisemaBridge}{\#1\#2\#3}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreHEpisemaBridge}{\#1\#2\#3\#4}{gregoriotex-signs.tex}
 Macro to typeset a bridge episema for the last note of a glyph
 (element, syllable) if the next episema is at the same height.
 
@@ -411,7 +412,8 @@ Macro to typeset a bridge episema for the last note of a glyph
   & \texttt{8} & Space between two puncta inclinata debilis.\\
   & \texttt{9} & Space before a punctum (or something else) and a punctum inclinatum.\\
   & \texttt{10} & Space between puncta inclinata (also debilis for now), larger ambitus (range=3rd).\\
-  & \texttt{11} & Space between puncta inclinata (also debilis for now), larger ambitus (range=4th or more).
+  & \texttt{11} & Space between puncta inclinata (also debilis for now), larger ambitus (range=4th or more).\\
+  \#4 & \TeX\ code & code that sets heuristics\\
 \end{argtable}
 
 \macroname{\textbackslash GreHighChoralSign}{\#1\#2\#3}{gregoriotex-signs.tex}
@@ -787,6 +789,12 @@ in gabc.
 
 \macroname{\textbackslash GreStar}{}{gregoriotex-symbol.tex}
 Macro to typeset an asterisk (\GreStar).
+
+\macroname{\textbackslash GreSupposeHighLedgerLine}{}{gregoriotex-spaces.tex}
+Indicates that the system should act as if a ledger line exists above the staff.
+
+\macroname{\textbackslash GreSupposeLowLedgerLine}{}{gregoriotex-spaces.tex}
+Indicates that the system should act as if a ledger line exists below the staff.
 
 \macroname{\textbackslash GreSyllable}{\#1\#2\#3\#4\#5\#6\#7\#8\#9}{gregoriotex-syllable.tex}
 Macro to typeset the syllable.

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -618,8 +618,14 @@ Macro called at the end of the score to ensure that a big initial setting doesnâ
 \macroname{\textbackslash greoldcatcode}{}{gregoriotex.tex}
 Macro to store the catcode for ``@'' so that we can use said symbol in function names under Plain \TeX\ and then restore the original catcode after the package is done loading.
 
+\macroname{\textbackslash gre@prephepisemaledgerlineheuristics}{}{gregoriotex-spaces.tex}
+Prepares the system to accept ledger line heuristics for the horizontal episema.
+
 \macroname{\textbackslash gre@reseteolcustos}{}{gregoriotex-main.tex}
 Alias that resets the use of automatic custos to the value set by \verb=\greseteolcustos=.  This macro is aliased to \verb=\gre@useautoeolcustos= or \verb=\gre@usemanualeolcustos= by \verb=\greseteolcustos=.
+
+\macroname{\textbackslash gre@resetledgerlineheuristics}{}{gregoriotex-spaces.tex}
+Resets the ledger line heuristic flags.
 
 \macroname{\textbackslash gre@setstylefont}{}{gregoriotex-main.tex}
 Macro for opening up greextra font.
@@ -1194,11 +1200,20 @@ Boolean which indicates if the most recent note was a punctum mora.
 \macroname{\textbackslash ifgre@lastispunctumsave}{}{gregoriotex-signs.tex}
 Boolean for storing \verb=\ifgre@lastispunctum= so that it can be restored later.
 
+\macroname{\textbackslash ifgre@ledgerline@above}{}{gregoriotex-spaces.tex}
+Boolean which indicates whether the system should act as if there is a ledger line above the staff.
+
+\macroname{\textbackslash ifgre@ledgerline@below}{}{gregoriotex-spaces.tex}
+Boolean which indicates whether the system should act as if there is a ledger line below the staff.
+
 \macroname{\textbackslash gre@nlbstate}{}{gregoriotex-main.tex}
 Macro which indicates if we are in a no line break area due to translation centering (\texttt{1}), an explicit no line break designation in the gabc (\texttt{2}), or not at all (\texttt{0}).
 
 \macroname{\textbackslash gre@nlbinitialstate}{}{gregoriotex-main.tex}
 Macro to store \verb=\gre@nlbstate= as we initialize or end a no line break area so that we can manipulate said flag as part of the process.
+
+\macroname{\textbackslash ifgre@useledgerlineheuristic}{}{gregoriotex-spaces.tex}
+Boolean which specifies whether ledger line heuristics will be used or not.
 
 \macroname{\textbackslash ifgre@usestylefont}{}{gregoriotex-main.tex}
 Boolean which specifies whether the style font should be loaded or not.

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -497,6 +497,14 @@ void dump_write_score(FILE *f, gregorio_score *score)
                                             dump_bool(note->h_episema_below_connect));
                                 }
                             }
+                            if (note->explicit_high_ledger_line) {
+                                fprintf(f, "         explicit high line     %s\n",
+                                        dump_bool(note->supposed_high_ledger_line));
+                            }
+                            if (note->explicit_low_ledger_line) {
+                                fprintf(f, "         explicit low line      %s\n",
+                                        dump_bool(note->supposed_low_ledger_line));
+                            }
                         }
                     }
                 }

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -676,6 +676,22 @@ V   {
 s   {
         gregorio_change_shape(current_note, S_STROPHA);
     }
+\[hl:1\] {
+        current_note->supposed_high_ledger_line = true;
+        current_note->explicit_high_ledger_line = true;
+    }
+\[hl:0\] {
+        current_note->supposed_high_ledger_line = false;
+        current_note->explicit_high_ledger_line = true;
+    }
+\[ll:1\] {
+        current_note->supposed_low_ledger_line = true;
+        current_note->explicit_low_ledger_line = true;
+    }
+\[ll:0\] {
+        current_note->supposed_low_ledger_line = false;
+        current_note->explicit_low_ledger_line = true;
+    }
 .   {
         gregorio_messagef("det_notes_from_string", VERBOSITY_ERROR, 0,
                 _("unrecognized character: \"%c\""),

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -412,6 +412,15 @@ static const char *mora_vposition(gregorio_note *note)
     }
 }
 
+static void write_note_heuristics(FILE *f, gregorio_note *note) {
+    if (note->explicit_high_ledger_line) {
+        fprintf(f, "[hl:%c]", note->supposed_high_ledger_line? '1' : '0');
+    }
+    if (note->explicit_low_ledger_line) {
+        fprintf(f, "[ll:%c]", note->supposed_low_ledger_line? '1' : '0');
+    }
+}
+
 /*
  * 
  * The function that writes one gregorio_note.
@@ -600,6 +609,7 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
                     note->h_episema_above_size);
         }
     }
+    write_note_heuristics(f, note);
     if (note->texverb) {
         fprintf(f, "[nv:%s]", note->texverb);
     }

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1473,6 +1473,16 @@ static void gregoriotex_write_bar(FILE *f, gregorio_bar type,
     }
 }
 
+static __inline char *suppose_high_ledger_line(const gregorio_note *const note)
+{
+    return note->supposed_high_ledger_line? "\\GreSupposeHighLedgerLine" : "";
+}
+
+static __inline char *suppose_low_ledger_line(const gregorio_note *const note)
+{
+    return note->supposed_low_ledger_line? "\\GreSupposeLowLedgerLine" : "";
+}
+
 /*
  * ! @brief Writes augmentum duplexes (double dots) We suppose we are on the
  * last note. \n The algorithm is the following: if there is a previous note,
@@ -1877,9 +1887,11 @@ static __inline void write_single_hepisema(FILE *const f, int hepisema_case,
                             != SP_ZERO_WIDTH)) {
                     /* not followed by a zero-width space */
                     /* try to fuse from punctum inclinatum to nobar glyph */
-                    fprintf(f, "\\GreHEpisemaBridge{%d}{%d}{%d}%%\n",
+                    fprintf(f, "\\GreHEpisemaBridge{%d}{%d}{%d}{%s%s}%%\n",
                             pitch_value(height), hepisema_case,
-                            get_punctum_inclinatum_to_nobar_space_case(glyph));
+                            get_punctum_inclinatum_to_nobar_space_case(glyph),
+                            suppose_high_ledger_line(note),
+                            suppose_low_ledger_line(note));
                 } else if (note->next
                         && (note->next->u.note.shape == S_PUNCTUM_INCLINATUM
                             || note->next->u.note.shape
@@ -1887,14 +1899,18 @@ static __inline void write_single_hepisema(FILE *const f, int hepisema_case,
                             || note->next->u.note.shape
                             == S_PUNCTUM_INCLINATUM_AUCTUS)) {
                     /* is a punctum inclinatum of some sort */
-                    fprintf(f, "\\GreHEpisemaBridge{%d}{%d}{%d}%%\n",
+                    fprintf(f, "\\GreHEpisemaBridge{%d}{%d}{%d}{%s%s}%%\n",
                             pitch_value(height), hepisema_case,
-                            get_punctum_inclinatum_space_case(note->next));
+                            get_punctum_inclinatum_space_case(note->next),
+                            suppose_high_ledger_line(note),
+                            suppose_low_ledger_line(note));
                 }
             }
-            fprintf(f, "\\GreHEpisema{%d}{\\GreOCase%s}{%d}{%d}{%c}{%d}%%\n",
-                    pitch_value(height), note->gtex_offset_case, ambitus,
-                    hepisema_case, size_arg, pitch_value(height));
+            fprintf(f, "\\GreHEpisema{%d}{\\GreOCase%s}{%d}{%d}{%c}{%d}"
+                    "{%s%s}%%\n", pitch_value(height), note->gtex_offset_case,
+                    ambitus, hepisema_case, size_arg, pitch_value(height),
+                    suppose_high_ledger_line(note),
+                    suppose_low_ledger_line(note));
         }
     }
 }

--- a/src/struct.h
+++ b/src/struct.h
@@ -457,6 +457,12 @@ typedef struct gregorio_note {
     ENUM_BITFIELD(grehepisema_size) h_episema_below_size:2;
     bool h_episema_above_connect:1;
     bool h_episema_below_connect:1;
+    bool supposed_high_ledger_line:1;
+    bool supposed_low_ledger_line:1;
+    /* the "explicit" flags indicate that the "supposed" flags contain values
+     * that were explicitly specified in the gabc file */
+    bool explicit_high_ledger_line:1;
+    bool explicit_low_ledger_line:1;
     bool is_lower_note:1;
     bool is_upper_note:1;
     ENUM_BITFIELD(gregorio_vposition) mora_vposition:2;
@@ -778,6 +784,8 @@ static __inline bool is_fused(char liquescentia)
 #define LOWEST_PITCH 3
 #define HIGHEST_PITCH (LOWEST_PITCH + 12)
 #define DUMMY_PITCH (LOWEST_PITCH + 6)
+#define LOW_LEDGER_LINE_PITCH (LOWEST_PITCH + 1)
+#define HIGH_LEDGER_LINE_PITCH (HIGHEST_PITCH - 1)
 
 gregorio_score *gregorio_new_score(void);
 void gregorio_add_note(gregorio_note **current_note, signed char pitch,

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1024,6 +1024,7 @@
   \ifhmode\par\fi %
   \gre@beginningofscoretrue%
   \gre@reseteolcustos%
+  \gre@resetledgerlineheuristics%
   \global\setluatexattribute\gre@attr@glyph@id{0}%
   \xdef\gre@gabcname{#6}%
   \global\let\gre@save@englishcentering\gre@lyriccentering\relax % OBSOLETE

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1129,12 +1129,16 @@
 % dumb top function
 % #6 is a trick for bridges: if we must use a different height because of a
 %    bridge, use #6, otherwise use #1
-\def\GreHEpisema#1#2#3#4#5#6{%
+% #7 is used for setting heuristics
+\def\GreHEpisema#1#2#3#4#5#6#7{%
+  \gre@prephepisemaledgerlineheuristics%
+  #7%
   \ifgre@hepisemabridge%
     \gre@hepisorline{#6}{#2}{#3}{#4}{#5}%
   \else %
     \gre@hepisorline{#1}{#2}{#3}{#4}{#5}%
   \fi %
+  \gre@resetledgerlineheuristics%
   \relax %
 }%
 
@@ -1162,8 +1166,11 @@
 % #1 is the height
 % #2 is 0 for episema above, 1 for episema below
 % #3 is the "space case" for the following note, if a punctum inclinatum
-\def\GreHEpisemaBridge#1#2#3{%
+% #4 is for setting heuristics
+\def\GreHEpisemaBridge#1#2#3#4{%
   \ifgre@hepisemabridge%
+    \gre@prephepisemaledgerlineheuristics%
+    #4%
     \ifcase#2 %
       \gre@calculate@glyphraisevalue{#1}{9}%
     \or %
@@ -1187,6 +1194,7 @@
         \hss %
       }%
     }%
+    \gre@resetledgerlineheuristics%
   \fi %
   \relax %
 }%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -416,6 +416,38 @@
 % addedraisevalue is for the vertical episema and the puncta
 \newdimen\gre@dimen@addedraisevalue\relax%
 
+\newif\ifgre@useledgerlineheuristic%
+\gre@useledgerlineheuristictrue%
+\def\gresetledgerlineheuristic#1{%
+  \IfStrEq{#1}{enable}%
+    {\gre@useledgerlineheuristictrue}%
+    {\IfStrEq{#1}{disable}%
+      {\gre@useledgerlineheuristicfalse}%
+      {\gre@error{Unrecognized option in \protect\gresetledgerlineheuristic}}%
+    }%
+}%
+% for backwards compatibility, we set these to true by default, and the
+% system will set them appropriately if the heuristics determine a ledger
+% line probably doesn't exist at that point
+\newif\ifgre@ledgerline@above%
+\newif\ifgre@ledgerline@below%
+\def\GreSupposeHighLedgerLine{%
+  \ifgre@useledgerlineheuristic\gre@ledgerline@abovetrue\fi %
+}%
+\def\GreSupposeLowLedgerLine{%
+  \ifgre@useledgerlineheuristic\gre@ledgerline@belowtrue\fi %
+}%
+\def\gre@resetledgerlineheuristics{%
+  \gre@ledgerline@abovetrue\gre@ledgerline@belowtrue %
+}%
+\def\gre@prephepisemaledgerlineheuristics{%
+  \ifgre@useledgerlineheuristic %
+    \gre@ledgerline@abovefalse\gre@ledgerline@belowfalse %
+  \else %
+    \gre@ledgerline@abovetrue\gre@ledgerline@belowtrue %
+  \fi %
+}%
+
 % a very useful macro : it determines the good height of a glyph : the argument is the "number" where the glyph should be : 4 for the first line, 6 for the second, etc.
 % the second argument is for the cases of signs: for example if the note is on a line, the punctummora will be above, and the auctus duplex beneath. the possible values are:
 %% 0: no modification
@@ -440,9 +472,13 @@
   \or\gre@count@temp@three=\number 1%
   \or\gre@count@temp@three=\number 2%
   \or\gre@count@temp@three=\number 3%
-    \ifnum#2=3\relax %
-    \else %
-      \global\gre@isonalinetrue % if it is a vertical episema, we don't care if it is on a line or not... which may cause some problems...
+    \ifgre@ledgerline@below %
+      \ifnum#2=3\relax %
+      \else %
+        % if it is a vertical episema, we don't care if it is on a line or
+        % not... which may cause some problems...
+        \global\gre@isonalinetrue %
+      \fi %
     \fi %
   \or\gre@count@temp@three=\number 4%
   \or\gre@count@temp@three=\number 5%
@@ -458,7 +494,9 @@
     \global\gre@isonalinetrue%
   \or\gre@count@temp@three=\number 12%
   \or\gre@count@temp@three=\number 13%
-    \global\gre@isonalinetrue%
+    \ifgre@ledgerline@above %
+      \global\gre@isonalinetrue%
+    \fi %
   \or\gre@count@temp@three=\number 14%
   % the following are only useful for horizontal episema and rare signs
   \or\gre@count@temp@three=\number 15%


### PR DESCRIPTION
Fixes #716.

Note: I ended up realizing that the heuristic override is actually a note attribute, so rather than adding `6` to the episema specification, I implemented this as something like `[hl:0]` (meaning to act as if **no** high ledger line exists) and `[ll:1]` (meaning to act as if a high ledger line exists) attached to a note.

Please review and merge if satisfactory.