### PR TITLE
Allowed headers to be processed in TeX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Neume fusion, activated in gabc by `@`.  Use `@` before a clivis or a porrectus to get an unstemmed figure.  Use `@` between two notes to fuse them explicitly.  Enclose a set of notes within `@[` and `]` to automatically guess their fusion.  See GregorioRef for details (for the channge requests, see [#679](https://github.com/gregorio-project/gregorio/issues/679), [#687](https://github.com/gregorio-project/gregorio/issues/687), and [#692](https://github.com/gregorio-project/gregorio/issues/692)).
 - Hollow version of the oriscus, called by adding the `r` modifier to an oriscus, as in `gor` or `gor<` (See [#724](https://github.com/gregorio-project/gregorio/issues/724)).
 - Support for arbitrary external gabc headers starting with `x-`.  These are simply accepted by gregorio.
+- Headers (including the arbitrary headers starting with `x-`) are now passed to TeX and may be captured in TeX by using the `\gresetheadercapture` command.  See GregorioRef for details.
 - Support for half-spaces and ad-hoc spaces.  Use `/0` in gabc for a half-space between notes.  Use `/[factor]` (substituting a positive or negative real number for the scale factor) for an ad-hoc space whose length is `interelementspace` scaled by the desired factor.  See [#736](https://github.com/gregorio-project/gregorio/issues/736).
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -918,6 +918,14 @@ If the \texttt{string} option is supplied, the value will be passed with all
 non-space characters as \TeX{} catcode 12 (and all spaces as catcode 10).
 If not, the value will be evaluated as \TeX{}.
 
+The standard gabc headers will be processed first, in an arbitrary (but
+not random) order, followed by the external headers (the ones whose names
+start with \texttt{x-}), in the order they were presented in the gabc file.
+Headers will be processed in the TeX state at the point of the
+\verb=\gregorioscore= call.  This means, for example, that should the
+capturing macro produce something, it will be typeset within the same
+paragraph as the \verb=\gregorioscore= call.
+
 
 \subsubsection{Ancient Notation}
 For a full description of how to make use of the ancient notation capabilities of gregorio and Gregorio\TeX, look at the GregorioNabcRef documentation.  The commands listed here allow the manipulation of settings related to that notation.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -889,6 +889,36 @@ harmonizes with the greciliae font.  This macro must be redefined should
 a different value be desired.
 
 
+\subsubsection{Headers}
+
+\macroname{\textbackslash gresetheadercapture}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-main.tex}
+Macro to tell Gregorio\TeX{} to capture a given header by calling a specified
+macro.
+
+\begin{argtable}
+  \#1 & string & The name of the header\\
+  \#2 & string & The name of the macro to use (without the leading backslash)\\
+  \#3 & string & a comma-separated list of options\\
+\end{argtable}
+
+The options are:
+
+\begin{tabular}{ll}
+  \texttt{name}   & The header name should also be passed to the macro\\
+  \texttt{string} & The header value should be passed to the macro as a string\\
+\end{tabular}
+
+If the \texttt{name} option is not supplied, the macro supplied must take one
+argument: the value of the header.
+
+If the \texttt{name} option is supplied, the macro supplied must take two
+arguments: the name and the value of the header (in that order).
+
+If the \texttt{string} option is supplied, the value will be passed with all
+non-space characters as \TeX{} catcode 12 (and all spaces as catcode 10).
+If not, the value will be evaluated as \TeX{}.
+
+
 \subsubsection{Ancient Notation}
 For a full description of how to make use of the ancient notation capabilities of gregorio and Gregorio\TeX, look at the GregorioNabcRef documentation.  The commands listed here allow the manipulation of settings related to that notation.
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -410,6 +410,14 @@ therefore compatible with the score.
   \#1 & string & Version number for Gregorio\TeX.\\
 \end{argtable}
 
+\macroname{\textbackslash GreHeader}{\#1\#2}{gregoriotex-main.tex}
+Macro used to pass headers to TeX.
+
+\begin{argtable}
+  \#1 & string & The header name.\\
+  \#2 & string & The header value.\\
+\end{argtable}
+
 \macroname{\textbackslash GreHEpisema}{\#1\#2\#3\#4\#5\#6\#7}{gregoriotex-signs.tex}
 Macro to typeset an horizontal episema.
 

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3563,24 +3563,33 @@ static void initialize_score(gregoriotex_status *const status,
 static __inline void write_escapable_header_text(FILE *const f,
         const char *text)
 {
+    /* We escape these characters into \string\ddd (where ddd is the decimal
+     * ASCII value of the character) for most escapes, and into \string\n for
+     * newlines. We do it this way to get the "raw" string values through TeX
+     * and into Lua, where the sequences become \ddd and \n respectively and
+     * are translated into their byte values. Lua can then decide whether the
+     * full strings should be evaluated by TeX as TeX or as strings */
     for (; *text; ++text) {
         switch (*text) {
         case '\\':
         case '{':
         case '}':
         case '~':
-        case '%':
+        case '%': /* currently, we'll never get %, but handle it anyway */
         case '#':
         case '"':
+            /* these characters have special meaning to TeX */
             fprintf(f, "\\string\\%03d", *text);
             break;
         case '\n':
+            /* currently, we'll never get \n, but handle it anyway */
             fprintf(f, "\\string\\n");
             break;
         case '\r':
             /* ignore */
             break;
         default:
+            /* UTF-8 multibyte sequences will fall into here, which is fine */
             fputc(*text, f);
             break;
         }

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3560,6 +3560,99 @@ static void initialize_score(gregoriotex_status *const status,
     status->point_and_click = point_and_click;
 }
 
+static __inline void write_escapable_header_text(FILE *const f,
+        const char *text)
+{
+    for (; *text; ++text) {
+        switch (*text) {
+        case '\\':
+        case '{':
+        case '}':
+        case '~':
+        case '%':
+        case '#':
+        case '"':
+            fprintf(f, "\\string\\%03d", *text);
+            break;
+        case '\n':
+            fprintf(f, "\\string\\n");
+            break;
+        case '\r':
+            /* ignore */
+            break;
+        default:
+            fputc(*text, f);
+            break;
+        }
+    }
+}
+
+static void write_header(FILE *const f, const char *const name,
+        const char *const value)
+{
+    if (value) {
+        fprintf(f, "\\GreHeader{");
+        write_escapable_header_text(f, name);
+        fprintf(f, "}{");
+        write_escapable_header_text(f, value);
+        fprintf(f, "}%%\n");
+    }
+}
+
+static void write_numeric_header(FILE *const f, const char *const name,
+        const int value)
+{
+    fprintf(f, "\\GreHeader{");
+    write_escapable_header_text(f, name);
+    fprintf(f, "}{%d}%%\n", value);
+}
+
+static void write_headers(FILE *const f, gregorio_score *const score)
+{
+    int i;
+    gregorio_external_header *header;
+
+    if (score->number_of_voices != 1) {
+        write_numeric_header(f, "number-of-voices", score->number_of_voices);
+    }
+    write_header(f, "name", score->name);
+    write_header(f, "score-copyright", score->score_copyright);
+    write_header(f, "gabc-copyright", score->gabc_copyright);
+    write_header(f, "office-part", score->office_part);
+    write_header(f, "occasion", score->occasion);
+    write_header(f, "meter", score->meter);
+    write_header(f, "commentary", score->commentary);
+    write_header(f, "arranger", score->arranger);
+    if (score->mode) {
+        write_numeric_header(f, "mode", score->mode);
+    }
+    write_header(f, "author", score->si.author);
+    write_header(f, "date", score->si.date);
+    write_header(f, "manuscript", score->si.manuscript);
+    write_header(f, "manuscript-reference", score->si.manuscript_reference);
+    write_header(f, "manuscript-storage-place", score->si.manuscript_storage_place);
+    write_header(f, "book", score->si.book);
+    write_header(f, "transcriber", score->si.transcriber);
+    write_header(f, "language", score->language);
+    write_header(f, "transcription-date", score->si.transcription_date);
+    if (score->nabc_lines) {
+        write_numeric_header(f, "nabc-lines", score->nabc_lines);
+    }
+    write_header(f, "user-notes", score->user_notes);
+
+    /* since gregorio_voice_info is voice-specific, and there is no current
+     * way to move to the next voice for writing headers to GregorioTeX, these
+     * will be skipped until such is needed */
+
+    for (i = 0; i < MAX_ANNOTATIONS; ++i) {
+        write_header(f, "annotation", score->annotation[i]);
+    }
+
+    for (header = score->external_headers; header; header = header->next) {
+        write_header(f, header->name, header->value);
+    }
+}
+
 void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
         const char *const point_and_click_filename)
 {
@@ -3600,6 +3693,8 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
         fprintf(f, "%% The copyright of the score is: %s\n",
                 score->score_copyright);
     }
+
+    write_headers(f, score);
 
     fprintf(f, "\\GreBeginScore{%s}{%d}{%d}{%d}{%d}{%s}%%\n",
             digest_to_hex(score->digest), status.top_height,

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1567,6 +1567,17 @@
 }%
 
 %%%%%%%%%%%%%%%%%%%
+%% headers
+%%%%%%%%%%%%%%%%%%%
+\def\gresetheadercapture#1#2#3{%
+  \directlua{gregoriotex.set_header_capture("#1","#2","#3")}%
+}%
+
+\def\GreHeader#1#2{%
+  \directlua{gregoriotex.capture_header("#1","#2")}%
+}%
+
+%%%%%%%%%%%%%%%%%%%
 %% score including
 %%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This is my proposed solution to (the C-side of) #662.  The user can use a custom header (say `x-commentary`) and pass it to the `\grecommentary` macro by specifying `\gresetheadercapture{x-commentary}{grecommentary}{}`.  I thought that perhaps a general solution would be more useful to allow third-party use of headers both upstream and downstream from the gabc file.

Feel free to nix this if you don't feel it's a good idea.  Otherwise, please review and merge if satisfactory.