### PR TITLE
Suppressed the custos immediately before EUOUAE blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The oriscus-based shapes in the greciliae font are more consistent.  The shape of a scandicus with a second ambitus of two is more consistent across all score fonts.
 - Minimal space between notes of different syllables (or words) has been reduced when the second syllable starts with an alteration.
 - The space between note and horizontal episema has been tightened for notes at the `c` or `k` height when there is no ledger line.  Due to the intricacies of measurement, the system tries to make a best guess as to the existence of the ledger line.  If the guess is wrong, you may use the `[hl:n]` and `[ll:n]` notations in gabc to override the guess.  See [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#716](https://github.com/gregorio-project/gregorio/issues/716)).
+- The custos that might appear immediately before a `<eu>` block is now suppressed by default.  This behavior is controlled by the `\greseteolcustosbeforeeuouae` command.  See GregorioRef and [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#761](https://github.com/gregorio-project/gregorio/issues/761)).
 
 ### Added
 - Support for two-, three-, and five-line staves.  Set the `staff-lines` header to `2`, `3`, or `5`.  For all values of `staff-lines`, the note below the staff remains 'c'.  The two new notes above the staff (for a five-line staff) are `n` and `p`.  See [#429](https://github.com/gregorio-project/gregorio/issues/429).
@@ -26,6 +27,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
 - Support for a secondary clef.  Use `@` to join two clefs together, as in `c1@c4`.  The first clef is considered the primary one and will be used when computing an automatic custos before a clef change.  See [#755](https://github.com/gregorio-project/gregorio/issues/755).
 - `mode-modifier` gabc header for text (styled by the `modemodifier` style) to typeset after the value of `mode` when it is used.  See GregorioRef for details (for the change request, see [#756](https://github.com/gregorio-project/gregorio/issues/756)).
+
 
 ### Deprecated
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,10 @@ Note: Using `[hl:n]` and `[ll:n]` **will not** add a ledger line if it doesn't e
 
 If you prefer the old behavior, you may switch this off by issuing `\gresetledgerlineheuristic{disable}` in your TeX document.  You may switch it back on with `\gresetledgerlineheuristic{enable}`.
 
+### Custos before EUOUAE blocks
+
+In the past, Gregorio handled the notes of an `<eu>` block like any other, which meant that a custos would appear before the `<eu>` block if it happened to start on a new line.  However, the '<eu>' block is not a continuation of the melody, but rather a reminder of the ending to use for the paired psalm tone.  As a result, a custos immediately before an EUOUAE block is now suppressed by default.  If you desire the old behaviour, use `\greseteolcustosbeforeeuouae{auto}` in your TeX document.  To once again suppress the custos, use `\greseteolcustosbeforeeuouae{suppressed}`.
+
 ## 4.0
 
 ### Font changes

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -788,6 +788,16 @@ Macro to determine whether Gregorio\TeX\ should automatically place the custos a
 
 \textbf{Nota Bene:} This command only effects the custos that appears at the end of a line.  Custos which are placed at a key change are unaffected.  Further, if custos are specified in the gabc file manually and Gregorio\TeX\ is set to place custos automatically, you will get two custos at the line breaks.
 
+\macroname{\textbackslash greseteolcustosbeforeeuouae}{\{\#1\}}{gregoriotex-main.tex}
+Macro to determine whether Gregorio\TeX\ should automatically place the custos at a line break before a EUOUAE.  Since the EUOUAE block is typically not a continuation of the melody but rather a reminder of the end of the tone that follows, this is set to \texttt{suppressed} (no custos) by default.
+
+\begin{argtable}
+  \#1 & \texttt{suppressed} & Custos will not automatically be placed at a line break before a EUOUAE block (the default)\\
+  & \texttt{auto} & Custos will behave according to \verb=greseteolcustos= at a line break before a EUOUAE block\\
+\end{argtable}
+
+\textbf{Nota Bene:} If \verb=\greseteolcustos= is set to \texttt{manual}, this setting is effectively ignored.
+
 \macroname{\textbackslash greseteolshifts}{\{\#1\}}{gregoriotex-main.tex}
 Macro to determine whether Gregorio\TeX\ should apply a small shift at the end of each line which allows lyrics to stretch under the final custos.
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -578,6 +578,9 @@ where this macro is called.
   \#1 & integer & Height number of the custos.\\
 \end{argtable}
 
+\macroname{\textbackslash GreNextSyllableBeginsEUOUAE}{}{gregoriotex-syllable.tex}
+Indicates that the syllable which follows begins a EUOUAE block.
+
 \macroname{\textbackslash GreOriscusCavum}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
 Macro to typeset an oriscus cavum (the oriscus points at a higher note).
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1329,6 +1329,9 @@ Count to indicated if the spacing between lines should be variable (\texttt{1}) 
 \macroname{\textbackslash ifgre@blockeolcustos}{}{gregoriotex-main.tex}
 Boolean which indicates whether the custos at the end of the line should be blocked.
 
+\macroname{\textbackslash ifgre@blockeolcustosbeforeeuouae}{}{gregoriotex-main.tex}
+Boolean which indicates whether the custos at the end of the line should be blocked if a EUOUE block immediately follows.
+
 \macroname{\textbackslash ifgre@breakintranslation}{}{gregoriotex-main.tex}
 Boolean which indicates if line breaks are allowed inside a translation.
 

--- a/doc/GregorioRef.lua
+++ b/doc/GregorioRef.lua
@@ -39,6 +39,18 @@ local EXCLUDE = {
   QuilismaLineTR = true,
   VirgaLineBR = true,
   SalicusOriscus = true,
+  ['Virgula.2'] = true,
+  ['Virgula.3'] = true,
+  ['Virgula.5'] = true,
+  ['DivisioMinima.2'] = true,
+  ['DivisioMinima.3'] = true,
+  ['DivisioMinima.5'] = true,
+  ['DivisioMinor.2'] = true,
+  ['DivisioMinor.3'] = true,
+  ['DivisioMinor.5'] = true,
+  ['DivisioMaior.2'] = true,
+  ['DivisioMaior.3'] = true,
+  ['DivisioMaior.5'] = true,
 }
 
 local GABC = {

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3295,6 +3295,8 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
     }
     if (!syllable->next_syllable) {
         fprintf(f, "%%\n\\GreLastOfScore %%\n");
+    } else if (syllable->next_syllable->euouae == EUOUAE_BEGINNING) {
+        fprintf(f, "%%\n\\GreNextSyllableBeginsEUOUAE %%\n");
     }
     fprintf(f, "}{%%\n");
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1309,6 +1309,17 @@
 }%
 \greseteolcustos{auto}%
 
+\newif\ifgre@blockeolcustosbeforeeuouae%
+\def\greseteolcustosbeforeeuouae#1{%
+  \IfStrEq{#1}{suppressed}%
+    {\gre@blockeolcustosbeforeeuouaetrue\relax}%
+    {\IfStrEq{#1}{auto}%
+      {\gre@blockeolcustosbeforeeuouaefalse\relax}%
+      {\gre@error{Unrecognized option for \protect\greseteolcustosbeforeeuouae}}%
+    }%
+}%
+\greseteolcustosbeforeeuouae{suppressed}%
+
 % macro to suppress the custos
 \def\greblockcustos{%
   \gre@obsolete{\protect\greblockcustos}{\protect\greseteolcustos{manual}}%
@@ -1536,6 +1547,9 @@
     \GreBeginNLBArea{0}{0}%
   \fi %
   \gre@in@euouaetrue %
+  % as soon as the EUOUAE starts, we stop blocking the EOL custos that might
+  % have been blocked on the prior syllable.
+  \gre@reseteolcustos %
 }
 
 \def\GreEndEUOUAE#1{%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -697,6 +697,12 @@
   \relax %
 }%
 
+\def\GreNextSyllableBeginsEUOUAE{%
+  \ifgre@blockeolcustosbeforeeuouae %
+    \gre@usemanualeolcustos %
+  \fi %
+}%
+
 %% @desc Macro to make a few checks and call the right macros between
 %%       \endbeforebar, \endofword, \endofsyllable
 %% @arg#1 next syllable type (#7 of \GreSyllable)


### PR DESCRIPTION
Fixes #761.

Due to the nature of the `<eu>` block, I decided it made the most sense to suppress the custos immediately before it by default, but it may still be turned back on.  Because this is a change in behavior, I added a note to UPGRADE.md.

I made some small fixes to the documentation while I was documenting the new code.

There were two existing tests which failed, but gave an appropriate result given these changes, so I accepted them.  I also added a test for this new feature as well.

Please review and merge if satisfactory.