### PR TITLE
Allowed optional ragged automatic line break immediately before EUOUAE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
 - Support for a secondary clef.  Use `@` to join two clefs together, as in `c1@c4`.  The first clef is considered the primary one and will be used when computing an automatic custos before a clef change.  See [#755](https://github.com/gregorio-project/gregorio/issues/755).
 - `mode-modifier` gabc header for text (styled by the `modemodifier` style) to typeset after the value of `mode` when it is used.  See GregorioRef for details (for the change request, see [#756](https://github.com/gregorio-project/gregorio/issues/756)).
+- Automatic line breaks before a `<eu>` block may be made ragged by using `\gresetbreakbeforeeuouae{ragged}`.  See GregorioRef for details (for the change request, see [#764](https://github.com/gregorio-project/gregorio/issues/764)).
 
 
 ### Deprecated

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -762,6 +762,14 @@ Macro to specify how the translation text should be aligned with it respective s
 \subsubsection{End of Line Behavior}
 While Gregorio\TeX\ will automatically wrap scores to fit your page, there are several ways to fine tune that line breaking behavior with the following commands.
 
+\macroname{\textbackslash gresetbreakbeforeeuouae}{\{\#1\}}{gregoriotex-main.tex}
+Macro to determine whether an automatic linebreak before a EUOUAE area is justified or not.
+
+\begin{argtable}
+  \#1 & \texttt{justified} & Automatic line breaks before EUOUAE areas should be justified (default)\\
+  & \texttt{ragged} & Automatic line breaks before EUOUAE areas should be ragged\\
+\end{argtable}
+
 \macroname{\textbackslash gresetbreakineuouae}{\{\#1\}}{gregoriotex-main.tex}
 Macro to determine whether line breaks are allowed inside a EUOUAE area (delimited by \texttt{<eu></eu>} tags in gabc).
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -104,8 +104,12 @@ Macro to typeset a vertical episema on a bar.
   \#1 & string & Type of glyph the episema is attached to.  See \nameref{EpisemaSpecial} argument for description of options.\\
 \end{argtable}
 
-\macroname{\textbackslash GreBeginEUOUAE}{}{gregoriotex-main.tex}
+\macroname{\textbackslash GreBeginEUOUAE}{\#1}{gregoriotex-main.tex}
 Macro to mark the beginning of a EUOUAE block.  Alters spacings and prohibits a line break until the end of the block.
+
+\begin{argtable}
+  \#1 & integer & The identifier of the EUOUAE block.\\
+\end{argtable}
 
 \macroname{\textbackslash GreBeginNLBArea}{\#1\#2}{gregoriotex-main.tex}
 Macro called at beginning of a no line break area.
@@ -578,8 +582,12 @@ where this macro is called.
   \#1 & integer & Height number of the custos.\\
 \end{argtable}
 
-\macroname{\textbackslash GreNextSyllableBeginsEUOUAE}{}{gregoriotex-syllable.tex}
+\macroname{\textbackslash GreNextSyllableBeginsEUOUAE}{\#1}{gregoriotex-syllable.tex}
 Indicates that the syllable which follows begins a EUOUAE block.
+
+\begin{argtable}
+  \#1 & integer & The identifier of the EUOUAE block.\\
+\end{argtable}
 
 \macroname{\textbackslash GreOriscusCavum}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
 Macro to typeset an oriscus cavum (the oriscus points at a higher note).

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1330,7 +1330,10 @@ Count to indicated if the spacing between lines should be variable (\texttt{1}) 
 Boolean which indicates whether the custos at the end of the line should be blocked.
 
 \macroname{\textbackslash ifgre@blockeolcustosbeforeeuouae}{}{gregoriotex-main.tex}
-Boolean which indicates whether the custos at the end of the line should be blocked if a EUOUE block immediately follows.
+Boolean which indicates whether the custos at the end of the line should be blocked if a EUOUAE block immediately follows.
+
+\macroname{\textbackslash ifgre@raggedbreakbeforeeuouae}{}{gregoriotex-main.tex}
+Boolean which indicates whether an automatic line break immediately before a EUOUAE block should be ragged.
 
 \macroname{\textbackslash ifgre@breakintranslation}{}{gregoriotex-main.tex}
 Boolean which indicates if line breaks are allowed inside a translation.

--- a/src/struct.h
+++ b/src/struct.h
@@ -627,10 +627,11 @@ typedef struct gregorio_syllable {
      * case of polyphonic score. In most scores (monophonic), the array
      * has only one element. */
     struct gregorio_element **elements;
+    unsigned short euouae_id;
     unsigned short src_line, src_column, src_offset;
     /* a syllable can be a GRE_SYLLABLE, a GRE_*_KEY_CHANGE or a
      * GRE_BAR. It is useful when there is only that in a syllable. */
-    char type;
+    ENUM_BITFIELD(gregorio_type) type:8;
     /* again, an additional field to put some signs or other things... */
     ENUM_BITFIELD(gregorio_sign) special_sign:8;
     /* type of translation (with center beginning or only center end) */

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1320,6 +1320,17 @@
 }%
 \greseteolcustosbeforeeuouae{suppressed}%
 
+\newif\ifgre@raggedbreakbeforeeuouae%
+\def\gresetbreakbeforeeuouae#1{%
+  \IfStrEq{#1}{ragged}%
+    {\gre@raggedbreakbeforeeuouaetrue\relax}%
+    {\IfStrEq{#1}{justified}%
+      {\gre@raggedbreakbeforeeuouaefalse\relax}%
+      {\gre@error{Unrecognized option for \protect\greseteolcustosbeforeeuouae}}%
+    }%
+}%
+\gresetbreakbeforeeuouae{justified}%
+
 % macro to suppress the custos
 \def\greblockcustos{%
   \gre@obsolete{\protect\greblockcustos}{\protect\greseteolcustos{manual}}%
@@ -1542,7 +1553,13 @@
 \newif\ifgre@in@euouae
 \gre@in@euouaefalse
 
-\def\GreBeginEUOUAE{%
+\def\GreBeginEUOUAE#1{%
+  \ifgre@raggedbreakbeforeeuouae %
+    \directlua{gregoriotex.save_pos(#1,2)}%
+    \ifcase\directlua{gregoriotex.is_ypos_different(#1)}\relax%
+      \gre@newlinecommon{1}%
+    \fi %
+  \fi %
   \ifgre@euouae@implies@nlba %
     \GreBeginNLBArea{0}{0}%
   \fi %

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -697,9 +697,13 @@
   \relax %
 }%
 
-\def\GreNextSyllableBeginsEUOUAE{%
+\def\GreNextSyllableBeginsEUOUAE#1{%
+  \GreNoBreak %
   \ifgre@blockeolcustosbeforeeuouae %
     \gre@usemanualeolcustos %
+  \fi %
+  \ifgre@raggedbreakbeforeeuouae %
+    \directlua{gregoriotex.save_pos(#1,1)}%
   \fi %
 }%
 


### PR DESCRIPTION
Also fixed bug preventing custos suppression between `(::) (Z)` and `<eu>`.
Fixes #764.

All current tests pass except for the gabc-gtex test that emits `\GreBeginEUOUAE` and `\GreNextSyllableBeginsEUOUAE` which now require an extra argument.

Please review and merge if satisfactory.