### PR TITLE
Added a 'mode-modifier' header for typesetting text after 'mode'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Support for half-spaces and ad-hoc spaces.  Use `/0` in gabc for a half-space between notes.  Use `/[factor]` (substituting a positive or negative real number for the scale factor) for an ad-hoc space whose length is `interelementspace` scaled by the desired factor.  See [#736](https://github.com/gregorio-project/gregorio/issues/736).
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
 - Support for a secondary clef.  Use `@` to join two clefs together, as in `c1@c4`.  The first clef is considered the primary one and will be used when computing an automatic custos before a clef change.  See [#755](https://github.com/gregorio-project/gregorio/issues/755).
+- `mode-modifier` gabc header for text (styled by the `modemodifier` style) to typeset after the value of `mode` when it is used.  See GregorioRef for details (for the change request, see [#756](https://github.com/gregorio-project/gregorio/issues/756)).
 
 ### Deprecated
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -643,6 +643,7 @@ Different elements of an include score have different styles applied.  These ele
   \stylename{firstsyllable} & the first syllable of the score excluding the score initial & none\\
   \stylename{firstword} & the first word of the first score excluding the score initial & none\\
   \stylename{modeline} & the rendered annotation from the \texttt{mode: ;} header in the gabc file & \parbox[t]{2.2cm}{\raggedleft\textsc{\textbf{Bold Small Capitals}}}\\
+  \stylename{modemodifier} & the rendered annotation from the \texttt{mode-modifier: ;} header in the gabc file & \parbox[t]{2.2cm}{\raggedleft\textit{\textbf{Bold Italics}}}\\
   \stylename{nabc} & ancient notation & {\color{gregoriocolor}gregoriocolor} (\LaTeX)\\
   && none (Plain \TeX)\\
 \end{tabular}

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -543,7 +543,7 @@ Macro for typesetting low choral signs.
   & \texttt{1} & Choral sign occurs before last note of podatus, porrectus, or torculus resupinus.\\
 \end{argtable}
 
-\macroname{\textbackslash GreMode}{\#1}{gregoriotex-main.tex}
+\macroname{\textbackslash GreMode}{\#1\#2}{gregoriotex-main.tex}
 If the gabc file contains a mode in the header, then this function
 places said mode as the first (top) annotation.  If the user has
 manually added a first annotation in the \TeX\ file, then this
@@ -552,6 +552,7 @@ is used, then this function does nothing.
 
 \begin{argtable}
   \#1 & \texttt{1}--\texttt{8} & The mode.  Other values are ignored.\\
+  \#2 & \TeX\ code & Arbitrary code to typeset after the mode.\\
 \end{argtable}
 
 \macroname{\textbackslash GreNatural}{\#1\#2}{gregoriotex-signs.tex}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -259,13 +259,14 @@ optional argument.
   \#1 & string & Snippet of gabc code.\\
 \end{argtable}
 
-\macroname{\textbackslash gre@writemode}{\#1}{gregoriotex-main.tex}
+\macroname{\textbackslash gre@writemode}{\#1\#2}{gregoriotex-main.tex}
 Macro that writes its argument with \verb=\greannotation=. The
 argument typically is given to this macro by \verb=\GreMode= in the
 gtex file.
 
 \begin{argtable}
-  \#1 & string & Text to place above the initial of a score.\\
+  \#1 & string & Mode text to place above the initial of a score.\\
+  \#2 & \TeX\ code & Arbitrary code to typeset after the mode text.\\
 \end{argtable}
 
 \macroname{\textbackslash gre@brace@common}{\#1\#2\#3\#4\#5\#6\#7}{gregoriotex-signs.tex}

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -40,6 +40,7 @@ language: latin;
 initial-style: 1;
 user-notes: whatever other comments you wish to make;
 mode: 6;
+mode-modifier: t.;
 annotation: IN.;
 annotation: 6;
 %%
@@ -95,6 +96,9 @@ Here is a detailed description of each header field:
   \item There is a \verb=\greannotation= defined immediatly prior to \verb=\gregorioscore=.
   \item The \texttt{annotation} header field is defined.
   \end{itemize}
+\item[mode-modifier] The mode "modifier" of the piece. This may be any
+  \TeX\ code to typeset after the mode, if the mode is typeset.  If the mode
+  is not typeset, the mode-modifier will also not be typeset.
 \item[annotation] The annotation is the text to appear above the
   initial letter. Usually this is an abbreviation of the office-part
   in the upper line, and an indication of the mode (and differentia

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -157,11 +157,14 @@ void dump_write_score(FILE *f, gregorio_score *score)
     if (score->mode) {
         fprintf(f, "   mode                      %d\n", score->mode);
     }
+    if (score->mode_modifier) {
+        fprintf(f, "   mode_modifier             %s\n", score->mode_modifier);
+    }
     if (score->staff_lines != 4) {
-        fprintf (f, "   staff_lines               %d\n", (int)score->staff_lines);
+        fprintf(f, "   staff_lines               %d\n", (int)score->staff_lines);
     }
     if (score->nabc_lines) {
-        fprintf (f, "   nabc_lines                %d\n", (int)score->nabc_lines);
+        fprintf(f, "   nabc_lines                %d\n", (int)score->nabc_lines);
     }
     if (score->user_notes) {
         fprintf(f, "   user_notes                %s\n", score->user_notes);

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -174,6 +174,9 @@ semicolon. */
 <INITIAL>mode {
         return MODE;
     }
+<INITIAL>mode-modifier {
+        return MODE_MODIFIER;
+    }
 <INITIAL>annotation {
         return ANNOTATION;
     }

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -647,7 +647,7 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
 %token GABC_COPYRIGHT SCORE_COPYRIGHT OCCASION METER COMMENTARY ARRANGER
 %token GABC_VERSION USER_NOTES DEF_MACRO ALT_BEGIN ALT_END CENTERING_SCHEME
 %token TRANSLATION_CENTER_END BNLBA ENLBA EUOUAE_B EUOUAE_E NABC_CUT NABC_LINES
-%token LANGUAGE HYPHEN EXTERNAL_HEADER STAFF_LINES END_OF_FILE
+%token LANGUAGE HYPHEN EXTERNAL_HEADER STAFF_LINES MODE_MODIFIER END_OF_FILE
 
 %%
 
@@ -788,6 +788,13 @@ mode_definition:
             score->mode=atoi($2.text);
             free($2.text);
         }
+    }
+    ;
+
+mode_modifier_definition:
+    MODE_MODIFIER attribute {
+        check_multiple("mode-modifier", score->mode_modifier);
+        gregorio_set_score_mode_modifier (score, $2.text);
     }
     ;
 
@@ -977,6 +984,7 @@ definition:
     | gabc_version_definition
     | initial_style_definition
     | mode_definition
+    | mode_modifier_definition
     | gregoriotex_font_definition
     | user_notes_definition
     | centering_scheme_definition

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -906,6 +906,7 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     if (score->mode) {
         fprintf(f, "mode: %d;\n", score->mode);
     }
+    gabc_write_str_attribute(f, "mode-modifier", score->mode_modifier);
     for (annotation_num = 0; annotation_num < MAX_ANNOTATIONS; ++annotation_num) {
         if (score->annotation[annotation_num]) {
             fprintf(f, "annotation: %s;\n",

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3601,6 +3601,7 @@ static void write_headers(FILE *const f, gregorio_score *const score)
     if (score->mode) {
         write_numeric_header(f, "mode", score->mode);
     }
+    write_header(f, "mode-modifier", score->mode_modifier);
     write_header(f, "author", score->si.author);
     write_header(f, "date", score->si.date);
     write_header(f, "manuscript", score->si.manuscript);
@@ -3718,7 +3719,8 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
         fprintf(f, "%%\n");
     }
     if (score->mode != 0) {
-        fprintf(f, "\\GreMode{%d}%%\n", score->mode);
+        fprintf(f, "\\GreMode{%d}{%s}%%\n", score->mode,
+                score->mode_modifier? score->mode_modifier : "");
     }
 
     if (score->initial_style != INITIAL_NOT_SPECIFIED) {

--- a/src/struct.c
+++ b/src/struct.c
@@ -1091,6 +1091,7 @@ gregorio_score *gregorio_new_score(void)
     new_score->commentary = NULL;
     new_score->arranger = NULL;
     new_score->language = NULL;
+    new_score->mode_modifier = NULL;
     gregorio_source_info_init(&new_score->si);
     new_score->first_voice_info = NULL;
     new_score->mode = 0;
@@ -1132,6 +1133,7 @@ static void gregorio_free_score_infos(gregorio_score *score)
     free(score->commentary);
     free(score->arranger);
     free(score->language);
+    free(score->mode_modifier);
     free(score->user_notes);
     free(score->gregoriotex_font);
     for (annotation_num = 0; annotation_num < MAX_ANNOTATIONS; ++annotation_num) {
@@ -1266,6 +1268,17 @@ void gregorio_set_score_language(gregorio_score *score, char *language)
     }
     free(score->language);
     score->language = language;
+}
+
+void gregorio_set_score_mode_modifier(gregorio_score *score, char *mode_modifier)
+{
+    if (!score) {
+        gregorio_message(_("function called with NULL argument"),
+                "gregorio_set_score_mode_modifier", VERBOSITY_WARNING, 0);
+        return;
+    }
+    free(score->mode_modifier);
+    score->mode_modifier = mode_modifier;
 }
 
 void gregorio_set_score_number_of_voices(gregorio_score *score,

--- a/src/struct.h
+++ b/src/struct.h
@@ -701,6 +701,7 @@ typedef struct gregorio_score {
     char *commentary;
     char *arranger;
     char *language;
+    char *mode_modifier;
     struct gregorio_source_info si;
     /* the mode of a song is between 1 and 8 */
     char mode;
@@ -889,6 +890,7 @@ void gregorio_set_score_meter(gregorio_score *score, char *meter);
 void gregorio_set_score_commentary(gregorio_score *score, char *commentary);
 void gregorio_set_score_arranger(gregorio_score *score, char *arranger);
 void gregorio_set_score_language(gregorio_score *score, char *language);
+void gregorio_set_score_mode_modifier(gregorio_score *score, char *mode_modifier);
 void gregorio_set_score_gabc_version(gregorio_score *score, char *gabc_version);
 void gregorio_set_score_number_of_voices(gregorio_score *score,
         int number_of_voices);

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -589,32 +589,34 @@
 %% macros for the typesetting the things above the initial
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\def\gre@writemode#1{%
-  \greannotation{\gre@style@modeline #1\endgre@style@modeline}%
+\def\gre@writemode#1#2{%
+  \greannotation{%
+    \gre@style@modeline #1\endgre@style@modeline\space\gre@style@modemodifier #2\unskip\endgre@style@modemodifier\relax %
+  }%
   \relax %
 }%
 
-\def\GreMode#1{%
+\def\GreMode#1#2{%
   \ifhbox \gre@box@annotation%
     \relax%
   \else%
     \ifcase#1%
     \or%
-      \gre@writemode{I}%
+      \gre@writemode{I}{#2}%
     \or%
-      \gre@writemode{II}%
+      \gre@writemode{II}{#2}%
     \or%
-      \gre@writemode{III}%
+      \gre@writemode{III}{#2}%
     \or%
-      \gre@writemode{IV}%
+      \gre@writemode{IV}{#2}%
     \or%
-      \gre@writemode{V}%
+      \gre@writemode{V}{#2}%
     \or%
-      \gre@writemode{VI}%
+      \gre@writemode{VI}{#2}%
     \or%
-      \gre@writemode{VII}%
+      \gre@writemode{VII}{#2}%
     \or%
-      \gre@writemode{VIII}%
+      \gre@writemode{VIII}{#2}%
     \fi%
   \fi%
   \relax%

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -187,6 +187,10 @@
   {\begingroup\begin{scshape}\begin{bfseries}}%
   {\end{bfseries}\end{scshape}\endgroup}%
   
+\newenvironment{gre@style@modemodifier}%
+  {\begingroup\begin{itshape}\begin{bfseries}}%
+  {\end{bfseries}\end{itshape}\endgroup}%
+
 \newenvironment{gre@style@nabc}%
   {\begingroup\color{red}}%
   {\endgroup}%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -233,6 +233,14 @@
 }%
 \def\endgre@style@modeline{\endgroup}%
 
+\def\gre@style@modemodifier{%
+  \begingroup%
+  \bf%
+  \it%
+  \relax%
+}%
+\def\endgre@style@modemodifier{\endgroup}%
+
 \def\gre@style@nabc{%
   \begingroup%
   \relax% we do nothing since colors are implemented in PlainTeX


### PR DESCRIPTION
Fixes #756.

All current tests pass except the gabc-gabc tests that emit `\GreMode`, which changed for this pull request.  I added some additional tests to check the new functionality.

Please review and merge if satisfactory.