### PR TITLE
Corrected positioning of signs under the first note of a quadratum figure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Fixed
 - The alignment of the vertical episema under a punctum inclinatum deminutus is now correct (see [#742](https://github.com/gregorio-project/gregorio/issues/742)).
 - `<eu>` and `<nlba>` may now be ended on the final divisio maior/finalis (see [#743](https://github.com/gregorio-project/gregorio/issues/743)).
+- Sign positioning on the first note of quadratum figures is now correct (see [#752](https://github.com/gregorio-project/gregorio/issues/752)).
 
 ### Changed
 - Initial handling has been simplified.  The initial style should now be specified from TeX by using the `\gresetinitiallines` command, rather than from a gabc header.  Big initials and normal initials are now governed by a single `initial` style, meant to be changed between scores as appropriate.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#632](https://github.com/gregorio-project/gregorio/issues/632)).  Deprecations for this change are listed in the Deprecation section, below.

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -413,8 +413,11 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
         }
         break;
     case T_PESQUADRATUM:
+    case T_PESQUADRATUM_LONGQUEUE:
     case T_PESQUASSUS:
+    case T_PESQUASSUS_LONGQUEUE:
     case T_PESQUILISMAQUADRATUM:
+    case T_PESQUILISMAQUADRATUM_LONGQUEUE:
         if (i == 1) {
             note->gtex_offset_case = first_note_case(note, glyph);
             h_episema = above_if_h_episema(note->next);


### PR DESCRIPTION
Fixes #752.

All current tests pass, which means the tests didn't cover the broken figure.  I added a test to cover the cases fixed by this pull request.

Please review and merge if satisfactory.