### PR TITLE
Implemented the ability to add a secondary clef.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Headers (including the arbitrary headers starting with `x-`) are now passed to TeX and may be captured in TeX by using the `\gresetheadercapture` command.  See GregorioRef for details.
 - Support for half-spaces and ad-hoc spaces.  Use `/0` in gabc for a half-space between notes.  Use `/[factor]` (substituting a positive or negative real number for the scale factor) for an ad-hoc space whose length is `interelementspace` scaled by the desired factor.  See [#736](https://github.com/gregorio-project/gregorio/issues/736).
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
+- Support for a secondary clef.  Use `@` to join two clefs together, as in `c1@c4`.  The first clef is considered the primary one and will be used when computing an automatic custos before a clef change.  See [#755](https://github.com/gregorio-project/gregorio/issues/755).
 
 ### Deprecated
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -124,15 +124,18 @@ Makes argument bold.  Accesses \LaTeX\ \verb=\textbf= (\textit{gregoriotex.sty})
   \#1 & string & Text to be typeset in bold.\\
 \end{argtable}
 
-\macroname{\textbackslash GreChangeClef}{\#1\#2\#3\#4}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreChangeClef}{\#1\#2\#3\#4\#5\#6\#7}{gregoriotex-signs.tex}
 Macro called when key changes
 
 \begin{argtable}
   \#1 & character & Type of new clef (c or f).\\
-  \#2 & integer   & Line of new clef.\\
+  \#2 & \texttt{1}--\texttt{5} & Line of new clef.\\
   \#3 & \texttt{0} & Print space before clef.\\
   & \texttt{1} & Do not print space before clef.\\
-  \#4 & integer   & Height number of flat in key (\texttt{0} for no flat).\\
+  \#4 & integer & Height number of flat in clef (\texttt{3} for no flat).\\
+  \#5 & \texttt{c} or \texttt{f} & Type of secondary clef.\\
+  \#6 & \texttt{0}--\texttt{5} & Line of secondary clef (\texttt{0} for no secondary clef).\\
+  \#7 & integer & Height of flat in secondary clef (\texttt{3} for no flat).\\
 \end{argtable}
 
 \macroname{\textbackslash GreCirculus}{\#1\#2}{gregoriotex-signs.tex}
@@ -767,24 +770,30 @@ ligatures. In this example we should call \verb=\grefixedtext{\textit{ffj}}=.
   \#1 & character & The initial letter of the score.\\
 \end{argtable}
 
-\macroname{\textbackslash GreSetInitialClef}{\#1\#2\#3}{gregoriotex-signs.tex}
-Macro for writing initial key.
+\macroname{\textbackslash GreSetInitialClef}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
+Macro for writing initial clef.
 
 \begin{argtable}
   \#1 & \texttt{c} or \texttt{f} & Type of clef.\\
-  \#2 & \texttt{1}--\texttt{4}       & Line of key.\\
-  \#3 & integer & Height number of flat in key (\texttt{0} for no flat).\\
+  \#2 & \texttt{1}--\texttt{5} & Line of clef.\\
+  \#3 & integer & Height number of flat in clef (\texttt{3} for no flat).\\
+  \#4 & \texttt{c} or \texttt{f} & Type of secondary clef.\\
+  \#5 & \texttt{0}--\texttt{5} & Line of secondary clef (\texttt{0} for no secondary clef).\\
+  \#6 & integer & Height of flat in secondary clef (\texttt{3} for no flat).\\
 \end{argtable}
 
-\macroname{\textbackslash GreSetLinesClef}{\#1\#2\#3\#4}{gregoriotex-main.tex}
+\macroname{\textbackslash GreSetLinesClef}{\#1\#2\#3\#4\#5\#6\#7}{gregoriotex-main.tex}
 Macro to define the clef that will appear at the beginning of the lines.
 
 \begin{argtable}
   \#1 & \texttt{c} or \texttt{f} & Type of clef.\\
-  \#2 & \texttt{1}--\texttt{4}       & Line of key.\\
+  \#2 & \texttt{1}--\texttt{5} & Line of clef.\\
   \#3 & \texttt{0} & No space after clef.\\
   & \texttt{1} & Space after clef.\\
-  \#4 & integer & Height of flat in key (\texttt{0} for no flat).\\
+  \#4 & integer & Height of flat in clef (\texttt{3} for no flat).\\
+  \#5 & \texttt{c} or \texttt{f} & Type of secondary clef.\\
+  \#6 & \texttt{0}--\texttt{5} & Line of secondary clef (\texttt{0} for no secondary clef).\\
+  \#7 & integer & Height of flat in secondary clef (\texttt{3} for no flat).\\
 \end{argtable}
 
 \macroname{\textbackslash GreSetNextSyllable}{\#1\#2\#3}{gregoriotex-syllable.tex}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -406,11 +406,23 @@ Macro calculating the \verb=\gre@clefnum= from the letter and number.
   \#2 & integer & line number\\
 \end{argtable}
 
-\macroname{\textbackslash gre@clefnum}{}{gregoriotex-signs.tex}
-Count holding the current clef number.
+\macroname{\textbackslash gre@clef}{}{gregoriotex-signs.tex}
+Macro holding the current clef type.
 
-\macroname{\textbackslash gre@clefflat}{}{gregoriotex-signs.tex}
-Macro to hold the height of the current flat for the clef (\texttt{a} if no flat).
+\macroname{\textbackslash gre@clefline}{}{gregoriotex-signs.tex}
+Macro holding the current clef line.
+
+\macroname{\textbackslash gre@clefflatheight}{}{gregoriotex-signs.tex}
+Macro to hold the height of the current flat for the clef (\texttt{3} if no flat).
+
+\macroname{\textbackslash gre@cleftwo}{}{gregoriotex-signs.tex}
+Macro holding the current secondary clef type.
+
+\macroname{\textbackslash gre@cleftwoline}{}{gregoriotex-signs.tex}
+Macro holding the current secondary clef line (or 0 for no secondary clef).
+
+\macroname{\textbackslash gre@cleftwoflatheight}{}{gregoriotex-signs.tex}
+Macro to hold the height of the current flat for the secondary clef (\texttt{3} if no flat).
 
 \macroname{\textbackslash gre@updatelinesclef}{}{gregoriotex-signs.tex}
 Macro redrawing a key from \verb=\gre@clefnum=, useful for vertical space changes.
@@ -643,17 +655,43 @@ The font size at which symbols are to be loaded.
 \macroname{\textbackslash gre@textnormal}{\#1}{gregoriotex-syllable.tex}
 Macro which applies the default text format.
 
-\macroname{\textbackslash gre@typekey}{\#1\#2\#3\#4\#5}{gregoriotex-signs.tex}
-Macro which typesets the key.
+\macroname{\textbackslash gre@save@clef}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
+Saves clef information for use in \verb=gre@updatelinesclef=.
 
 \begin{argtable}
-  \#1 & character & the type of the key: c or f\\
-  \#2 & integer & the line of the key (1 is the lowest)\\
-  \#3 & \texttt{0} & no need to use small key characters (inside a line)\\
-  & \texttt{1} & we must use small key characters (inside a line)\\
-  \#4 & \texttt{0} & no extra space is needed after the key\\
-  & \texttt{}1 & we must type a space after the key\\
-  \#5 & integer & if \texttt{3}, it means that we must not put a flat after the key, otherwise it’s the height of the flat\\
+  \#1 & character & the type of the clef: c or f\\
+  \#2 & integer & the line of the clef (1 is the lowest)\\
+  \#3 & integer & if \texttt{3}, it means that we must not put a flat after the clef, otherwise it’s the height of the flat\\
+  \#4 & character & the type of the secondary clef: c or f\\
+  \#5 & integer & the line of the secondary clef (1 is the lowest, 0 for no secondary clef)\\
+  \#6 & integer & if \texttt{3}, it means that we must not put a flat after the secondary clef, otherwise it’s the height of the flat\\
+\end{argtable}	
+
+\macroname{\textbackslash gre@typeclef}{\#1\#2\#3\#4\#5\#6\#7\#8}{gregoriotex-signs.tex}
+Macro which typesets the clef.
+
+\begin{argtable}
+  \#1 & character & the type of the clef: c or f\\
+  \#2 & integer & the line of the clef (1 is the lowest)\\
+  \#3 & \texttt{0} & no need to use small clef characters (inside a line)\\
+  & \texttt{1} & we must use small clef characters (inside a line)\\
+  \#4 & \texttt{0} & no extra space is needed after the clef\\
+  & \texttt{}1 & we must type a space after the clef\\
+  \#5 & integer & if \texttt{3}, it means that we must not put a flat after the clef, otherwise it’s the height of the flat\\
+  \#6 & character & the type of the secondary clef: c or f\\
+  \#7 & integer & the line of the secondary clef (1 is the lowest, 0 for no secondary clef)\\
+  \#8 & integer & if \texttt{3}, it means that we must not put a flat after the secondary clef, otherwise it’s the height of the flat\\
+\end{argtable}	
+
+\macroname{\textbackslash gre@typesingleclef}{\#1\#2\#3\#4}{gregoriotex-signs.tex}
+Macro which typesets a single clef.
+
+\begin{argtable}
+  \#1 & character & the type of the clef: c or f\\
+  \#2 & integer & the line of the clef (1 is the lowest)\\
+  \#3 & \texttt{0} & no need to use small clef characters (inside a line)\\
+  & \texttt{1} & we must use small clef characters (inside a line)\\
+  \#4 & integer & if \texttt{3}, it means that we must not put a flat after the clef, otherwise it’s the height of the flat\\
 \end{argtable}	
 
 \macroname{\textbackslash gre@updateleftbox}{}{gregoriotex-main.tex}
@@ -1362,6 +1400,12 @@ Box holding the staff lines.
 \macroname{\textbackslash gre@box@temp@sign}{}{gregoriotex-signs.tex}
 Box to hold a sign so we can measure it for placement.
 
+\macroname{\textbackslash gre@box@temp@clef}{}{gregoriotex-signs.tex}
+Box for holding (and measuring) the clef when stacking non-overlapping clefs.
+
+\macroname{\textbackslash gre@box@temp@cleftwo}{}{gregoriotex-signs.tex}
+Box for holding (and measuring) the secondary clef when stacking non-overlapping clefs.
+
 \macroname{\textbackslash gre@box@syllablenotes}{}{gregoriotex-syllable.tex}
 Box holding the notes associated with a syllable.
 
@@ -1370,6 +1414,7 @@ Box holding the text associated with a syllable.
 
 \macroname{\textbackslash gre@box@hep}{}{gregoriotex-chars.tex}
 Box holding the horizontal episema.
+
 
 
 \subsection{Distances}

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -271,23 +271,62 @@ static void end_variable_ledger(const ledger_line_type type)
     }
 }
 
-static __inline void check_clef_line(char line)
+static __inline int parse_clef_line(char line)
 {
     line -= '0';
     if (line < 0 || line > staff_lines) {
-        gregorio_messagef("check_clef_line", VERBOSITY_ERROR, 0,
+        gregorio_messagef("parse_clef_line", VERBOSITY_ERROR, 0,
                 _("invalid clef line for %u lines: %d"),
                 (unsigned int)staff_lines, (int)line);
+        return 1;
     }
+    return line;
 }
 
-static __inline void check_dominican_bar(const int bar)
+static __inline gregorio_bar parse_dominican_bar(char bar)
 {
+    bar -= '0';
     if (bar < 1 || bar > (2 * (staff_lines - 1))) {
-        gregorio_messagef("check_dominican_line", VERBOSITY_ERROR, 0,
+        gregorio_messagef("parse_dominican_line", VERBOSITY_ERROR, 0,
                 _("invalid dominican bar for %u lines: ;%d"),
-                (unsigned int)staff_lines, bar);
+                (unsigned int)staff_lines, (int)bar);
     }
+
+    switch (bar) {
+    case 1:
+        return B_DIVISIO_MINOR_D1;
+    case 2:
+        return B_DIVISIO_MINOR_D2;
+    case 3:
+        return B_DIVISIO_MINOR_D3;
+    case 4:
+        return B_DIVISIO_MINOR_D4;
+    case 5:
+        return B_DIVISIO_MINOR_D5;
+    case 6:
+        return B_DIVISIO_MINOR_D6;
+    case 7:
+        return B_DIVISIO_MINOR_D7;
+    case 8:
+        return B_DIVISIO_MINOR_D8;
+    }
+
+    gregorio_messagef("check_dominican_line", VERBOSITY_ERROR, 0,
+            _("invalid dominican bar: %d"), (int)bar);
+    return B_NO_BAR;
+}
+
+static __inline gregorio_clef letter_to_clef(char letter)
+{
+    switch (letter) {
+    case 'c':
+        return CLEF_C;
+    case 'f':
+        return CLEF_F;
+    }
+    gregorio_messagef("letter_to_clef", VERBOSITY_ERROR, 0,
+            _("invalid clef: %c"), letter);
+    return CLEF_C;
 }
 
 %}
@@ -672,27 +711,27 @@ Z   {
         gregorio_add_end_of_line_as_note(&current_note, GRE_END_OF_PAR,
                 &notes_lloc);
     }
-(c|f)[1-5] {
-        check_clef_line(gabc_notes_determination_text[1]);
-        if (gabc_notes_determination_text[0]=='c') {
-            gregorio_add_clef_change_as_note(&current_note, GRE_C_KEY_CHANGE,
-                    gabc_notes_determination_text[1], &notes_lloc);
-        } else {
-            gregorio_add_clef_change_as_note(&current_note, GRE_F_KEY_CHANGE,
-                    gabc_notes_determination_text[1], &notes_lloc);
-        }
+[cf][1-5] {
+        gregorio_add_clef_as_note(&current_note,
+                letter_to_clef(gabc_notes_determination_text[0]),
+                parse_clef_line(gabc_notes_determination_text[1]), false,
+                &notes_lloc);
     }
-(cb|fb)[1-5] {
-        check_clef_line(gabc_notes_determination_text[2]);
-        if (gabc_notes_determination_text[0]=='c') {
-            gregorio_add_clef_change_as_note(&current_note,
-                    GRE_C_KEY_CHANGE_FLATED, gabc_notes_determination_text[2],
-                    &notes_lloc);
-        } else {
-            gregorio_add_clef_change_as_note(&current_note,
-                    GRE_F_KEY_CHANGE_FLATED, gabc_notes_determination_text[2],
-                    &notes_lloc);
-        }
+[cf]b[1-5] {
+        gregorio_add_clef_as_note(&current_note,
+                letter_to_clef(gabc_notes_determination_text[0]),
+                parse_clef_line(gabc_notes_determination_text[2]), true,
+                &notes_lloc);
+    }
+@[cf][1-5] {
+        gregorio_add_secondary_clef_to_note(current_note,
+                letter_to_clef(gabc_notes_determination_text[1]),
+                parse_clef_line(gabc_notes_determination_text[2]), false);
+    }
+@[cf]b[1-5] {
+        gregorio_add_secondary_clef_to_note(current_note,
+                letter_to_clef(gabc_notes_determination_text[1]),
+                parse_clef_line(gabc_notes_determination_text[3]), true);
     }
 `   {
         add_bar_as_note(B_VIRGULA);
@@ -700,37 +739,8 @@ Z   {
 ,   {
         add_bar_as_note(B_DIVISIO_MINIMA);
     }
-[,;]1 {
-        check_dominican_bar(1);
-        add_bar_as_note(B_DIVISIO_MINOR_D1);
-    }
-[,;]2 {
-        check_dominican_bar(2);
-        add_bar_as_note(B_DIVISIO_MINOR_D2);
-    }
-[,;]3 {
-        check_dominican_bar(3);
-        add_bar_as_note(B_DIVISIO_MINOR_D3);
-    }
-[,;]4 {
-        check_dominican_bar(4);
-        add_bar_as_note(B_DIVISIO_MINOR_D4);
-    }
-[,;]5 {
-        check_dominican_bar(5);
-        add_bar_as_note(B_DIVISIO_MINOR_D5);
-    }
-[,;]6 {
-        check_dominican_bar(6);
-        add_bar_as_note(B_DIVISIO_MINOR_D6);
-    }
-[,;]7 {
-        check_dominican_bar(7);
-        add_bar_as_note(B_DIVISIO_MINOR_D7);
-    }
-[,;]8 {
-        check_dominican_bar(8);
-        add_bar_as_note(B_DIVISIO_MINOR_D8);
+[,;][1-8] {
+        add_bar_as_note(parse_dominican_bar(gabc_notes_determination_text[1]));
     }
 ;   {
         add_bar_as_note(B_DIVISIO_MINOR);

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -614,7 +614,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    gregorio_fix_initial_keys(score, DEFAULT_KEY);
+    gregorio_fix_initial_keys(score, gregorio_default_clef);
 
     switch (output_format) {
     case GABC:

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -103,14 +103,11 @@
   \gre@obsolete{\protect\grenormalclef}{\protect\gresetclef{visible}}%
 }%
 
-% a count describing the clef line and pitch : 1 for c on the first (bottom) line, 2 for c on the second line, 5 for f on the first, etc.
-\newcount\gre@clefnum%
-
 %% marcro to define the clef that will appear at the beginning of the lines
 % the first argument is the type : f or c, and the second is the height
 % the third argument is whether we must type a space after or not (0 if not, 1 if yes)
 % if the fourth argument is a, it means that we must not put a flat after the key, otherwise it's the height of the flat
-\def\GreSetLinesClef#1#2#3#4{%
+\def\GreSetLinesClef#1#2#3#4#5#6#7{%
   \gre@localleftbox{%
     \gre@skip@temp@four = \gre@dimen@additionalleftspace\relax%
     \kern\gre@skip@temp@four %
@@ -118,47 +115,83 @@
     \unkern %
     \ifgre@showclef%
       \gre@skip@temp@four = \gre@skip@afterclefnospace\relax%
-      \hbox{\gre@typekey{#1}{#2}{0}{#3}{#4}\hskip\gre@skip@temp@four}%
+      \hbox{\gre@typeclef{#1}{#2}{0}{#3}{#4}{#5}{#6}{#7}\hskip\gre@skip@temp@four}%
     \else %
       \gre@skip@temp@four = \gre@dimen@noclefspace\relax%
       \hbox{\kern\gre@skip@temp@four}%
     \fi %
   }%
-  \xdef\gre@clefflat{#4}%
+  \xdef\gre@clefflatheight{#4}%
+  \xdef\gre@cleftwoflatheight{#7}%
   \relax%
 }%
 
-%% macro calculating the \gre@clefnum from the letter and number
-% #1 is the letter, and #2 the line number, #3 is a if not flated
-% and otherwise the height of the flat
-\def\gre@calculate@clefnum#1#2#3{%
-  \global\gre@clefnum=#2\relax %
-  \ifx f#1%
-    \global\advance\gre@clefnum by 4\relax %
-  \fi %
-  \relax %
+\def\gre@save@clef#1#2#3#4#5#6{%
+  \global\let\gre@clef=#1\relax%
+  \xdef\gre@clefheight{#2}%
+  \xdef\gre@clefflatheight{#3}%
+  \global\let\gre@cleftwo=#4\relax%
+  \xdef\gre@cleftwoheight{#5}%
+  \xdef\gre@cleftwoflatheight{#6}%
 }%
 
 %% macro redrawing a key from clefnum, useful for vertical space changes
 \def\gre@updatelinesclef{%
-  \ifnum\gre@clefnum > 5\relax%
-    \gre@count@temp@three=\gre@clefnum %
-    \advance\gre@count@temp@three by -4\relax %
-    \GreSetLinesClef{f}{\gre@count@temp@three}{1}{\gre@clefflat}%
-  \else %
-    \GreSetLinesClef{c}{\gre@clefnum}{1}{\gre@clefflat}%
-  \fi %
-  \relax %
+  \GreSetLinesClef{\gre@clef}{\gre@clefheight}{1}{\gre@clefflatheight}%
+  {\gre@cleftwo}{\gre@cleftwoheight}{\gre@cleftwoflatheight}\relax %
 }%
 
-% macro that typesets the key
+\newbox\gre@box@temp@clef%
+\newbox\gre@box@temp@cleftwo%
+% macro that typesets the clef
+% arguments are :
+%% #1: the type of the clef : c or f
+%% #2: the line of the clef (1 is the lowest)
+%% #3: if we must use small clef characters (inside a line) or not 0: if not inside, 1 if inside
+%% #4: if we must type a space after or not
+%% #5: if 3, it means that we must not put a flat after the clef, otherwise it's the height of the flat
+%% #6: the type of the secondary clef : c or f
+%% #7: the line of the secondary clef (1 is the lowest)
+%% #8: if 3, it means that we must not put a flat after the secondary clef, otherwise it's the height of the flat
+\def\gre@typeclef#1#2#3#4#5#6#7#8{%
+  \setbox\gre@box@temp@width=\hbox{%
+    \ifcase#7%
+      \gre@typesingleclef{#1}{#2}{#3}{#5}%
+    \else %
+      \ifnum\numexpr (#7 - #2) * (#7 - #2) = 1 \relax %
+        \gre@typesingleclef{#1}{#2}{#3}{#5}%
+        \gre@skip@temp@two=\gre@skip@clefflatspace\relax%
+        \gre@hskip\gre@skip@temp@two %
+        \gre@typesingleclef{#6}{#7}{#3}{#8}%
+      \else %
+        \setbox\gre@box@temp@clef=\hbox{\gre@typesingleclef{#1}{#2}{#3}{#5}}%
+        \setbox\gre@box@temp@cleftwo=\hbox{\gre@typesingleclef{#6}{#7}{#3}{#8}}%
+        \ifdim\wd\gre@box@temp@clef>\wd\gre@box@temp@cleftwo%
+          \hbox to 0pt{\copy\gre@box@temp@cleftwo}\copy\gre@box@temp@clef%
+        \else %
+          \hbox to 0pt{\copy\gre@box@temp@clef}\copy\gre@box@temp@cleftwo%
+        \fi %
+      \fi %
+    \fi %
+  }%
+  \ifcase#3%
+    \global\gre@dimen@clefwidth=\wd\gre@box@temp@width %
+  \fi %
+  \copy\gre@box@temp@width %
+  \gre@skip@temp@two=\gre@skip@spaceafterlineclef\relax%
+  \ifnum#4=0\relax %
+    \gre@skip@temp@two=\gre@skip@afterclefnospace\relax%
+  \fi %
+  \gre@hskip\gre@skip@temp@two %
+}%
+
+% macro that typesets one clef
 % arguments are :
 %% #1: the type of the key : c or f
 %% #2: the line of the key (1 is the lowest)
 %% #3: if we must use small key characters (inside a line) or not 0: if not inside, 1 if inside
-%% #4: if we must type a space after or not
-%% #5: if 3, it means that we must not put a flat after the key, otherwise it's the height of the flat
-\def\gre@typekey#1#2#3#4#5{%
+%% #4: if 3, it means that we must not put a flat after the key, otherwise it's the height of the flat
+\def\gre@typesingleclef#1#2#3#4{%
   \ifcase#2 %
   \or%
     \gre@calculate@glyphraisevalue{\gre@pitch@c}{0}%
@@ -171,34 +204,24 @@
   \or%
     \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
   \fi%
-  \gre@skip@temp@two=\gre@skip@spaceafterlineclef\relax%
-  \ifnum#4=0\relax %
-    \gre@skip@temp@two=\gre@skip@afterclefnospace\relax%
-  \fi %
   \ifx c#1% we check if it is a c key
     \ifcase#3%
-      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@cclef}%\hskip\gre@skip@temp@two}
-      \setbox\gre@box@temp@width=\hbox{\gre@fontchar@cclef}%
-      \global\gre@dimen@clefwidth=\wd\gre@box@temp@width %
+      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@cclef}%
     \or%
-      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@incclef}%\hskip\gre@skip@temp@two}
+      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@incclef}%
     \fi%
   \else % we consider that it is a f key
     \ifcase#3%
-      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@fclef}%\hskip\gre@skip@temp@two}
-      \setbox\gre@box@temp@width=\hbox{\gre@fontchar@fclef}%
-      \global\gre@dimen@clefwidth=\wd\gre@box@temp@width %
+      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@fclef}%
     \or%
-      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@infclef}%\hskip\gre@skip@temp@two}
+      \raise\gre@dimen@glyphraisevalue\hbox{\gre@fontchar@infclef}%
     \fi%
   \fi%
-  \ifnum#5=3%
-    \gre@hskip\gre@skip@temp@two %
+  \ifnum#4=3%
   \else %
     \gre@skip@temp@four = \gre@skip@clefflatspace\relax%
     \gre@hskip\gre@skip@temp@four %
-    \GreFlat{#5}{1}%
-    \gre@hskip\gre@skip@temp@two %
+    \GreFlat{#4}{1}%
   \fi %
   \relax %
 }%
@@ -206,15 +229,15 @@
 % macro that writes the initial key, and sets the next keys to the same value
 % if #3 is a, it means that we must not put a flat after the key, otherwise it's the height
 % of the flat
-\def\GreSetInitialClef#1#2#3{%
-  \gre@calculate@clefnum{#1}{#2}{#3}%
+\def\GreSetInitialClef#1#2#3#4#5#6{%
+  \gre@save@clef{#1}{#2}{#3}{#4}{#5}{#6}%
   \ifgre@showclef%
-    \gre@typekey{#1}{#2}{0}{1}{#3}%
+    \gre@typeclef{#1}{#2}{0}{1}{#3}{#4}{#5}{#6}%
   \else%
     \gre@skip@temp@four = \gre@dimen@noclefspace\relax%
     \hbox{\kern\gre@skip@temp@four}%
   \fi %
-  \GreSetLinesClef{#1}{#2}{1}{#3}%
+  \GreSetLinesClef{#1}{#2}{1}{#3}{#4}{#5}{#6}%
   % if the initial is big, then we adjust the second line
   \ifnum\gre@biginitial=0\relax %
   \else %
@@ -228,12 +251,12 @@
 % #3 is 1 or 0 according to the need of a space before the clef. Useful for clefs after bars for example
 % if #4 is a, it means that we must not put a flat after the key, otherwise it's the height
 % of the flat
-\def\GreChangeClef#1#2#3#4{%
+\def\GreChangeClef#1#2#3#4#5#6#7{%
   % it makes no sense to change the clef when there is no clef...
   \gresetclef{visible}%
-  \gre@calculate@clefnum{#1}{#2}{#4}%
+  \gre@save@clef{#1}{#2}{#4}{#5}{#6}{#7}%
   \ifnum\gre@insidediscretionary=0\relax %
-    \GreSetLinesClef{#1}{#2}{1}{#4}%
+    \GreSetLinesClef{#1}{#2}{1}{#4}{#5}{#6}{#7}%
   \fi %
   \ifnum#3=1\relax %
     \gre@skip@temp@four = \gre@skip@clefchangespace\relax%
@@ -243,7 +266,7 @@
     \gre@skip@temp@four = -\gre@skip@spacearoundclefbars\relax%
     \gre@hskip\gre@skip@temp@four %
   \fi %
-  \gre@typekey{#1}{#2}{1}{0}{#4}%
+  \gre@typeclef{#1}{#2}{1}{0}{#4}{#5}{#6}{#7}%
   \gre@skip@temp@four = \gre@skip@clefchangespace\relax%
   \gre@hskip\gre@skip@temp@four %
   \relax%


### PR DESCRIPTION
Fixes #755.

While doing this, I found and fixed some bugs with flatted clefs on 5-line staves.

All the gabc-gtex tests fail because new arguments were added to old commands, so this was acceptable.  Two of the tests actually had incorrect expectations due to the 5-line staff bugs; these have also been accepted.  All other tests pass.  I added a couple of tests to exercise the new functionality from this pull request.

Please review and merge if satisfactory.