### PR TITLE
Added two-, three-, and five-line staff support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Headers (including the arbitrary headers starting with `x-`) are now passed to TeX and may be captured in TeX by using the `\gresetheadercapture` command.  See GregorioRef for details.
 - Support for half-spaces and ad-hoc spaces.  Use `/0` in gabc for a half-space between notes.  Use `/[factor]` (substituting a positive or negative real number for the scale factor) for an ad-hoc space whose length is `interelementspace` scaled by the desired factor.  See [#736](https://github.com/gregorio-project/gregorio/issues/736).
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
+- Support for two-, three-, and five-line staves.  Set the `staff-lines` header to `2`, `3`, or `5`.  The two new notes at the top of the scale (for a five-line staff) are `n` and `p`.
 
 ### Deprecated
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The space between note and horizontal episema has been tightened for notes at the `c` or `k` height when there is no ledger line.  Due to the intricacies of measurement, the system tries to make a best guess as to the existence of the ledger line.  If the guess is wrong, you may use the `[hl:n]` and `[ll:n]` notations in gabc to override the guess.  See [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#716](https://github.com/gregorio-project/gregorio/issues/716)).
 
 ### Added
-- Salicus flexus glyphs (See [#631](https://github.com/gregorio-project/gregorio/issues/631)).
+- Support for two-, three-, and five-line staves.  Set the `staff-lines` header to `2`, `3`, or `5`.  For all values of `staff-lines`, the note below the staff remains 'c'.  The two new notes above the staff (for a five-line staff) are `n` and `p`.  See [#429](https://github.com/gregorio-project/gregorio/issues/429).
+- Salicus flexus glyphs (see [#631](https://github.com/gregorio-project/gregorio/issues/631)).
 - Neume fusion, activated in gabc by `@`.  Use `@` before a clivis or a porrectus to get an unstemmed figure.  Use `@` between two notes to fuse them explicitly.  Enclose a set of notes within `@[` and `]` to automatically guess their fusion.  See GregorioRef for details (for the channge requests, see [#679](https://github.com/gregorio-project/gregorio/issues/679), [#687](https://github.com/gregorio-project/gregorio/issues/687), and [#692](https://github.com/gregorio-project/gregorio/issues/692)).
 - Hollow version of the oriscus, called by adding the `r` modifier to an oriscus, as in `gor` or `gor<` (See [#724](https://github.com/gregorio-project/gregorio/issues/724)).
 - Support for arbitrary external gabc headers starting with `x-`.  These are simply accepted by gregorio.
 - Headers (including the arbitrary headers starting with `x-`) are now passed to TeX and may be captured in TeX by using the `\gresetheadercapture` command.  See GregorioRef for details.
 - Support for half-spaces and ad-hoc spaces.  Use `/0` in gabc for a half-space between notes.  Use `/[factor]` (substituting a positive or negative real number for the scale factor) for an ad-hoc space whose length is `interelementspace` scaled by the desired factor.  See [#736](https://github.com/gregorio-project/gregorio/issues/736).
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
-- Support for two-, three-, and five-line staves.  Set the `staff-lines` header to `2`, `3`, or `5`.  The two new notes at the top of the scale (for a five-line staff) are `n` and `p`.
 
 ### Deprecated
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -20,7 +20,7 @@ respecting the annotation value in the \texttt{main.tex} file.
   \#2 & string & Second line text to place above the initial.\\
 \end{argtable}
 
-\macroname{\textbackslash GreBeginScore}{\#1\#2\#3\#4\#5\#6}{gregoriotex-main.tex}
+\macroname{\textbackslash GreBeginScore}{\#1\#2\#3\#4\#5\#6\#7}{gregoriotex-main.tex}
 Macro to start a score.
 
 \begin{argtable}
@@ -31,7 +31,8 @@ Macro to start a score.
       & 1 & there is a translation line somewhere in the score\\
   \#5 & 0 & there is no above lines text in the score\\
       & 1 & there is above lines text somewhere in the score\\
-  \#6 & string  & the absolute filename of the gabc file if point-and-click is enabled.
+  \#6 & string  & the absolute filename of the gabc file if point-and-click is enabled\\
+  \#7 & integer & the number of staff lines\\
 \end{argtable}
 
 \macroname{\textbackslash GreEndScore}{}{gregoriotex-main.tex}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -891,7 +891,7 @@ Macro to set the point-and-click position for above lines text.
 \macroname{\textbackslash gre@mark@translation}{}{gregoriotex-main.tex}
 Macro to set the point-and-click position for translations.
 
-\macroname{\textbackslash gre@pitch@[a-p]}{}{gregoriotex-main.tex}
+\macroname{\textbackslash gre@pitch@[a-n,p]}{}{gregoriotex-main.tex}
 Macros which map gabc pitch letters (the final part of the macro name) to the numerical value that Gregorio\TeX\ uses in processing note placement.
 
 \macroname{\textbackslash gre@pitch@adjust@top}{}{gregoriotex-main.tex}
@@ -899,6 +899,39 @@ If any note appears above this pitch, the space above the lines must be adjusted
 
 \macroname{\textbackslash gre@pitch@adjust@bottom}{}{gregoriotex-main.tex}
 If any note appears below this pitch, the space below the lines must be adjusted to account for it.
+
+\macroname{\textbackslash gre@pitch@abovestaff}{}{gregoriotex-main.tex}
+The pitch above the staff.
+
+\macroname{\textbackslash gre@pitch@belowstaff}{}{gregoriotex-main.tex}
+The pitch below the staff.
+
+\macroname{\textbackslash gre@pitch@ledger@above}{}{gregoriotex-main.tex}
+The pitch of the ledger line above the staff.
+
+\macroname{\textbackslash gre@pitch@ledger@below}{}{gregoriotex-main.tex}
+The pitch of the ledger line below the staff.
+
+\macroname{\textbackslash gre@pitch@barvepisema}{}{gregoriotex-main.tex}
+The pitch of the bar episema.
+
+\macroname{\textbackslash gre@pitch@underbrace}{}{gregoriotex-main.tex}
+The pitch of the under-the-staff brace.
+
+\macroname{\textbackslash gre@pitch@overbrace}{}{gregoriotex-main.tex}
+The pitch of the over-the-staff brace.
+
+\macroname{\textbackslash gre@pitch@overbraceglyph}{}{gregoriotex-main.tex}
+The pitch of the over-the-staff brace glyph.
+
+\macroname{\textbackslash gre@pitch@bar}{}{gregoriotex-main.tex}
+The pitch of the bar glyph.
+
+\macroname{\textbackslash gre@pitch@raresign}{}{gregoriotex-main.tex}
+The pitch of a rare sign (semicirculus, \etc).
+
+\macroname{\textbackslash gre@pitch@dummy}{}{gregoriotex-main.tex}
+A meaningless (don't-care) pitch.
 
 \macroname{\textbackslash gre@pointandclick}{\#1\#2}{gregoriotex-main.tex}
 Macro to generate the point-and-click links.
@@ -965,6 +998,16 @@ Alias for \verb=\resizebox=.
 
 \macroname{\textbackslash gre@dimension}{}{gregoriotex-spaces.tex}
 Workhorse function behind \verb=\grecreatedim= and \verb=\grechangedim=.
+
+\macroname{\textbackslash gre@setstafflines}{\#1}{gregoriotex-main.tex}
+Sets the number of staff lines.
+
+\begin{argtable}
+  \#1 & integer & The number of staff lines\\
+\end{argtable}
+
+\macroname{\textbackslash gre@stafflines}{}{gregoriotex-main.tex}
+Contains the number of staff lines.
 
 \subsection{Auxiliary File}
 Gregorio\TeX\ creates its own auxiliary file (extension \texttt{gaux}) which it uses to store information between successive typesetting runs.  This allows for such features as the dynamic interline spacing.  The following functions are used to interact with that auxiliary file.
@@ -1279,6 +1322,15 @@ Boolean which indicates that a third-line adjustment to staff line width is nece
 
 \macroname{\textbackslash ifgre@scale@stafflinefactor}{}{gregoriotex-spaces.tex}
 Boolean indicating whether the stafflinefactor should scale with changes of \texttt{grefactor}, or not.
+
+\macroname{\textbackslash ifgre@haslinethree}{}{gregoriotex-spaces.tex}
+Boolean indicating whether the staff has a third line.
+
+\macroname{\textbackslash ifgre@haslinefour}{}{gregoriotex-spaces.tex}
+Boolean indicating whether the staff has a fourth line.
+
+\macroname{\textbackslash ifgre@haslinefive}{}{gregoriotex-spaces.tex}
+Boolean indicating whether the staff has a fifth line.
 
 
 

--- a/fonts/greciliae-base.sfd
+++ b/fonts/greciliae-base.sfd
@@ -20,7 +20,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1176402534
-ModificationTime: 1450990984
+ModificationTime: 1452000033
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
@@ -43,7 +43,7 @@ NameList: Adobe Glyph List
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 144 16 4
+WinInfo: 128 16 4
 BeginPrivate: 0
 EndPrivate
 Grid
@@ -71,7 +71,7 @@ Grid
  17.75 -700 l 0
 EndSplineSet
 TeXData: 1 0 0 346030 173015 115343 0 1048576 115343 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 379 170
+BeginChars: 379 182
 
 StartChar: Punctum
 Encoding: 0 -1 0
@@ -4294,6 +4294,231 @@ SplineSet
  23.4092 -10.4072 21.5576 16.9824 21.5576 36.8848 c 6
  21.5576 124.774 l 5
  30.1084 121.558 41.6006 119.038 61.2773 125.774 c 4
+EndSplineSet
+EndChar
+
+StartChar: Virgula.2
+Encoding: 170 -1 170
+Width: 143
+VWidth: 1788
+Flags: HW
+HStem: -63.45 84.5<2.23911 67.6846>
+VStem: 87.1504 55.8996<-187.09 -83.284>
+LayerCount: 2
+Fore
+SplineSet
+-6.4502 -34.8496 m 4
+ -6.4502 9.87012 22.1826 21.0498 54.6504 21.0498 c 4
+ 81.2305 21.0498 143.05 -2.5332 143.05 -102.45 c 4
+ 143.05 -192.583 89.75 -249.783 -16.8496 -274.05 c 5
+ -19.1338 -271.766 -22.0498 -261.704 -22.0498 -258.45 c 4
+ -22.0498 -256.717 -21.6172 -255.417 -20.75 -254.55 c 5
+ 51.1826 -222.482 87.1504 -184.35 87.1504 -140.15 c 4
+ 87.1504 -78.79 49.4326 -69.1816 16.9502 -63.4502 c 4
+ 1.34961 -61.7168 -6.4502 -52.1826 -6.4502 -34.8496 c 4
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.2
+Encoding: 171 -1 171
+Width: 19
+VWidth: 1418
+Flags: HW
+HStem: -265.569 318.553
+VStem: 0 19<-264.028 52.984>
+LayerCount: 2
+Fore
+SplineSet
+0 -258.872 m 13
+ 0 52.9844 l 29
+ 18.999 53.0215 l 29
+ 19 -265.569 l 21
+ 6.04395 -265.435 2.43457 -262.391 0 -258.872 c 13
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.2
+Encoding: 172 -1 172
+Width: 19
+VWidth: 2048
+Flags: W
+HStem: -330.997 173.996
+VStem: 0 19<-330.997 -157.001>
+LayerCount: 2
+Fore
+SplineSet
+0 -157.001 m 25
+ 19 -157 l 25
+ 19 -330.997 l 29
+ 0 -331.002 l 29
+ 0 -157.001 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.2
+Encoding: 173 -1 173
+Width: 19
+VWidth: 2048
+Flags: W
+HStem: -408.997 329.996
+VStem: 0 19<-408.997 -79.001>
+LayerCount: 2
+Fore
+SplineSet
+0 -79.001 m 29
+ 19 -79 l 29
+ 19 -408.997 l 25
+ 0 -409.002 l 25
+ 0 -79.001 l 29
+EndSplineSet
+EndChar
+
+StartChar: Virgula.3
+Encoding: 174 -1 174
+Width: 143
+VWidth: 2103
+Flags: HW
+HStem: 251.55 84.5<2.23911 67.6846>
+VStem: 87.1504 55.8996<127.91 231.716>
+LayerCount: 2
+Fore
+SplineSet
+-6.4502 280.15 m 4
+ -6.4502 324.87 22.1826 336.05 54.6504 336.05 c 4
+ 81.2305 336.05 143.05 312.467 143.05 212.55 c 4
+ 143.05 122.417 89.75 65.2168 -16.8496 40.9502 c 5
+ -19.1338 43.2344 -22.0498 53.2959 -22.0498 56.5498 c 4
+ -22.0498 58.2832 -21.6172 59.583 -20.75 60.4502 c 5
+ 51.1826 92.5176 87.1504 130.65 87.1504 174.85 c 4
+ 87.1504 236.21 49.4326 245.818 16.9502 251.55 c 4
+ 1.34961 253.283 -6.4502 262.817 -6.4502 280.15 c 4
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.3
+Encoding: 175 -1 175
+Width: 19
+VWidth: 1733
+Flags: HW
+HStem: 49.431 318.553
+VStem: 0 19<50.972 367.984>
+LayerCount: 2
+Fore
+SplineSet
+0 56.1279 m 13
+ 0 367.984 l 29
+ 18.999 368.021 l 29
+ 19 49.4307 l 21
+ 6.04395 49.5654 2.43457 52.6094 0 56.1279 c 13
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.3
+Encoding: 176 -1 176
+Width: 19
+VWidth: 2048
+Flags: W
+HStem: -251.497 329.996
+VStem: 0 19<-251.497 78.499>
+LayerCount: 2
+Fore
+SplineSet
+0 78.499 m 25
+ 19 78.5 l 25
+ 19 -251.497 l 29
+ 0 -251.502 l 29
+ 0 78.499 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.3
+Encoding: 177 -1 177
+Width: 19
+VWidth: 2048
+Flags: W
+VStem: 0 19<-408.997 235.999>
+LayerCount: 2
+Fore
+SplineSet
+0 235.999 m 29
+ 19 236 l 29
+ 19 -408.997 l 25
+ 0 -409.002 l 25
+ 0 235.999 l 29
+EndSplineSet
+EndChar
+
+StartChar: Virgula.5
+Encoding: 178 -1 178
+Width: 143
+VWidth: 2733
+Flags: HW
+HStem: 881.55 84.5<2.23911 67.6846>
+VStem: 87.1504 55.8996<757.91 861.716>
+LayerCount: 2
+Fore
+SplineSet
+-6.4502 910.15 m 4
+ -6.4502 954.87 22.1826 966.05 54.6504 966.05 c 4
+ 81.2305 966.05 143.05 942.467 143.05 842.55 c 4
+ 143.05 752.417 89.75 695.217 -16.8496 670.95 c 5
+ -19.1338 673.234 -22.0498 683.296 -22.0498 686.55 c 4
+ -22.0498 688.283 -21.6172 689.583 -20.75 690.45 c 5
+ 51.1826 722.518 87.1504 760.65 87.1504 804.85 c 4
+ 87.1504 866.21 49.4326 875.818 16.9502 881.55 c 4
+ 1.34961 883.283 -6.4502 892.817 -6.4502 910.15 c 4
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.5
+Encoding: 179 -1 179
+Width: 19
+VWidth: 2363
+Flags: HW
+HStem: 679.431 318.553
+VStem: 0 19<680.972 997.984>
+LayerCount: 2
+Fore
+SplineSet
+0 686.128 m 13
+ 0 997.984 l 29
+ 18.999 998.021 l 29
+ 19 679.431 l 21
+ 6.04395 679.565 2.43457 682.609 0 686.128 c 13
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.5
+Encoding: 180 -1 180
+Width: 19
+VWidth: 2048
+Flags: W
+VStem: 0 19<-251.497 708.499>
+LayerCount: 2
+Fore
+SplineSet
+0 708.499 m 25
+ 19 708.5 l 25
+ 19 -251.497 l 25
+ 0 -251.502 l 25
+ 0 708.499 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.5
+Encoding: 181 -1 181
+Width: 19
+VWidth: 2048
+Flags: W
+VStem: 0 19<-408.997 865.999>
+LayerCount: 2
+Fore
+SplineSet
+0 865.999 m 29
+ 19 866 l 29
+ 19 -408.997 l 25
+ 0 -409.002 l 25
+ 0 865.999 l 29
 EndSplineSet
 EndChar
 EndChars

--- a/fonts/gregorio-base.sfd
+++ b/fonts/gregorio-base.sfd
@@ -19,7 +19,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1176402534
-ModificationTime: 1450889377
+ModificationTime: 1452000445
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
@@ -42,7 +42,7 @@ NameList: Adobe Glyph List
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 112 16 4
+WinInfo: 128 16 4
 BeginPrivate: 0
 EndPrivate
 Grid
@@ -56,7 +56,7 @@ Grid
  22 -700 l 0
 EndSplineSet
 TeXData: 1 0 0 346030 173015 115343 0 1048576 115343 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 375 157
+BeginChars: 375 169
 
 StartChar: Punctum
 Encoding: 0 -1 0
@@ -3803,6 +3803,213 @@ SplineSet
  35.7568 101.498 47.9521 102.019 59.4951 106.538 c 4
  75.2842 112.72 94.1699 133.238 108.22 133.413 c 4
  122.994 133.597 131.045 125.214 139.445 115.413 c 5
+EndSplineSet
+EndChar
+
+StartChar: Virgula.2
+Encoding: 158 -1 157
+Width: 152
+VWidth: 1418
+Flags: HW
+HStem: -1039 15 -724 15 -409 15 -94 15
+LayerCount: 2
+Fore
+SplineSet
+152 -76.667 m 1
+ 152 -132.322 67 -191 0 -211.002 c 1
+ 46 -172 152.5 -134.002 120 -68.002 c 1
+ 124.5 -99.002 17 -119.502 17 -57.002 c 1
+ 17 -32.002 49 -17.002 75 -17.002 c 1
+ 122.5 -16.002 152 -43.3223 152 -76.667 c 1
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.2
+Encoding: 159 -1 158
+Width: 19
+VWidth: 1418
+Flags: HW
+HStem: -1039 15 -724 15 -409 15 -94 15
+LayerCount: 2
+Fore
+SplineSet
+0 -270.872 m 9
+ 0 89.9844 l 29
+ 18.999 90.0215 l 25
+ 19 -277.569 l 17
+ 6.04395 -277.435 2.43457 -274.391 0 -270.872 c 9
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.2
+Encoding: 160 -1 159
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 -157.001 m 25
+ 19 -157 l 25
+ 19 -330.997 l 25
+ 0 -331.002 l 25
+ 0 -157.001 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.2
+Encoding: 161 -1 160
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 -79.001 m 29
+ 19 -79 l 29
+ 19 -408.997 l 25
+ 0 -409.002 l 25
+ 0 -79.001 l 29
+EndSplineSet
+EndChar
+
+StartChar: Virgula.3
+Encoding: 162 -1 161
+Width: 152
+VWidth: 1733
+Flags: HW
+HStem: -724 15 -409 15 -94 15 221 15
+LayerCount: 2
+Fore
+SplineSet
+152 238.333 m 1
+ 152 182.678 67 124 0 103.998 c 1
+ 46 143 152.5 180.998 120 246.998 c 1
+ 124.5 215.998 17 195.498 17 257.998 c 1
+ 17 282.998 49 297.998 75 297.998 c 1
+ 122.5 298.998 152 271.678 152 238.333 c 1
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.3
+Encoding: 163 -1 162
+Width: 19
+VWidth: 1733
+Flags: HW
+HStem: -724 15 -409 15 -94 15 221 15
+LayerCount: 2
+Fore
+SplineSet
+0 44.1279 m 9
+ 0 404.984 l 29
+ 18.999 405.021 l 25
+ 19 37.4307 l 17
+ 6.04395 37.5654 2.43457 40.6094 0 44.1279 c 9
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.3
+Encoding: 164 -1 163
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 78.499 m 25
+ 19 78.5 l 25
+ 19 -251.497 l 29
+ 0 -251.502 l 29
+ 0 78.499 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.3
+Encoding: 165 -1 164
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 235.999 m 29
+ 19 236 l 29
+ 19 -408.997 l 25
+ 0 -409.002 l 25
+ 0 235.999 l 29
+EndSplineSet
+EndChar
+
+StartChar: Virgula.5
+Encoding: 166 -1 165
+Width: 152
+VWidth: 2363
+Flags: HW
+HStem: -94 15 221 15 536 15 851 15
+LayerCount: 2
+Fore
+SplineSet
+152 868.333 m 1
+ 152 812.678 67 754 0 733.998 c 1
+ 46 773 152.5 810.998 120 876.998 c 1
+ 124.5 845.998 17 825.498 17 887.998 c 1
+ 17 912.998 49 927.998 75 927.998 c 1
+ 122.5 928.998 152 901.678 152 868.333 c 1
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.5
+Encoding: 167 -1 166
+Width: 19
+VWidth: 2363
+Flags: HW
+HStem: -94 15 221 15 536 15 851 15
+LayerCount: 2
+Fore
+SplineSet
+0 674.128 m 9
+ 0 1034.98 l 29
+ 18.999 1035.02 l 25
+ 19 667.431 l 17
+ 6.04395 667.565 2.43457 670.609 0 674.128 c 9
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.5
+Encoding: 168 -1 167
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 708.499 m 25
+ 19 708.5 l 25
+ 19 -251.497 l 29
+ 0 -251.502 l 29
+ 0 708.499 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.5
+Encoding: 169 -1 168
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 865.999 m 29
+ 19 866 l 29
+ 19 -408.997 l 25
+ 0 -409.002 l 25
+ 0 865.999 l 29
 EndSplineSet
 EndChar
 EndChars

--- a/fonts/parmesan-base.sfd
+++ b/fonts/parmesan-base.sfd
@@ -19,7 +19,7 @@ OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1176402534
-ModificationTime: 1450894718
+ModificationTime: 1452000795
 OS2TypoAscent: 0
 OS2TypoAOffset: 1
 OS2TypoDescent: 0
@@ -42,7 +42,7 @@ NameList: Adobe Glyph List
 DisplaySize: -96
 AntiAlias: 1
 FitToEm: 1
-WinInfo: 112 16 4
+WinInfo: 128 16 4
 BeginPrivate: 0
 EndPrivate
 Grid
@@ -58,7 +58,7 @@ Grid
  22 -700 l 0
 EndSplineSet
 TeXData: 1 0 0 346030 173015 115343 0 1048576 115343 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 375 157
+BeginChars: 375 169
 
 StartChar: Punctum
 Encoding: 0 -1 0
@@ -3876,6 +3876,213 @@ SplineSet
  142.621 133.545 152.755 117.062 157.406 98.457 c 4
  160.507 86.8291 161.282 79.2246 161.282 66.8213 c 4
  161.282 54.418 155.919 50.7939 148.205 50.5576 c 4
+EndSplineSet
+EndChar
+
+StartChar: Virgula.2
+Encoding: 158 -1 157
+Width: 152
+VWidth: 1418
+Flags: HW
+HStem: -1039 15 -724 15 -409 15 -94 15
+LayerCount: 2
+Fore
+SplineSet
+152.337 -76.667 m 1
+ 152.337 -132.322 67 -191 0 -211.002 c 1
+ 46 -172 152.5 -134.002 120 -68.002 c 1
+ 124.5 -99.002 17 -119.502 17 -57.002 c 1
+ 17 -32.002 49 -17.002 75 -17.002 c 1
+ 122.5 -16.002 152.337 -43.3223 152.337 -76.667 c 1
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.2
+Encoding: 159 -1 158
+Width: 19
+VWidth: 1418
+Flags: HW
+HStem: -1039 15 -724 15 -409 15 -94 15
+LayerCount: 2
+Fore
+SplineSet
+0 -270.872 m 9
+ 0.00292969 89.9844 l 25
+ 18.999 90.0215 l 25
+ 19 -277.569 l 17
+ 6.04395 -277.435 2.43457 -274.391 0 -270.872 c 9
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.2
+Encoding: 160 -1 159
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 -157.001 m 25
+ 19 -157 l 25
+ 18.9912 -330.997 l 29
+ 0 -331.002 l 29
+ 0 -157.001 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.2
+Encoding: 161 -1 160
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 -79.001 m 29
+ 19 -79 l 29
+ 18.9912 -408.997 l 25
+ 0 -409.002 l 25
+ 0 -79.001 l 29
+EndSplineSet
+EndChar
+
+StartChar: Virgula.3
+Encoding: 162 -1 161
+Width: 152
+VWidth: 1733
+Flags: HW
+HStem: -724 15 -409 15 -94 15 221 15
+LayerCount: 2
+Fore
+SplineSet
+152.337 238.333 m 1
+ 152.337 182.678 67 124 0 103.998 c 1
+ 46 143 152.5 180.998 120 246.998 c 1
+ 124.5 215.998 17 195.498 17 257.998 c 1
+ 17 282.998 49 297.998 75 297.998 c 1
+ 122.5 298.998 152.337 271.678 152.337 238.333 c 1
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.3
+Encoding: 163 -1 162
+Width: 19
+VWidth: 1733
+Flags: HW
+HStem: -724 15 -409 15 -94 15 221 15
+LayerCount: 2
+Fore
+SplineSet
+0 44.1279 m 9
+ 0.00292969 404.984 l 25
+ 18.999 405.021 l 25
+ 19 37.4307 l 17
+ 6.04395 37.5654 2.43457 40.6094 0 44.1279 c 9
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.3
+Encoding: 164 -1 163
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 78.499 m 25
+ 19 78.5 l 25
+ 18.9912 -251.497 l 29
+ 0 -251.502 l 29
+ 0 78.499 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.3
+Encoding: 165 -1 164
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 235.999 m 29
+ 19 236 l 29
+ 18.9912 -408.997 l 25
+ 0 -409.002 l 25
+ 0 235.999 l 29
+EndSplineSet
+EndChar
+
+StartChar: Virgula.5
+Encoding: 166 -1 165
+Width: 152
+VWidth: 2363
+Flags: HW
+HStem: -94 15 221 15 536 15 851 15
+LayerCount: 2
+Fore
+SplineSet
+152.337 868.333 m 1
+ 152.337 812.678 67 754 0 733.998 c 1
+ 46 773 152.5 810.998 120 876.998 c 1
+ 124.5 845.998 17 825.498 17 887.998 c 1
+ 17 912.998 49 927.998 75 927.998 c 1
+ 122.5 928.998 152.337 901.678 152.337 868.333 c 1
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinima.5
+Encoding: 167 -1 166
+Width: 19
+VWidth: 2363
+Flags: HW
+HStem: -94 15 221 15 536 15 851 15
+LayerCount: 2
+Fore
+SplineSet
+0 674.128 m 9
+ 0.00292969 1034.98 l 25
+ 18.999 1035.02 l 25
+ 19 667.431 l 17
+ 6.04395 667.565 2.43457 670.609 0 674.128 c 9
+EndSplineSet
+EndChar
+
+StartChar: DivisioMinor.5
+Encoding: 168 -1 167
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 708.499 m 25
+ 19 708.5 l 25
+ 18.9912 -251.497 l 29
+ 0 -251.502 l 29
+ 0 708.499 l 25
+EndSplineSet
+EndChar
+
+StartChar: DivisioMaior.5
+Encoding: 169 -1 168
+Width: 19
+VWidth: 2048
+Flags: HW
+HStem: -409 15 -94 15 221 15 536 15
+LayerCount: 2
+Fore
+SplineSet
+0 865.999 m 29
+ 19 866 l 29
+ 18.9912 -408.997 l 25
+ 0 -409.002 l 25
+ 0 865.999 l 29
 EndSplineSet
 EndChar
 EndChars

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -88,10 +88,14 @@ static const char *dump_bool(bool value) {
     return value? "true" : "false";
 }
 
-static const char *dump_pitch(const char height) {
+static const char *dump_pitch(const char height, const char highest_pitch) {
     static char buf[20];
-    if (height >= LOWEST_PITCH && height <= HIGHEST_PITCH) {
-        gregorio_snprintf(buf, 20, "%c", height + 'a' - LOWEST_PITCH);
+    if (height >= LOWEST_PITCH && height <= highest_pitch) {
+        char pitch = height + 'a' - LOWEST_PITCH;
+        if (pitch == 'o') {
+            pitch = 'p';
+        }
+        gregorio_snprintf(buf, 20, "%c", pitch);
     } else {
         gregorio_snprintf(buf, 20, "?%d", height);
     }
@@ -175,6 +179,9 @@ void dump_write_score(FILE *f, gregorio_score *score)
     }
     if (score->mode) {
         fprintf(f, "   mode                      %d\n", score->mode);
+    }
+    if (score->staff_lines != 4) {
+        fprintf (f, "   staff_lines               %d\n", (int)score->staff_lines);
     }
     if (score->nabc_lines) {
         fprintf (f, "   nabc_lines                %d\n", (int)score->nabc_lines);
@@ -273,7 +280,8 @@ void dump_write_score(FILE *f, gregorio_score *score)
             case GRE_CUSTOS:
                 if (element->u.misc.pitched.pitch) {
                     fprintf(f, "     pitch                   %s\n",
-                            dump_pitch(element->u.misc.pitched.pitch));
+                            dump_pitch(element->u.misc.pitched.pitch,
+                                score->highest_pitch));
                 }
                 if (element->u.misc.pitched.force_pitch) {
                     fprintf(f, "     force_pitch             true\n");
@@ -386,7 +394,8 @@ void dump_write_score(FILE *f, gregorio_score *score)
                     case GRE_NATURAL:
                     case GRE_SHARP:
                         fprintf(f, "       pitch                 %s\n",
-                                dump_pitch(glyph->u.misc.pitched.pitch));
+                                dump_pitch(glyph->u.misc.pitched.pitch,
+                                    score->highest_pitch));
                         break;
 
                     case GRE_GLYPH:
@@ -419,7 +428,8 @@ void dump_write_score(FILE *f, gregorio_score *score)
                             case GRE_NOTE:
                                 if (note->u.note.pitch) {
                                     fprintf(f, "         pitch                  %s\n",
-                                            dump_pitch(note->u.note.pitch));
+                                            dump_pitch(note->u.note.pitch,
+                                                score->highest_pitch));
                                 }
                                 if (note->u.note.shape) {
                                     fprintf(f, "         shape                  %d (%s)\n",

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -273,21 +273,24 @@ static gregorio_element *gabc_det_elements_from_glyphs(
  */
 
 static gregorio_element *gabc_det_elements_from_notes(
-        gregorio_note *current_note, int *current_key)
+        gregorio_note *current_note, int *current_key,
+        const gregorio_score *const score)
 {
     gregorio_element *final = NULL;
-    gregorio_glyph *tmp = gabc_det_glyphs_from_notes(current_note, current_key);
+    gregorio_glyph *tmp = gabc_det_glyphs_from_notes(current_note, current_key,
+            score);
     final = gabc_det_elements_from_glyphs(tmp);
     return final;
 }
 
-gregorio_element *gabc_det_elements_from_string(char *const str, int *const current_key,
-        char *macros[10], gregorio_scanner_location *const loc)
+gregorio_element *gabc_det_elements_from_string(char *const str,
+        int *const current_key, char *macros[10],
+        gregorio_scanner_location *const loc, const gregorio_score *const score)
 {
     gregorio_element *final;
     gregorio_note *tmp;
-    tmp = gabc_det_notes_from_string(str, macros, loc);
-    final = gabc_det_elements_from_notes(tmp, current_key);
+    tmp = gabc_det_notes_from_string(str, macros, loc, score);
+    final = gabc_det_elements_from_notes(tmp, current_key, score);
     return final;
 }
 

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -750,7 +750,7 @@ static gregorio_note *close_glyph(gregorio_glyph **last_glyph,
 /* TODO: there may be a side effect with the flated keys... */
 
 static char gabc_determine_custo_pitch(gregorio_note *current_note,
-        int current_key)
+        int current_key, const gregorio_score *const score)
 {
     int pitch_difference = 0;
     int newkey;
@@ -773,11 +773,11 @@ static char gabc_determine_custo_pitch(gregorio_note *current_note,
             while (pitch_difference < LOWEST_PITCH) {
                 pitch_difference += 7;
             }
-            while (pitch_difference > HIGHEST_PITCH) {
+            while (pitch_difference > score->highest_pitch) {
                 pitch_difference -= 7;
             }
             assert(pitch_difference >= LOWEST_PITCH
-                    && pitch_difference <= HIGHEST_PITCH);
+                    && pitch_difference <= score->highest_pitch);
             return (char) pitch_difference;
         }
         current_note = current_note->next;
@@ -824,7 +824,7 @@ static char gabc_determine_custo_pitch(gregorio_note *current_note,
 /* this function updates current_key with the new values (with clef changes) */
 
 gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
-        int *current_key)
+        int *current_key, const gregorio_score *const score)
 {
     /* the first note of the current glyph, to be able to close it well:
      * later we will cut the link (next_notes and previous_note) between
@@ -909,7 +909,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
 
             case GRE_CUSTOS:
                 pitch = gabc_determine_custo_pitch(current_note->next,
-                        *current_key);
+                        *current_key, score);
                 break;
 
             case GRE_MANUAL_CUSTOS:

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -48,6 +48,8 @@ static const char *overbrace_var_kind;
 static int before_ledger_type;
 static char *before_ledger_length = NULL;
 static int ledger_var[2] = { 0, 0 };
+static unsigned char staff_lines;
+static signed char highest_pitch;
 
 typedef enum ledger_line_type {
     LL_OVER = 0,
@@ -55,7 +57,16 @@ typedef enum ledger_line_type {
 } ledger_line_type;
 
 static __inline char pitch_letter_to_height(const char pitch) {
-    return pitch - 'a' + LOWEST_PITCH;
+    char result = pitch - 'a' + LOWEST_PITCH;
+    if (pitch == 'p') {
+        --result;
+    }
+    if (result > highest_pitch) {
+        gregorio_messagef("pitch_letter_to_height", VERBOSITY_ERROR, 0,
+                _("invalid pitch for %u lines: %c"), (unsigned int)staff_lines,
+                pitch);
+    }
+    return result;
 }
 
 static gregorio_shape punctum(const char pitch)
@@ -257,6 +268,25 @@ static void end_variable_ledger(const ledger_line_type type)
         ledger_var[type] = 0;
         gregorio_add_texverb_as_note(&current_note, gregorio_strdup(tempstr),
                 GRE_TEXVERB_GLYPH, &notes_lloc);
+    }
+}
+
+static __inline void check_clef_line(char line)
+{
+    line -= '0';
+    if (line < 0 || line > staff_lines) {
+        gregorio_messagef("check_clef_line", VERBOSITY_ERROR, 0,
+                _("invalid clef line for %u lines: %d"),
+                (unsigned int)staff_lines, (int)line);
+    }
+}
+
+static __inline void check_dominican_bar(const int bar)
+{
+    if (bar < 1 || bar > (2 * (staff_lines - 1))) {
+        gregorio_messagef("check_dominican_line", VERBOSITY_ERROR, 0,
+                _("invalid dominican bar for %u lines: ;%d"),
+                (unsigned int)staff_lines, bar);
     }
 }
 
@@ -625,7 +655,7 @@ static void end_variable_ledger(const ledger_line_type type)
                 gregorio_strdup("\\hss%\n}%\n\\GreNoBreak\\relax "),
                 GRE_TEXVERB_ELEMENT, &notes_lloc);
     }
-[a-m]\+ {
+[a-np]\+ {
         gregorio_add_manual_custos_as_note(&current_note,
                 pitch_letter_to_height(gabc_notes_determination_text[0]),
                 &notes_lloc);
@@ -642,7 +672,8 @@ Z   {
         gregorio_add_end_of_line_as_note(&current_note, GRE_END_OF_PAR,
                 &notes_lloc);
     }
-(c|f)[1-4] {
+(c|f)[1-5] {
+        check_clef_line(gabc_notes_determination_text[1]);
         if (gabc_notes_determination_text[0]=='c') {
             gregorio_add_clef_change_as_note(&current_note, GRE_C_KEY_CHANGE,
                     gabc_notes_determination_text[1], &notes_lloc);
@@ -651,7 +682,8 @@ Z   {
                     gabc_notes_determination_text[1], &notes_lloc);
         }
     }
-(cb|fb)[1-4] {
+(cb|fb)[1-5] {
+        check_clef_line(gabc_notes_determination_text[2]);
         if (gabc_notes_determination_text[0]=='c') {
             gregorio_add_clef_change_as_note(&current_note,
                     GRE_C_KEY_CHANGE_FLATED, gabc_notes_determination_text[2],
@@ -668,44 +700,40 @@ Z   {
 ,   {
         add_bar_as_note(B_DIVISIO_MINIMA);
     }
-,1  {
+[,;]1 {
+        check_dominican_bar(1);
         add_bar_as_note(B_DIVISIO_MINOR_D1);
     }
-,2  {
+[,;]2 {
+        check_dominican_bar(2);
         add_bar_as_note(B_DIVISIO_MINOR_D2);
     }
-,3  {
+[,;]3 {
+        check_dominican_bar(3);
         add_bar_as_note(B_DIVISIO_MINOR_D3);
     }
-,4  {
+[,;]4 {
+        check_dominican_bar(4);
         add_bar_as_note(B_DIVISIO_MINOR_D4);
     }
-,5  {
+[,;]5 {
+        check_dominican_bar(5);
         add_bar_as_note(B_DIVISIO_MINOR_D5);
     }
-,6  {
+[,;]6 {
+        check_dominican_bar(6);
         add_bar_as_note(B_DIVISIO_MINOR_D6);
+    }
+[,;]7 {
+        check_dominican_bar(7);
+        add_bar_as_note(B_DIVISIO_MINOR_D7);
+    }
+[,;]8 {
+        check_dominican_bar(8);
+        add_bar_as_note(B_DIVISIO_MINOR_D8);
     }
 ;   {
         add_bar_as_note(B_DIVISIO_MINOR);
-    }
-;1  {
-        add_bar_as_note(B_DIVISIO_MINOR_D1);
-    }
-;2  {
-        add_bar_as_note(B_DIVISIO_MINOR_D2);
-    }
-;3  {
-        add_bar_as_note(B_DIVISIO_MINOR_D3);
-    }
-;4  {
-        add_bar_as_note(B_DIVISIO_MINOR_D4);
-    }
-;5  {
-        add_bar_as_note(B_DIVISIO_MINOR_D5);
-    }
-;6  {
-        add_bar_as_note(B_DIVISIO_MINOR_D6);
     }
 :   {
         add_bar_as_note(B_DIVISIO_MAIOR);
@@ -737,13 +765,13 @@ r4  {
 r5  {
         gregorio_add_special_sign(current_note, _SEMI_CIRCULUS_REVERSUS);
     }
-[a-mA-M]x {
+[a-npA-NP]x {
         add_alteration(GRE_FLAT);
     }
-[a-mA-M]# {
+[a-npA-NP]# {
         add_alteration(GRE_SHARP);
     }
-[a-mA-M]y {
+[a-npA-NP]y {
         add_alteration(GRE_NATURAL);
     }
 !?\/0 {
@@ -789,39 +817,39 @@ r5  {
 =   {
         gregorio_change_shape(current_note, S_LINEA);
     }
-[a-mA-M]vv {
+[a-npA-NP]vv {
         lex_add_note(0, S_BIVIRGA, _NO_SIGN, L_NO_LIQUESCENTIA);
     }
-[a-mA-M]vvv {
+[a-npA-NP]vvv {
         lex_add_note(0, S_TRIVIRGA, _NO_SIGN, L_NO_LIQUESCENTIA);
     }
-[a-mA-M]VV {
+[a-npA-NP]VV {
         lex_add_note(0, S_BIVIRGA, _NO_SIGN, L_NO_LIQUESCENTIA);
     }
-[a-mA-M]VVV {
+[a-npA-NP]VVV {
         lex_add_note(0, S_TRIVIRGA, _NO_SIGN, L_NO_LIQUESCENTIA);
     }
-[a-mA-M]ss {
+[a-npA-NP]ss {
         lex_add_note(0, S_DISTROPHA, _NO_SIGN, L_NO_LIQUESCENTIA);
     }
-[a-mA-M]ss(\<|\>) {
+[a-npA-NP]ss(\<|\>) {
         lex_add_note(0, S_DISTROPHA, _NO_SIGN, L_AUCTUS_ASCENDENS);
     }
-[a-mA-M]sss {
+[a-npA-NP]sss {
         lex_add_note(0, S_TRISTROPHA, _NO_SIGN, L_NO_LIQUESCENTIA);
     }
-[a-mA-M]sss(\<|\>) {
+[a-npA-NP]sss(\<|\>) {
         lex_add_note(0, S_TRISTROPHA, _NO_SIGN, L_AUCTUS_ASCENDENS);
     }
-[a-mA-M] {
+[a-npA-NP] {
         lex_add_note(0, punctum(gabc_notes_determination_text[0]), _NO_SIGN,
                 L_NO_LIQUESCENTIA);
     }
--[a-mA-M] {
+-[a-npA-NP] {
         lex_add_note(1, punctum(gabc_notes_determination_text[1]), _NO_SIGN,
                 L_INITIO_DEBILIS);
     }
-@[a-mA-M] {
+@[a-npA-NP] {
         lex_add_note(1, punctum(gabc_notes_determination_text[1]), _NO_SIGN,
                 L_FUSED);
     }
@@ -892,7 +920,7 @@ s   {
 %%
 
 gregorio_note *gabc_det_notes_from_string(char *str, char *newmacros[10],
-        gregorio_scanner_location *loc)
+        gregorio_scanner_location *loc, const gregorio_score *const score)
 {
     int i;
     YY_BUFFER_STATE buf;
@@ -904,6 +932,9 @@ gregorio_note *gabc_det_notes_from_string(char *str, char *newmacros[10],
     notes_lloc.last_line = loc->first_line;
     notes_lloc.last_column = loc->first_column;
     notes_lloc.last_offset = loc->first_offset;
+
+    staff_lines = score->staff_lines;
+    highest_pitch = score->highest_pitch;
 
     /* a small optimization could uccur here: we could do it only once at the
      * beginning of the score, not at each syllable */

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -219,6 +219,9 @@ semicolon. */
 <INITIAL>gregoriotex-font {
         return GREGORIOTEX_FONT;
     }
+<INITIAL>staff-lines {
+        return STAFF_LINES;
+    }
 <INITIAL>nabc-lines {
         return NABC_LINES;
     }

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -37,7 +37,11 @@
 #include "gabc.h"
 
 static __inline char pitch_letter(const char height) {
-    return height + 'a' - LOWEST_PITCH;
+    char result = height + 'a' - LOWEST_PITCH;
+    if (result == 'o') {
+        return 'p';
+    }
+    return result;
 }
 
 static __inline void unsupported(const char *fn, const char *type,
@@ -337,6 +341,12 @@ static void gabc_write_bar(FILE *f, gregorio_bar type)
         break;
     case B_DIVISIO_MINOR_D6:
         fprintf(f, ";6");
+        break;
+    case B_DIVISIO_MINOR_D7:
+        fprintf(f, ";7");
+        break;
+    case B_DIVISIO_MINOR_D8:
+        fprintf(f, ";8");
         break;
     default:
         unsupported("gabc_write_bar", "bar type",
@@ -896,6 +906,12 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     gabc_write_str_attribute(f, "transcriber", score->si.transcriber);
     gabc_write_str_attribute(f, "transcription-date",
                              score->si.transcription_date);
+    if (score->staff_lines != 4) {
+        fprintf(f, "staff-lines: %u;\n", score->staff_lines);
+    }
+    if (score->nabc_lines) {
+        fprintf(f, "nabc-lines: %zu;\n", score->nabc_lines);
+    }
     if (score->mode) {
         fprintf(f, "mode: %d;\n", score->mode);
     }

--- a/src/gabc/gabc.h
+++ b/src/gabc/gabc.h
@@ -29,11 +29,12 @@
 
 /* functions to read gabc */
 gregorio_note *gabc_det_notes_from_string(char *str, char *macros[10],
-        gregorio_scanner_location *loc);
+        gregorio_scanner_location *loc, const gregorio_score *score);
 gregorio_element *gabc_det_elements_from_string(char *str, int *current_key,
-        char *macros[10], gregorio_scanner_location *loc);
+        char *macros[10], gregorio_scanner_location *loc,
+        const gregorio_score *const score);
 gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
-        int *current_key);
+        int *current_key, const gregorio_score *score);
 void gabc_digest(const void *buf, size_t size);
 int gabc_score_determination_lex_destroy(void);
 int gabc_notes_determination_lex_destroy(void);

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -1093,12 +1093,13 @@ static bool is_h_episema_below_better_height(const signed char new_height,
     return new_height < old_height;
 }
 
-static __inline bool has_high_ledger_line(const signed char height, bool is_sign)
+static __inline bool has_high_ledger_line(const signed char height,
+        bool is_sign, const gregorio_score *const score)
 {
     if (is_sign) {
-        return height > HIGH_LEDGER_LINE_PITCH;
+        return height > score->high_ledger_line_pitch;
     }
-    return height >= HIGH_LEDGER_LINE_PITCH;
+    return height >= score->high_ledger_line_pitch;
 }
 
 static __inline bool has_low_ledger_line(const signed char height, bool is_sign)
@@ -1135,7 +1136,7 @@ static __inline void position_h_episema(gregorio_note *const note,
 
 static __inline void next_has_ledger_line(
         const height_computation *const h, bool *high_ledger_line,
-        bool *low_ledger_line)
+        bool *low_ledger_line, const gregorio_score *const score)
 {
     const gregorio_element *element = h->last_connected_element;
     const gregorio_glyph *glyph = h->last_connected_glyph;
@@ -1163,7 +1164,7 @@ static __inline void next_has_ledger_line(
             }
 
             *high_ledger_line = *high_ledger_line
-                    || has_high_ledger_line(note->u.note.pitch, false);
+                    || has_high_ledger_line(note->u.note.pitch, false, score);
             *low_ledger_line = *low_ledger_line
                     || has_low_ledger_line(note->u.note.pitch, false);
 
@@ -1181,7 +1182,7 @@ static __inline void next_has_ledger_line(
 
 static __inline void previous_has_ledger_line(
         const height_computation *const h, bool *high_ledger_line,
-        bool *low_ledger_line)
+        bool *low_ledger_line, const gregorio_score *const score)
 {
     const gregorio_element *element = h->start_element;
     const gregorio_glyph *glyph = h->start_glyph;
@@ -1211,7 +1212,7 @@ static __inline void previous_has_ledger_line(
                 note = gregorio_glyph_last_note(glyph);
             }
             *high_ledger_line = *high_ledger_line
-                    || has_high_ledger_line(note->u.note.pitch, false);
+                    || has_high_ledger_line(note->u.note.pitch, false, score);
             *low_ledger_line = *low_ledger_line
                     || has_low_ledger_line(note->u.note.pitch, false);
 
@@ -1228,7 +1229,7 @@ static __inline void previous_has_ledger_line(
 }
 
 static __inline void set_h_episema_height(const height_computation *const h,
-        gregorio_note *const end)
+        gregorio_note *const end, const gregorio_score *const score)
 {
     gregorio_note *last_note = NULL;
 
@@ -1236,13 +1237,13 @@ static __inline void set_h_episema_height(const height_computation *const h,
     const gregorio_glyph *glyph = h->start_glyph;
     gregorio_note *note = h->start_note;
 
-    bool high_ledger_line = has_high_ledger_line(h->height, true)
-            || has_high_ledger_line(h->height - h->vpos, false);
+    bool high_ledger_line = has_high_ledger_line(h->height, true, score)
+            || has_high_ledger_line(h->height - h->vpos, false, score);
     bool low_ledger_line = has_low_ledger_line(h->height, true)
             || has_low_ledger_line(h->height - h->vpos, false);
 
-    next_has_ledger_line(h, &high_ledger_line, &low_ledger_line);
-    previous_has_ledger_line(h, &high_ledger_line, &low_ledger_line);
+    next_has_ledger_line(h, &high_ledger_line, &low_ledger_line, score);
+    previous_has_ledger_line(h, &high_ledger_line, &low_ledger_line, score);
 
     for ( ; element; element = element->next) {
         if (element->type == GRE_ELEMENT) {
@@ -1305,7 +1306,7 @@ static __inline bool has_space_to_left(const gregorio_note *const note) {
 }
 
 static __inline void end_h_episema(height_computation *const h,
-        gregorio_note *const end)
+        gregorio_note *const end, const gregorio_score *const score)
 {
     signed char proposed_height;
 
@@ -1366,7 +1367,7 @@ static __inline void end_h_episema(height_computation *const h,
             }
         }
 
-        set_h_episema_height(h, end);
+        set_h_episema_height(h, end, score);
 
         h->active = false;
         h->height = 0;
@@ -1383,7 +1384,7 @@ static __inline void end_h_episema(height_computation *const h,
 static __inline void compute_h_episema(height_computation *const h,
         const gregorio_element *const element,
         const gregorio_glyph *const glyph, gregorio_note *const note,
-        const int i, const gtex_type type)
+        const int i, const gtex_type type, const gregorio_score *const score)
 {
     signed char next_height;
     grehepisema_size size;
@@ -1403,7 +1404,7 @@ static __inline void compute_h_episema(height_computation *const h,
                     }
                 }
                 else {
-                    end_h_episema(h, note);
+                    end_h_episema(h, note, score);
                     start_h_episema(h, element, glyph, note);
                 }
             } else {
@@ -1415,7 +1416,7 @@ static __inline void compute_h_episema(height_computation *const h,
             h->last_connected_glyph = glyph;
             h->last_connected_note = note;
         } else {
-            end_h_episema(h, note);
+            end_h_episema(h, note, score);
         }
     } else if (!h->is_shown(note)) {
         /* special handling for porrectus shapes because of their shape:   
@@ -1426,14 +1427,14 @@ static __inline void compute_h_episema(height_computation *const h,
         case T_PORRECTUS:
         case T_PORRECTUS_FLEXUS:
             if (i == 2) {
-                end_h_episema(h, note);
+                end_h_episema(h, note, score);
             }
             break;
 
         case T_TORCULUS_RESUPINUS:
         case T_TORCULUS_RESUPINUS_FLEXUS:
             if (i == 3) {
-                end_h_episema(h, note);
+                end_h_episema(h, note, score);
             }
             break;
 
@@ -1447,7 +1448,7 @@ static __inline void compute_h_episema(height_computation *const h,
 static __inline void compute_note_positioning(height_computation *const above,
         height_computation *const below, const gregorio_element *const element,
         const gregorio_glyph *const glyph, gregorio_note *const note,
-        const int i, const gtex_type type)
+        const int i, const gtex_type type, const gregorio_score *const score)
 {
     gregorio_vposition default_vpos = advise_positioning(glyph, note, i, type);
 
@@ -1461,8 +1462,8 @@ static __inline void compute_note_positioning(height_computation *const above,
         }
     }
 
-    compute_h_episema(above, element, glyph, note, i, type);
-    compute_h_episema(below, element, glyph, note, i, type);
+    compute_h_episema(above, element, glyph, note, i, type, score);
+    compute_h_episema(below, element, glyph, note, i, type, score);
 }
 
 static __inline int compute_fused_shift(const gregorio_glyph *glyph)
@@ -1605,7 +1606,8 @@ static __inline int compute_fused_shift(const gregorio_glyph *glyph)
     return shift;
 }
 
-void gregoriotex_compute_positioning(const gregorio_element *element)
+void gregoriotex_compute_positioning(const gregorio_element *element,
+        const gregorio_score *const score)
 {
     height_computation above = {
         /*.vpos =*/ VPOS_ABOVE,
@@ -1665,17 +1667,17 @@ void gregoriotex_compute_positioning(const gregorio_element *element)
                             note = note->next) {
                         if (note->type == GRE_NOTE) {
                             compute_note_positioning(&above, &below, element,
-                                    glyph, note, ++i, type);
+                                    glyph, note, ++i, type, score);
                         }
                     }
                 }
             }
         } else if (!is_bridgeable_space(element)) {
-            end_h_episema(&above, NULL);
-            end_h_episema(&below, NULL);
+            end_h_episema(&above, NULL, score);
+            end_h_episema(&below, NULL, score);
         }
     }
-    end_h_episema(&above, NULL);
-    end_h_episema(&below, NULL);
+    end_h_episema(&above, NULL, score);
+    end_h_episema(&below, NULL, score);
 }
 

--- a/src/gregoriotex/gregoriotex.h
+++ b/src/gregoriotex/gregoriotex.h
@@ -154,6 +154,7 @@ bool gtex_is_h_episema_below_shown(const gregorio_note *const note);
 const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         const gregorio_element *const element, gtex_alignment *const  type,
         gtex_type *const gtype);
-void gregoriotex_compute_positioning(const gregorio_element *element);
+void gregoriotex_compute_positioning(const gregorio_element *element,
+        const gregorio_score *score);
 
 #endif

--- a/src/struct.c
+++ b/src/struct.c
@@ -1071,6 +1071,7 @@ gregorio_score *gregorio_new_score(void)
     for (annotation_num = 0; annotation_num < MAX_ANNOTATIONS; ++annotation_num) {
         new_score->annotation[annotation_num] = NULL;
     }
+    gregorio_set_score_staff_lines(new_score, 4);
     return new_score;
 }
 
@@ -1410,6 +1411,24 @@ void gregorio_set_score_transcription_date(gregorio_score *score,
     score->si.transcription_date = transcription_date;
 }
 
+void gregorio_set_score_staff_lines(gregorio_score *const score,
+        const char staff_lines)
+{
+    if (!score) {
+        gregorio_message(_("function called with NULL argument"),
+                "gregorio_set_score_staff_lines", VERBOSITY_WARNING, 0);
+        return;
+    }
+    if (staff_lines < 2 || staff_lines > 5) {
+        gregorio_message(_("invalid number of staff lines"),
+                "gregorio_set_score_staff_lines", VERBOSITY_WARNING, 0);
+        return;
+    }
+    score->staff_lines = staff_lines;
+    score->highest_pitch = LOWEST_PITCH + 4 + (2 * staff_lines);
+    score->high_ledger_line_pitch = score->highest_pitch - 1;
+}
+
 void gregorio_add_score_external_header(gregorio_score *score, char *name,
         char *value)
 {
@@ -1466,11 +1485,13 @@ void gregorio_set_voice_virgula_position(gregorio_voice_info *voice_info,
  * * 3 for a C key on the second line
  * * 5 for a C key on the third line (default key)
  * * 7 for a C key on the fourth line
+ * * 9 for a C key on the fifth line
  *
  * * -2 for a F key on the first line
  * * 0 for a F key on the second line
  * * 2 for a F key on the third line
  * * 4 for a F key on the fourth line
+ * * 6 for a F key on the fifth line
  *
  *********************************/
 
@@ -1516,6 +1537,10 @@ void gregorio_det_step_and_line_from_key(int key, char *step, int *line)
         *step = 'f';
         *line = 4;
         break;
+    case 6:
+        *step = 'f';
+        *line = 5;
+        break;
     case 1:
         *step = 'c';
         *line = 1;
@@ -1531,6 +1556,10 @@ void gregorio_det_step_and_line_from_key(int key, char *step, int *line)
     case 7:
         *step = 'c';
         *line = 4;
+        break;
+    case 9:
+        *step = 'c';
+        *line = 5;
         break;
     default:
         *step = '?';

--- a/src/struct.c
+++ b/src/struct.c
@@ -1421,7 +1421,7 @@ void gregorio_set_score_staff_lines(gregorio_score *const score,
     }
     if (staff_lines < 2 || staff_lines > 5) {
         gregorio_message(_("invalid number of staff lines"),
-                "gregorio_set_score_staff_lines", VERBOSITY_WARNING, 0);
+                "gregorio_set_score_staff_lines", VERBOSITY_ERROR, 0);
         return;
     }
     score->staff_lines = staff_lines;

--- a/src/struct.h
+++ b/src/struct.h
@@ -153,7 +153,9 @@ ENUM(gregorio_shape, GREGORIO_SHAPE);
     E(B_DIVISIO_MINOR_D3) \
     E(B_DIVISIO_MINOR_D4) \
     E(B_DIVISIO_MINOR_D5) \
-    L(B_DIVISIO_MINOR_D6)
+    E(B_DIVISIO_MINOR_D6) \
+    E(B_DIVISIO_MINOR_D7) \
+    L(B_DIVISIO_MINOR_D8)
 ENUM(gregorio_bar, GREGORIO_BAR);
 
 /* definition of the signs. You can notice that the values are made so
@@ -698,7 +700,7 @@ typedef struct gregorio_score {
     char *annotation[MAX_ANNOTATIONS];
     /* field giving informations on the initial (no initial, normal initial 
      * or two lines initial) */
-    signed char initial_style;
+    signed char initial_style; /* DEPRECATED */
     /* the font to use in gregoriotex */
     char *gregoriotex_font;
     size_t nabc_lines;
@@ -711,6 +713,9 @@ typedef struct gregorio_score {
     struct gregorio_external_header *external_headers;
     struct gregorio_external_header *last_external_header;
     gregorio_lyric_centering centering;
+    unsigned char staff_lines;
+    signed char highest_pitch;
+    signed char high_ledger_line_pitch;
 } gregorio_score;
 
 /*
@@ -786,10 +791,8 @@ static __inline bool is_fused(char liquescentia)
 
 /* The first pitch MUST be an odd number */
 #define LOWEST_PITCH 3
-#define HIGHEST_PITCH (LOWEST_PITCH + 12)
 #define DUMMY_PITCH (LOWEST_PITCH + 6)
 #define LOW_LEDGER_LINE_PITCH (LOWEST_PITCH + 1)
-#define HIGH_LEDGER_LINE_PITCH (HIGHEST_PITCH - 1)
 
 gregorio_score *gregorio_new_score(void);
 void gregorio_add_note(gregorio_note **current_note, signed char pitch,
@@ -894,6 +897,7 @@ void gregorio_set_score_transcriber(gregorio_score *score, char *transcriber);
 void gregorio_set_score_transcription_date(gregorio_score *score,
         char *transcription_date);
 void gregorio_set_score_user_notes(gregorio_score *score, char *user_notes);
+void gregorio_set_score_staff_lines(gregorio_score *score, char staff_lines);
 void gregorio_add_score_external_header(gregorio_score *score, char *name,
         char *value);
 void gregorio_set_voice_style(gregorio_voice_info *voice_info, char *style);

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -185,11 +185,16 @@
 \def\gre@pitch@l{14}%
 \def\gre@pitch@m{15}%
 \def\gre@pitch@n{16}%
-\def\gre@pitch@o{17}%
-\def\gre@pitch@p{18}%
+\def\gre@pitch@p{17}%
 
-\let\gre@pitch@adjust@top\gre@pitch@j %
 \let\gre@pitch@adjust@bottom\gre@pitch@c %
+\let\gre@pitch@belowstaff\gre@pitch@c %
+\let\gre@pitch@ledger@below\gre@pitch@b %
+\let\gre@pitch@barvepisema\gre@pitch@c %
+\let\gre@pitch@underbrace\gre@pitch@b %
+\let\gre@pitch@overbraceglyph\gre@pitch@g %
+\let\gre@pitch@bar\gre@pitch@g %
+\let\gre@pitch@dummy\gre@pitch@g %
 
 % factor is the factor with which you open you font (the number after the at). It will decide almost everything (spaces, etc.), so it is particularly important.
 % it is set to the default value : 17 (the value that makes it look like a standard graduale)
@@ -767,19 +772,32 @@
       \else %
         \vskip\gre@dimen@stafflineheight\relax%
       \fi %
-      \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-      \kern\gre@skip@temp@four %
-      \ifgre@showlines %
-        \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-      \else %
-        \vskip\gre@dimen@stafflineheight\relax%
+      \ifgre@haslinethree %
+        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
+        \kern\gre@skip@temp@four %
+        \ifgre@showlines %
+          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
+        \else %
+          \vskip\gre@dimen@stafflineheight\relax%
+        \fi %
       \fi %
-      \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-      \kern\gre@skip@temp@four %
-      \ifgre@showlines %
-        \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-      \else %
-        \vskip\gre@dimen@stafflineheight\relax%
+      \ifgre@haslinefour %
+        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
+        \kern\gre@skip@temp@four %
+        \ifgre@showlines %
+          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
+        \else %
+          \vskip\gre@dimen@stafflineheight\relax%
+        \fi %
+      \fi %
+      \ifgre@haslinefive %
+        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
+        \kern\gre@skip@temp@four %
+        \ifgre@showlines %
+          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
+        \else %
+          \vskip\gre@dimen@stafflineheight\relax%
+        \fi %
       \fi %
       \vskip\gre@dimen@spacelinestext\relax%
       \vskip\gre@dimen@spacebeneathtext\relax%
@@ -819,19 +837,32 @@
       \else %
         \vskip\gre@dimen@stafflineheight\relax%
       \fi %
-      \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-      \kern\gre@skip@temp@four %
-      \ifgre@showlines %
-        \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-      \else %
-        \vskip\gre@dimen@stafflineheight\relax%
+      \ifgre@haslinethree %
+        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
+        \kern\gre@skip@temp@four %
+        \ifgre@showlines %
+          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
+        \else %
+          \vskip\gre@dimen@stafflineheight\relax%
+        \fi %
       \fi %
-      \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-      \kern\gre@skip@temp@four %
-      \ifgre@showlines %
-        \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-      \else %
-        \vskip\gre@dimen@stafflineheight\relax%
+      \ifgre@haslinefour %
+        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
+        \kern\gre@skip@temp@four %
+        \ifgre@showlines %
+          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
+        \else %
+          \vskip\gre@dimen@stafflineheight\relax%
+        \fi %
+      \fi %
+      \ifgre@haslinefive %
+        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
+        \kern\gre@skip@temp@four %
+        \ifgre@showlines %
+          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
+        \else %
+          \vskip\gre@dimen@stafflineheight\relax%
+        \fi %
       \fi %
       \vskip\gre@dimen@spacelinestext\relax%
       \vskip\gre@dimen@additionalbottomspace\relax%
@@ -1011,6 +1042,64 @@
 % gre@attr@dash (see its definition in gregorio-syllable) is 0 when we are in a score, and unset when we are not
 
 \newif\ifgre@beginningofscore%
+\newif\ifgre@haslinethree%
+\newif\ifgre@haslinefour%
+\newif\ifgre@haslinefive%
+
+\def\gre@setstafflines#1{%
+  \def\gre@stafflines{#1}%
+  \ifcase#1% 0
+    \gre@error{Invalid number of staff lines}%
+  \or % 1
+    \gre@error{Invalid number of staff lines}%
+  \or % 2
+    \let\gre@pitch@adjust@top\gre@pitch@f %
+    \let\gre@pitch@abovestaff\gre@pitch@g %
+    \let\gre@pitch@ledger@above\gre@pitch@h %
+    \let\gre@pitch@raresign\gre@pitch@g %
+    \let\gre@pitch@overbrace\gre@pitch@i %
+    \grechangeglyph{Virgula}{*}{.2}%
+    \grechangeglyph{Divisio*}{*}{.2}%
+    \gre@haslinethreefalse %
+    \gre@haslinefourfalse %
+    \gre@haslinefivefalse %
+  \or % 3
+    \let\gre@pitch@adjust@top\gre@pitch@h %
+    \let\gre@pitch@abovestaff\gre@pitch@i %
+    \let\gre@pitch@ledger@above\gre@pitch@j %
+    \let\gre@pitch@raresign\gre@pitch@i %
+    \let\gre@pitch@overbrace\gre@pitch@k %
+    \grechangeglyph{Virgula}{*}{.3}%
+    \grechangeglyph{Divisio*}{*}{.3}%
+    \gre@haslinethreetrue %
+    \gre@haslinefourfalse %
+    \gre@haslinefivefalse %
+  \or % 4
+    \let\gre@pitch@adjust@top\gre@pitch@j %
+    \let\gre@pitch@abovestaff\gre@pitch@k %
+    \let\gre@pitch@ledger@above\gre@pitch@l %
+    \let\gre@pitch@raresign\gre@pitch@k %
+    \let\gre@pitch@overbrace\gre@pitch@m %
+    \greresetglyph{Virgula}%
+    \greresetglyph{Divisio*}%
+    \gre@haslinethreetrue %
+    \gre@haslinefourtrue %
+    \gre@haslinefivefalse %
+  \or % 5
+    \let\gre@pitch@adjust@top\gre@pitch@l %
+    \let\gre@pitch@abovestaff\gre@pitch@m %
+    \let\gre@pitch@ledger@above\gre@pitch@n %
+    \let\gre@pitch@raresign\gre@pitch@m %
+    \let\gre@pitch@overbrace\gre@pitch@p %
+    \grechangeglyph{Virgula}{*}{.5}%
+    \grechangeglyph{Divisio*}{*}{.5}%
+    \gre@haslinethreetrue %
+    \gre@haslinefourtrue %
+    \gre@haslinefivetrue %
+  \else %
+    \gre@error{Invalid number of staff lines}%
+  \fi %
+}%
 
 %macro called at the beginning of a score
 % #1 is the gabc score id
@@ -1019,7 +1108,8 @@
 % #4 is 1 if there is a translation somewhere
 % #5 is if 1 if we have space above the staff
 % #6 is the point-and-click filename
-\def\GreBeginScore#1#2#3#4#5#6{%
+% #7 is the number of staff lines
+\def\GreBeginScore#1#2#3#4#5#6#7{%
   % scores must be new paragraphs!
   \ifhmode\par\fi %
   \gre@beginningofscoretrue%
@@ -1027,6 +1117,7 @@
   \gre@resetledgerlineheuristics%
   \global\setluatexattribute\gre@attr@glyph@id{0}%
   \xdef\gre@gabcname{#6}%
+  \gre@setstafflines{#7}%
   \global\let\gre@save@englishcentering\gre@lyriccentering\relax % OBSOLETE
   \global\let\gre@opening@initialstyle\gre@initiallines\relax % DEPRECATED by 4.1
   \ifgre@justifylastline%
@@ -1078,7 +1169,7 @@
   % with some versions of LuaTeX, the \localrightbox and \localleftbox must be set empty in an environment with the good attributes set
   \gre@localleftbox{}%
   \gre@localrightbox{}%
-  \gre@calculate@additionalspaces{\gre@pitch@g}{\gre@pitch@g}{0}{0}%
+  \gre@calculate@additionalspaces{\gre@pitch@dummy}{\gre@pitch@dummy}{0}{0}%
   \global\gre@dimen@currentabovelinestextheight=0 sp%
   \gre@removetranslationspace %
   \gre@normalinitial %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -168,6 +168,8 @@
     \gre@calculate@glyphraisevalue{\gre@pitch@g}{0}%
   \or%
     \gre@calculate@glyphraisevalue{\gre@pitch@i}{0}%
+  \or%
+    \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
   \fi%
   \gre@skip@temp@two=\gre@skip@spaceafterlineclef\relax%
   \ifnum#4=0\relax %
@@ -256,15 +258,11 @@
   \setbox\gre@box@temp@width=\hbox{\gre@pickcustos{#1}}%
   \gre@dimen@temp@three=\wd\gre@box@temp@width %
   \ifgre@showlines %
-    \ifnum#1=\gre@pitch@a\relax %
+    \ifnum#1<\gre@pitch@belowstaff\relax %
       \gre@additionalbottomcustoslinemiddle %
-    \else\ifnum#1=\gre@pitch@b\relax %
-      \gre@additionalbottomcustoslinemiddle %
-    \else\ifnum#1=\gre@pitch@l\relax %
+    \else\ifnum#1>\gre@pitch@abovestaff\relax %
       \gre@additionaltopcustoslinemiddle %
-    \else\ifnum#1=\gre@pitch@m\relax %
-      \gre@additionaltopcustoslinemiddle %
-    \fi\fi\fi\fi %
+    \fi\fi %
   \fi %
   \raise \gre@dimen@glyphraisevalue\relax%
   \copy\gre@box@temp@width %
@@ -307,15 +305,11 @@
       }%
       \gre@localrightbox{%
       \ifgre@showlines %
-        \ifnum#1=\gre@pitch@a\relax %
+        \ifnum#1<\gre@pitch@belowstaff\relax %
           \gre@additionalbottomcustoslineend %
-        \else\ifnum#1=\gre@pitch@b\relax %
-          \gre@additionalbottomcustoslineend %
-        \else\ifnum#1=\gre@pitch@l\relax %
+        \else\ifnum#1>\gre@pitch@abovestaff\relax %
           \gre@additionaltopcustoslineend %
-        \else\ifnum#1=\gre@pitch@m\relax %
-          \gre@additionaltopcustoslineend %
-        \fi\fi\fi\fi %
+        \fi\fi %
       \fi %
       \raise \gre@dimen@glyphraisevalue\relax%
       \copy\gre@box@temp@width %
@@ -439,12 +433,57 @@
   \or\gre@fontchar@custostopshort %
   \or\gre@fontchar@custostoplong %
   \or\gre@fontchar@custostopshort %
-  \or\gre@fontchar@custostoplong %
-  \or\gre@fontchar@custostopshort %
-  \or\gre@fontchar@custostoplong %
-  \or\gre@fontchar@custostopshort %
+  \or %
+    \ifgre@haslinethree %
+      \gre@fontchar@custostoplong %
+    \else %
+      \gre@fontchar@custosbottomlong %
+    \fi %
+  \or %
+    \ifgre@haslinethree %
+      \gre@fontchar@custostopshort %
+    \else %
+      \gre@fontchar@custosbottomshort %
+    \fi %
+  \or %
+    \ifgre@haslinefour %
+      \gre@fontchar@custostoplong %
+    \else %
+      \gre@fontchar@custosbottomlong %
+    \fi %
+  \or %
+    \ifgre@haslinefour %
+      \gre@fontchar@custostopshort %
+    \else %
+      \ifgre@haslinethree %
+        \gre@fontchar@custosbottomshort %
+      \else %
+        \gre@fontchar@custosbottommiddle %
+      \fi %
+    \fi %
+  \or %
+    \ifgre@haslinefive %
+      \gre@fontchar@custostoplong %
+    \else %
+      \gre@fontchar@custosbottomlong %
+    \fi %
+  \or %
+    \ifgre@haslinefive %
+      \gre@fontchar@custostopshort %
+    \else %
+      \ifgre@haslinefour %
+        \gre@fontchar@custosbottomshort %
+      \else %
+        \gre@fontchar@custosbottommiddle %
+      \fi %
+    \fi %
   \or\gre@fontchar@custosbottomlong %
-  \or\gre@fontchar@custosbottomshort %
+  \or %
+    \ifgre@haslinefive %
+      \gre@fontchar@custosbottomshort %
+    \else %
+      \gre@fontchar@custosbottommiddle %
+    \fi %
   \or\gre@fontchar@custosbottomlong %
   \or\gre@fontchar@custosbottommiddle %
   \fi%
@@ -477,7 +516,7 @@
 % #4: 1 if we shift to the beginning of the last glyph, 0 otherwise
 % #5: 1 if we put an accentus above or not
 \def\GreOverCurlyBrace#1#2#3#4#5{%
-  \gre@brace@common{#1}{#2}{#3}{#4}{#5}{\gre@pitch@g}{\gre@fontchar@curlybrace}%
+  \gre@brace@common{#1}{#2}{#3}{#4}{#5}{\gre@pitch@overbraceglyph}{\gre@fontchar@curlybrace}%
 }%
 
 % #1: the width
@@ -485,7 +524,7 @@
 % #3: a horizontal shift
 % #4: 1 if we shift to the beginning of the last glyph, 0 otherwise
 \def\GreOverBrace#1#2#3#4{%
-  \gre@brace@common{#1}{#2}{#3}{#4}{0}{\gre@pitch@g}{\gre@fontchar@brace}%
+  \gre@brace@common{#1}{#2}{#3}{#4}{0}{\gre@pitch@overbraceglyph}{\gre@fontchar@brace}%
 }%
 
 % #1: the width
@@ -493,7 +532,7 @@
 % #3: a horizontal shift
 % #4: 1 if we shift to the beginning of the last glyph, 0 otherwise
 \def\GreUnderBrace#1#2#3#4{%
-  \gre@brace@common{#1}{#2}{#3}{#4}{0}{\gre@pitch@b}{\gre@fontchar@underbrace}%
+  \gre@brace@common{#1}{#2}{#3}{#4}{0}{\gre@pitch@underbrace}{\gre@fontchar@underbrace}%
 }%
 
 % #1: the width
@@ -534,7 +573,7 @@
     }%
     \hss %
     \ifnum#5=1\relax %
-      \gre@calculate@glyphraisevalue{\gre@pitch@m}{13}%
+      \gre@calculate@glyphraisevalue{\gre@pitch@overbrace}{13}%
       \advance\gre@dimen@glyphraisevalue by \gre@dimen@curlybraceaccentusshift\relax%
       \raise\gre@dimen@glyphraisevalue\hbox{%
         \gre@font@music\GreCPAccentus\relax %
@@ -940,8 +979,8 @@
     \gre@calculate@glyphraisevalue{#1}{3}%
   \or %
     % if it is not, we call it with 6 as second argument, it will give us the height of the rare signs (accentus, etc.) the first argument is m if the pitch is < k, otherwise it's n.
-    \ifnum#1<\gre@pitch@k\relax %
-      \gre@calculate@glyphraisevalue{\gre@pitch@k}{6}%
+    \ifnum#1<\gre@pitch@raresign\relax %
+      \gre@calculate@glyphraisevalue{\gre@pitch@raresign}{6}%
     \else %
       {%
         \gre@count@temp@three=#1%
@@ -964,7 +1003,7 @@
 }%
 
 \def\GreBarBrace#1{%
-  \gre@vepisemaorrare{\gre@pitch@g}{#1}{%
+  \gre@vepisemaorrare{\gre@pitch@overbraceglyph}{#1}{%
     \ifgre@drawbraces %
       \hbox{\gre@draw@brace{*}}%
     \else %
@@ -975,7 +1014,7 @@
 }%
 
 \def\GreBarVEpisema#1{%
-  \gre@vepisemaorrare{\gre@pitch@c}{#1}{\GreCPVEpisema}{1}{}%
+  \gre@vepisemaorrare{\gre@pitch@barvepisema}{#1}{\GreCPVEpisema}{1}{}%
   \relax %
 }%
 
@@ -1123,8 +1162,8 @@
       + \gre@dimen@spacebeneathtext %
       + \gre@dimen@spacelinestext %
       + \the\gre@dimen@currenttranslationheight %
-      + 4\gre@dimen@interstafflinespace %
-      + 4\gre@dimen@stafflineheight)\relax%
+      + \gre@stafflines\gre@dimen@interstafflinespace %
+      + \gre@stafflines\gre@dimen@stafflineheight)\relax%
   \or % 1
     \gre@dimen@glyphraisevalue=%
       \dimexpr(\the\gre@dimen@additionalbottomspace %
@@ -1161,9 +1200,9 @@
     \gre@calculate@glyphraisevalue{#1}{5}%
   \or %
     % the glyphraisevalue is ignored anyway... but it's just in case...
-    \gre@calculate@glyphraisevalue{\gre@pitch@l}{0}%
+    \gre@calculate@glyphraisevalue{\gre@pitch@ledger@above}{0}%
   \or %
-    \gre@calculate@glyphraisevalue{\gre@pitch@b}{0}%
+    \gre@calculate@glyphraisevalue{\gre@pitch@ledger@below}{0}%
   \or %
     \gre@calculate@glyphraisevalue{#1}{11}%
   \fi %
@@ -1253,7 +1292,7 @@
     \else % OBSOLETE
       \gre@obsolete{\protect\greadditionalstafflinesformat}{\protect\grechangestyle{additionalstafflinesformat}}% OBSOLETE
     \fi% OBSOLETE
-    \gre@hepisorline{\gre@pitch@a}{#1}{#2}{#3}{f}%
+    \gre@hepisorline{\gre@pitch@dummy}{#1}{#2}{#3}{f}%
     \endgre@style@additionalstafflines%
     \gre@dimen@glyphraisevalue=\gre@dimen@savedglyphraise\relax%
   \fi %
@@ -1320,6 +1359,10 @@
     \gre@writebar{10}{0}{#2}%
   \or %
     \gre@writebar{11}{0}{#2}%
+  \or %
+    \gre@writebar{12}{0}{#2}%
+  \or %
+    \gre@writebar{13}{0}{#2}%
   \fi %
   \relax%
 }%
@@ -1337,6 +1380,10 @@
     \gre@writebar{10}{1}{#2}%
   \or %
     \gre@writebar{11}{1}{#2}%
+  \or %
+    \gre@writebar{12}{1}{#2}%
+  \or %
+    \gre@writebar{13}{1}{#2}%
   \fi %
   \relax%
 }%
@@ -1380,7 +1427,7 @@
     \fi %
   \fi %
   \gre@newglyphcommon %
-  \gre@calculate@glyphraisevalue{\gre@pitch@g}{0}% bar glyphs are made to be at this height
+  \gre@calculate@glyphraisevalue{\gre@pitch@bar}{0}% bar glyphs are made to be at this height
   \GreNoBreak %
   \ifcase#1 % 0 : virgula
     \ifnum#2=1\relax %
@@ -1549,6 +1596,36 @@
       \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
+  \or % 12 : dominican bar 7
+    \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
+    \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
+    \ifnum#2=1\relax %
+      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@hskip\gre@skip@temp@four %
+      \GreNoBreak %
+    \fi %
+    \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominican}%
+    \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
+    #3\relax %
+    \ifnum#2=1\relax %
+      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@hskip\gre@skip@temp@four %
+    \fi %
+  \or % 13 : dominican bar 8
+    \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
+    \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
+    \ifnum#2=1\relax %
+      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@hskip\gre@skip@temp@four %
+      \GreNoBreak %
+    \fi %
+    \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
+    \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
+    #3\relax %
+    \ifnum#2=1\relax %
+      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@hskip\gre@skip@temp@four %
+    \fi %
   \fi %
   \gre@debugmsg{spacing}{Width of bar just printed: \the\wd\gre@box@temp@width}%
   \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %
@@ -1558,7 +1635,7 @@
 
 \def\gre@fontchar@divisiomaior{%
   \ifnum\gre@stafflinefactor=17\relax %
-    %\gre@calculate@glyphraisevalue{\gre@pitch@g}{0}% bar glyphs are made to be at this height
+    %\gre@calculate@glyphraisevalue{\gre@pitch@bar}{0}% bar glyphs are made to be at this height
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioMaior}%
   \else %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioMaior}%
@@ -1574,7 +1651,7 @@
 }%
 
 \def\gre@fontchar@divisiofinalis{%
-  \gre@calculate@glyphraisevalue{\gre@pitch@g}{0}% bar glyphs are made to be at this height
+  \gre@calculate@glyphraisevalue{\gre@pitch@bar}{0}% bar glyphs are made to be at this height
   \gre@fontchar@divisiomaior %
   \gre@dimen@temp@four = 12000 sp%
   \multiply\gre@dimen@temp@four by \the\gre@factor%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -175,8 +175,10 @@
 %% Here is the function to compute some more vertical spaces from the basic values
 \newdimen\gre@dimen@staffheight\relax%
 \def\gre@calculate@staffheight{%
-  \global\gre@dimen@staffheight = 4\gre@dimen@stafflineheight\relax%
-  \global\advance\gre@dimen@staffheight by 3\gre@dimen@interstafflinespace\relax%
+  \global\gre@dimen@staffheight = \dimexpr %
+    \gre@stafflines\gre@dimen@stafflineheight %
+    + \gre@stafflines\gre@dimen@interstafflinespace %
+    - \gre@dimen@interstafflinespace\relax%
   %\global\multiply{\gre@dimen@spacebeneathtext} by \gre@factor % uncomment it if you want
   % something else than 0
   \relax %
@@ -488,20 +490,47 @@
     \global\gre@isonalinetrue%
   \or\gre@count@temp@three=\number 8%
   \or\gre@count@temp@three=\number 9%
-    \global\gre@isonalinetrue%
+    \ifgre@haslinethree %
+      \global\gre@isonalinetrue%
+    \else %
+      \ifgre@ledgerline@above %
+        \global\gre@isonalinetrue%
+      \fi %
+    \fi %
   \or\gre@count@temp@three=\number 10%
   \or\gre@count@temp@three=\number 11%
-    \global\gre@isonalinetrue%
+    \ifgre@haslinefour %
+      \global\gre@isonalinetrue%
+    \else %
+      \ifgre@haslinethree %
+        \ifgre@ledgerline@above %
+          \global\gre@isonalinetrue%
+        \fi %
+      \fi %
+    \fi %
   \or\gre@count@temp@three=\number 12%
   \or\gre@count@temp@three=\number 13%
-    \ifgre@ledgerline@above %
+    \ifgre@haslinefive %
       \global\gre@isonalinetrue%
+    \else %
+      \ifgre@haslinefour %
+        \ifgre@ledgerline@above %
+          \global\gre@isonalinetrue%
+        \fi %
+      \fi %
     \fi %
   \or\gre@count@temp@three=\number 14%
-  % the following are only useful for horizontal episema and rare signs
   \or\gre@count@temp@three=\number 15%
+    \ifgre@haslinefive %
+      \ifgre@ledgerline@above %
+        \global\gre@isonalinetrue%
+      \fi %
+    \fi %
   \or\gre@count@temp@three=\number 16%
   \or\gre@count@temp@three=\number 17%
+  \or\gre@count@temp@three=\number 18%
+  \or\gre@count@temp@three=\number 19%
+  \or\gre@count@temp@three=\number 20%
   \fi%
   % if there is not line... we don't consider notes are on lines
   \ifgre@showlines\else %


### PR DESCRIPTION
Fixes #429.

I'm not sure about the DivisioMinor glyphs, so pay extra attention to them.

Of the current tests, only the gabc-gtex tests fail because of changes to the macros.  I added tests for the new feature.

Please review and merge if satisfactory.