### PR TITLE
Added tunable spaces for bars with text underneath.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Support for custom length ledger lines.  See GregorioRef for details (for the change request, see [#598](https://github.com/gregorio-project/gregorio/issues/598)).
 - Support for a secondary clef.  Use `@` to join two clefs together, as in `c1@c4`.  The first clef is considered the primary one and will be used when computing an automatic custos before a clef change.  See [#755](https://github.com/gregorio-project/gregorio/issues/755).
 - `mode-modifier` gabc header for text (styled by the `modemodifier` style) to typeset after the value of `mode` when it is used.  See GregorioRef for details (for the change request, see [#756](https://github.com/gregorio-project/gregorio/issues/756)).
-
+- Tunable spaces for bars with text underneath: `spacearoundsmallbartext`, `spacearoundminortext`, `spacearoundmaiortext`, `spacearoundfinalistext`, `spacebeforefinalfinalistext`.  These are sized slightly larger than their "non-text" counterparts.  See GregorioRef and [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#766](https://github.com/gregorio-project/gregorio/issues/766)).
 
 ### Deprecated
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,6 +34,18 @@ If you prefer the old behavior, you may switch this off by issuing `\gresetledge
 
 In the past, Gregorio handled the notes of an `<eu>` block like any other, which meant that a custos would appear before the `<eu>` block if it happened to start on a new line.  However, the '<eu>' block is not a continuation of the melody, but rather a reminder of the ending to use for the paired psalm tone.  As a result, a custos immediately before an EUOUAE block is now suppressed by default.  If you desire the old behaviour, use `\greseteolcustosbeforeeuouae{auto}` in your TeX document.  To once again suppress the custos, use `\greseteolcustosbeforeeuouae{suppressed}`.
 
+### Spacing around bars (divisio) with text underneath
+
+The following spaces have been added:
+
+- `spacearoundsmallbartext` - for the space around virgula and divisio minima with text underneath
+- `spacearoundminortext` - for the space around divisio minor with text underneath
+- `spacearoundmaiortext` - for the space around divisio maior with text underneath
+- `spacearoundfinalistext` - for the space around divisio finalis with text underneath
+- `spacebeforefinalfinalistext` - for the space before a divisio finalis at the end of a score
+
+By default, these are sized one half millimeter larger than their "non-text" counterparts.  This may cause minor spacing changes in your existing scores.  Adjust them as necessary to get the look you want.
+
 ## 4.0
 
 ### Font changes

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1154,6 +1154,26 @@ Space around divisio finalis.
 A special space for finalis, for when it is the last glyph.
 \end{gdimension}
 
+\begin{gdimension}{spacearoundsmallbartext}
+Space around virgula and divisio minima with text underneath.
+\end{gdimension}
+
+\begin{gdimension}{spacearoundminortext}
+Space around divisio minor with text underneath.
+\end{gdimension}
+
+\begin{gdimension}{spacearoundmaiortext}
+Space around divisio maior with text underneath.
+\end{gdimension}
+
+\begin{gdimension}{spacearoundfinalistext}
+Space around divisio finalis with text underneath.
+\end{gdimension}
+
+\begin{gdimension}{spacebeforefinalfinalistext}
+A special space for finalis with text underneath, for when it is the last glyph.
+\end{gdimension}
+
 \begin{gdimension}{spacearoundclefbars}
 Additional space that will appear around bars that are preceded by a custos and followed by a key.
 \end{gdimension}

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -180,40 +180,50 @@ A Gregorio\TeX-specific discretionary. Currently only used to avoid clef change 
   \#3 & \TeX\ code & Third argument of resulting \verb=\discretionary=.\\
 \end{argtable}
 
-\macroname{\textbackslash GreDivisioFinalis}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreDivisioFinalis}{\#1\#2}{gregoriotex-signs.tex}
 Macro to typeset a divisio finalis.
 
 \begin{argtable}
-  \#1 & \TeX\ code & Macros which may happen before the skip but after the divisio finalis (typically \verb=\grevepisema=).\\
+  \#1 & \texttt{0} & There is no text under the bar.\\
+  & \texttt{1} & There is text under the bar.\\
+  \#2 & \TeX\ code & Macros which may happen before the skip but after the divisio finalis (typically \verb=\grevepisema=).\\
 \end{argtable}
 
-\macroname{\textbackslash GreDivisioMaior}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreDivisioMaior}{\#1\#2}{gregoriotex-signs.tex}
 Macro to typeset a divisio maior.
 
 \begin{argtable}
-  \#1 & \TeX\ code & Macros which may happen before the skip but after the divisio maior (typically \verb=\grevepisema=).\\
+  \#1 & \texttt{0} & There is no text under the bar.\\
+  & \texttt{1} & There is text under the bar.\\
+  \#2 & \TeX\ code & Macros which may happen before the skip but after the divisio maior (typically \verb=\grevepisema=).\\
 \end{argtable}
 
-\macroname{\textbackslash GreDivisioMinima}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreDivisioMinima}{\#1\#2}{gregoriotex-signs.tex}
 Macro to typeset a divisio minima.
 
 \begin{argtable}
-  \#1 & \TeX\ code & Macros which may happen before the skip but after the divisio minima (typically \verb=\grevepisema=).\\
+  \#1 & \texttt{0} & There is no text under the bar.\\
+  & \texttt{1} & There is text under the bar.\\
+  \#2 & \TeX\ code & Macros which may happen before the skip but after the divisio minima (typically \verb=\grevepisema=).\\
 \end{argtable}
 
-\macroname{\textbackslash GreDivisioMinor}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreDivisioMinor}{\#1\#2}{gregoriotex-signs.tex}
 Macro to typeset a divisio minor.
 
 \begin{argtable}
-  \#1 & \TeX\ code & Macros which may happen before the skip but after the divisio minor (typically \verb=\grevepisema=).\\
+  \#1 & \texttt{0} & There is no text under the bar.\\
+  & \texttt{1} & There is text under the bar.\\
+  \#2 & \TeX\ code & Macros which may happen before the skip but after the divisio minor (typically \verb=\grevepisema=).\\
 \end{argtable}
 
-\macroname{\textbackslash GreDominica}{\#1\#2}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreDominica}{\#1\#2\#3}{gregoriotex-signs.tex}
 Macro to typeset a dominican bar.
 
 \begin{argtable}
-  \#1 & \texttt{1}--\texttt{6} & Type of dominican bar.  Corresponds to bar types 6--11 in \verb=\grewritebar=.\\
-  \#2 & \TeX\ code    & Macros which may happen before the skip but after the divisio dominica (typically \verb=\grevepisema=).\\
+  \#1 & \texttt{1}--\texttt{6} & Type of dominican bar.  Corresponds to bar types 6--13 in \verb=\grewritebar=.\\
+  \#2 & \texttt{0} & There is no text under the bar.\\
+  & \texttt{1} & There is text under the bar.\\
+  \#3 & \TeX\ code    & Macros which may happen before the skip but after the divisio dominica (typically \verb=\grevepisema=).\\
 \end{argtable}
 
 \macroname{\textbackslash GreDrawAdditionalLine}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
@@ -479,19 +489,19 @@ Macro for typesetting high choral signs.
 \macroname{\textbackslash GreHyph}{}{gregoriotex-main.tex}
 Macro used for end of line hyphens.  Defaults to \verb=\gre@char@normalhyph=.
 
-\macroname{\textbackslash GreInDivisioFinalis}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreInDivisioFinalis}{\#1\#2}{gregoriotex-signs.tex}
 Same as \verb=\GreDivisioFinalis= except inside a syllable.
 
-\macroname{\textbackslash GreInDivisioMaior}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreInDivisioMaior}{\#1\#2}{gregoriotex-signs.tex}
 Same as \verb=\GreDivisioMaior= except inside a syllable.
 
-\macroname{\textbackslash GreInDivisioMinima}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreInDivisioMinima}{\#1\#2}{gregoriotex-signs.tex}
 Same as \verb=\GreDivisioMinima= except inside a syllable.
 
-\macroname{\textbackslash GreInDivisioMinor}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreInDivisioMinor}{\#1\#2}{gregoriotex-signs.tex}
 Same as \verb=\GreDivisioMinor= except inside a syllable.
 
-\macroname{\textbackslash GreInDominica}{\#1\#2}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreInDominica}{\#1\#2\#3}{gregoriotex-signs.tex}
 Same as \verb=\GreDominica= except inside a syllable.
 
 \macroname{\textbackslash GreInVirgula}{\#1\#2}{gregoriotex-signs.tex}
@@ -938,11 +948,13 @@ Macro for typesetting the vertical episema.
   \#2 & string  & Type of glyph the episema is attached to. See \nameref{EpisemaSpecial} argument for description of options.\\
 \end{argtable}
 
-\macroname{\textbackslash GreVirgula}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreVirgula}{\#1\#2}{gregoriotex-signs.tex}
 Macro to typeset a virgula.
 
 \begin{argtable}
-  \#1 & code & Macros which may happen before the skip but after the virgula (typically \verb=\grevepisema=).\\
+  \#1 & \texttt{0} & There is no text under the bar.\\
+  & \texttt{1} & There is text under the bar.\\
+  \#2 & code & Macros which may happen before the skip but after the virgula (typically \verb=\grevepisema=).\\
 \end{argtable}
 
 \macroname{\textbackslash GreWriteTranslation}{\#1}{gregoriotex-main.tex}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -710,7 +710,7 @@ Macro which specifies the alternate glyphs which are common to all of the styles
 \macroname{\textbackslash gre@widthof}{\#1}{gregoriotex-main.tex}
 Macro for calculating the width of its argument and storing it in \verb=\gre@dimen@temp@three=.
 
-\macroname{\textbackslash gre@writebar}{\#1\#2\#3}{gregoriotex-signs.tex}
+\macroname{\textbackslash gre@writebar}{\#1\#2\#3\#4}{gregoriotex-signs.tex}
 Macro to write a bar.
 
 \begin{argtable}
@@ -722,7 +722,9 @@ Macro to write a bar.
   & \texttt{5} & the last finalis\\
   \#2 & \texttt{0} & in a syllable containing only this bar\\
   & \texttt{1} & in a syllable containing other notes\\
-  \#3 & \TeX\ code & macros that may happen before the skip after the bar (typically GreVEpisema)\\
+  \#3 & \texttt{0} & if there is no text underneath the bar\\
+  & \texttt{1} & if there is text underneath the bar\\
+  \#4 & \TeX\ code & macros that may happen before the skip after the bar (typically GreVEpisema)\\
 \end{argtable}
 
 \macroname{\textbackslash gre@@arg}{}{gregoriotex-syllable.tex}

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1411,8 +1411,8 @@ OFFSET_CASE(BarStandard);
 OFFSET_CASE(BarVirgula);
 OFFSET_CASE(BarDivisioFinalis);
 
-static void gregoriotex_write_bar(FILE *f, gregorio_bar type,
-        gregorio_sign signs, bool is_inside_bar)
+static void write_bar(FILE *f, gregorio_bar type,
+        gregorio_sign signs, bool is_inside_bar, bool has_text)
 {
     /* the type number of function vepisemaorrare */
     const char *offset_case = BarStandard;
@@ -1464,10 +1464,11 @@ static void gregoriotex_write_bar(FILE *f, gregorio_bar type,
         fprintf(f, "Dominica{8}");
         break;
     default:
-        gregorio_messagef("gregoriotex_write_bar", VERBOSITY_ERROR, 0,
+        gregorio_messagef("write_bar", VERBOSITY_ERROR, 0,
                 _("unknown bar type: %d"), type);
         break;
     }
+    fprintf(f, "{%c}", has_text? '1' : '0');
     switch (signs) {
     case _V_EPISEMA:
         fprintf(f, "{\\GreBarVEpisema{\\GreOCase%s}}%%\n", offset_case);
@@ -3410,10 +3411,10 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
             break;
 
         case GRE_BAR:
-            gregoriotex_write_bar(f,
-                    element->u.misc.unpitched.info.bar,
+            write_bar(f, element->u.misc.unpitched.info.bar,
                     element->u.misc.unpitched.special_sign,
-                    element->next && !is_manual_custos(element->next));
+                    element->next && !is_manual_custos(element->next),
+                    !element->previous && syllable->text);
             break;
 
         case GRE_END_OF_LINE:

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1329,114 +1329,118 @@
 
 % we define two types of macro for each four bar : when it is inside a syllable, and when it is not
 
-\def\GreInVirgula#1{%
-  \gre@writebar{0}{1}{#1}%
+\def\GreInVirgula#1#2{%
+  \gre@writebar{0}{1}{#1}{#2}%
   \relax%
 }%
 
-\def\GreVirgula#1{%
-  \gre@writebar{0}{0}{#1}%
+\def\GreVirgula#1#2{%
+  \gre@writebar{0}{0}{#1}{#2}%
   \relax%
 }%
 
-\def\GreInDivisioMinima#1{%
-  \gre@writebar{1}{1}{#1}%
+\def\GreInDivisioMinima#1#2{%
+  \gre@writebar{1}{1}{#1}{#2}%
   \relax%
 }%
 
-\def\GreDivisioMinima#1{%
-  \gre@writebar{1}{0}{#1}%
+\def\GreDivisioMinima#1#2{%
+  \gre@writebar{1}{0}{#1}{#2}%
   \relax%
 }%
 
-\def\GreInDivisioMinor#1{%
-  \gre@writebar{2}{1}{#1}%
+\def\GreInDivisioMinor#1#2{%
+  \gre@writebar{2}{1}{#1}{#2}%
   \relax%
 }%
 
-\def\GreDivisioMinor#1{%
-  \gre@writebar{2}{0}{#1}%
+\def\GreDivisioMinor#1#2{%
+  \gre@writebar{2}{0}{#1}{#2}%
   \relax%
 }%
 
-\def\GreInDivisioMaior#1{%
-  \gre@writebar{3}{1}{#1}%
+\def\GreInDivisioMaior#1#2{%
+  \gre@writebar{3}{1}{#1}{#2}%
   \relax%
 }%
 
-\def\GreDivisioMaior#1{%
-  \gre@writebar{3}{0}{#1}%
+\def\GreDivisioMaior#1#2{%
+  \gre@writebar{3}{0}{#1}{#2}%
   \relax%
 }%
 
-\def\GreDominica#1#2{%
+\def\GreDominica#1#2#3{%
   \ifcase#1\or %
-    \gre@writebar{6}{0}{#2}%
+    \gre@writebar{6}{0}{#2}{#3}%
   \or %
-    \gre@writebar{7}{0}{#2}%
+    \gre@writebar{7}{0}{#2}{#3}%
   \or %
-    \gre@writebar{8}{0}{#2}%
+    \gre@writebar{8}{0}{#2}{#3}%
   \or %
-    \gre@writebar{9}{0}{#2}%
+    \gre@writebar{9}{0}{#2}{#3}%
   \or %
-    \gre@writebar{10}{0}{#2}%
+    \gre@writebar{10}{0}{#2}{#3}%
   \or %
-    \gre@writebar{11}{0}{#2}%
+    \gre@writebar{11}{0}{#2}{#3}%
   \or %
-    \gre@writebar{12}{0}{#2}%
+    \gre@writebar{12}{0}{#2}{#3}%
   \or %
-    \gre@writebar{13}{0}{#2}%
+    \gre@writebar{13}{0}{#2}{#3}%
   \fi %
   \relax%
 }%
 
-\def\GreInDominica#1#2{%
+\def\GreInDominica#1#2#3{%
   \ifcase#1\or %
-    \gre@writebar{6}{1}{#2}%
+    \gre@writebar{6}{1}{#2}{#3}%
   \or %
-    \gre@writebar{7}{1}{#2}%
+    \gre@writebar{7}{1}{#2}{#3}%
   \or %
-    \gre@writebar{8}{1}{#2}%
+    \gre@writebar{8}{1}{#2}{#3}%
   \or %
-    \gre@writebar{9}{1}{#2}%
+    \gre@writebar{9}{1}{#2}{#3}%
   \or %
-    \gre@writebar{10}{1}{#2}%
+    \gre@writebar{10}{1}{#2}{#3}%
   \or %
-    \gre@writebar{11}{1}{#2}%
+    \gre@writebar{11}{1}{#2}{#3}%
   \or %
-    \gre@writebar{12}{1}{#2}%
+    \gre@writebar{12}{1}{#2}{#3}%
   \or %
-    \gre@writebar{13}{1}{#2}%
+    \gre@writebar{13}{1}{#2}{#3}%
   \fi %
   \relax%
 }%
 
 
-\def\GreInDivisioFinalis#1{%
+\def\GreInDivisioFinalis#1#2{%
   \ifgre@endofscore %
-    \gre@writebar{5}{1}{#1}%
+    \gre@writebar{5}{1}{#1}{#2}%
   \else %
-    \gre@writebar{4}{1}{#1}%
+    \gre@writebar{4}{1}{#1}{#2}%
   \fi %
   \relax%
 }%
 
-\def\GreDivisioFinalis#1{%
+\def\GreDivisioFinalis#1#2{%
   \ifgre@endofscore %
-    \gre@writebar{5}{0}{#1}%
+    \gre@writebar{5}{0}{#1}{#2}%
   \else %
-    \gre@writebar{4}{0}{#1}%
+    \gre@writebar{4}{0}{#1}{#2}%
   \fi %
   \relax%
 }%
+
+% emits text if #1 is 0
+\def\gre@bar@text#1{\ifcase#1 \or text\fi}%
 
 %a macro to write a bar
 %% 1: the type of the bar : 0 for virgula, 1 for minima 2 for minor, 3 for major, 4 for finalis and 5 for the last finalis
 %% 2: is % for now we don't use it
 %%%%%% 0 if it is in a syllable containing only this bar
 %%%%%% 1 if it is in a syllable containing other notes
-%% 3: macros that may happen before the skip after the bar (typically GreVEpisema)
-\def\gre@writebar#1#2#3{%
+%% 3: is 0 if there's no text under the bar or 1 if there is text under the bar
+%% 4: macros that may happen before the skip after the bar (typically GreVEpisema)
+\def\gre@writebar#1#2#3#4{%
   % first, for the bar to be really centered, if the last glyph has a punctum
   % mora, we kern of the corresponding space. We do it only in the case
   % of a bar in the middle of other notes.
@@ -1454,80 +1458,80 @@
   \GreNoBreak %
   \ifcase#1 % 0 : virgula
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundsmallbar\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPVirgula}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPVirgula}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundsmallbar\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 1 : minima
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundsmallbar\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioMinima}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioMinima}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundsmallbar\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 2 : minor
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioMinor}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioMinor}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 3 : maior
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundmaior\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundmaior\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioMaior}%
     \gre@fontchar@divisiomaior %
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundmaior\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundmaior\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 4 : finalis
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundfinalis\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@divisiofinalis}%
-    #3\relax %
+    #4\relax %
     \gre@fontchar@divisiofinalis%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundfinalis\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 5 : finalis
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacebeforefinalfinalis\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacebeforefinalfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@divisiofinalis}%
-    #3\relax %
+    #4\relax %
     \gre@fontchar@divisiofinalis%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundfinalis\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 6 : dominican bar 1
@@ -1535,118 +1539,118 @@
     % we need to adjust the height of the bar a little so that it is perfectly aligned with the bottom (or the top for some bars) of the staff line, which is not the case by default if \gre@stafflinefactor is not 10.
     \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominican}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 7 : dominican bar 2
     \gre@calculate@glyphraisevalue{\gre@pitch@e}{0}%
     \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 8 : dominican bar 3
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominican}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 9 : dominican bar 4
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 10 : dominican bar 5
     \gre@calculate@glyphraisevalue{\gre@pitch@i}{0}%
     \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominican}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 11 : dominican bar 6
     \gre@calculate@glyphraisevalue{\gre@pitch@i}{0}%
     \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 12 : dominican bar 7
     \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
     \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominican}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 13 : dominican bar 8
     \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
     \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
-    #3\relax %
+    #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \gre@skip@spacearoundminor\relax%
+      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \fi %
@@ -1696,7 +1700,7 @@
   \GreNoBreak %
   \GreBarSyllable{\GreSetThisSyllable{}{}{}{}{}}{}{}{1}{}{}{0}{\GreLastOfLine}{%
     \GreNoBreak %
-    \GreDivisioFinalis{}%
+    \GreDivisioFinalis{0}{}%
     #1%
   }%
   \relax%
@@ -1708,7 +1712,7 @@
   \gre@localleftbox{}%
     \GreBarSyllable{\GreSetThisSyllable{}{}{}{}{}}{}{}{1}{}{}{0}{}{%
     \GreNoBreak %
-    \GreDivisioMaior{}%
+    \GreDivisioMaior{0}{}%
     #1%
   }%
   \relax%

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -178,6 +178,16 @@
 \grecreatedim{spacearoundfinalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 %a special space for finalis, for when it is the last glyph
 \grecreatedim{spacebeforefinalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{scalable}%
+%for virgula and divisio minima with text underneath
+\grecreatedim{spacearoundsmallbartext}{0.2323 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+%for the divisio minor with text underneath
+\grecreatedim{spacearoundminortext}{0.2323 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+%for divisio major with text underneath
+\grecreatedim{spacearoundmaiortext}{0.2323 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+%for divisio finalis with text underneath
+\grecreatedim{spacearoundfinalistext}{0.2323 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+%for finalis, for when it is the last glyph, with text underneath
+\grecreatedim{spacebeforefinalfinalistext}{0.34169 cm plus 0.07292 cm minus 0.27345 cm}{scalable}%
 % additional space that will appear around bars that are preceded by a custos and followed by a key.
 \grecreatedim{spacearoundclefbars}{0.03645 cm plus 0.00455 cm minus 0.0009 cm}{scalable}%
 % space between the text and the text of the bar


### PR DESCRIPTION
Fixes #766.

There was already a test that demonstrates the change, so I only updated the expectations for the tests that failed in the expected manner.  I think the unit test changes will probably conflict with one or more of the other recent pull requests, but I'll fix fix them once everything acceptable is merged.

I left the current spaces as is and added slightly larger spaces for bars with text underneath.  Let me know if I should tune them in some other way.

To answer the question in the issue, you can put something like `{ }(:)` to use the larger spaces around a bar without text.

Please review and merge if satisfactory.