### PR TITLE
Added support for typesetting simple slurs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `mode-modifier` gabc header for text (styled by the `modemodifier` style) to typeset after the value of `mode` when it is used.  See GregorioRef for details (for the change request, see [#756](https://github.com/gregorio-project/gregorio/issues/756)).
 - Automatic line breaks before a `<eu>` block may be made ragged by using `\gresetbreakbeforeeuouae{ragged}`.  See GregorioRef for details (for the change request, see [#764](https://github.com/gregorio-project/gregorio/issues/764)).
 - Tunable spaces for bars with text underneath: `spacearoundsmallbartext`, `spacearoundminortext`, `spacearoundmaiortext`, `spacearoundfinalistext`, `spacebeforefinalfinalistext`.  These are sized slightly larger than their "non-text" counterparts.  See GregorioRef and [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#766](https://github.com/gregorio-project/gregorio/issues/766)).
+- The ability to typeset simple slurs.  See GregorioRef for details (for the change request, see [#776](https://github.com/gregorio-project/gregorio/issues/776)).
 
 
 ### Deprecated

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1305,6 +1305,14 @@ Space around a clef change.
 Distance the initial will be raised above its default baseline.  The default baseline for the initial coincides with the baseline for the text below the staff.
 \end{gdimension}
 
+\begin{gdimension}{overslurshift}
+Distance an over-the-notes slur will be raised above the baseline of a note at the same height.
+\end{gdimension}
+
+\begin{gdimension}{underslurshift}
+Distance an under-the-notes slur will be raised above the baseline of a note at the same height.
+\end{gdimension}
+
 
 \subsection{Penalties}\label{penalties}
 Penalties are used by \TeX\ to determine where line and page breaks should occur.  Gregorio\TeX\ modifies or defines a few of its own to help with that process in scores.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -865,6 +865,21 @@ in gabc.
   \#1 & string & Text to be typeset in small caps font.\\
 \end{argtable}
 
+\macroname{\textbackslash GreSlur}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
+Typesets a slur.
+
+\begin{argtable}
+  \#1 & integer & Height number of the pitch.\\
+  \#2 & \texttt{-1} & The slur should appear under the note.\\
+      & \texttt{1} & The slur should appear over the note.\\
+  \#3 & \texttt{0} & The slur should start at the right end of the note.\\
+      & \texttt{1} & The slur should start at one punctum's width to the left of the right end of the note.\\
+      & \texttt{2} & The slur should start at one-half punctum's width to the left of the right end of the note.\\
+  \#4 & string & The horizontal dimension of the slur.\\
+  \#5 & string & The vertical dimension of the slur.\\
+  \#6 & integer & Height number of the pitch.\\
+\end{argtable}
+
 \macroname{\textbackslash GreStar}{}{gregoriotex-symbol.tex}
 Macro to typeset an asterisk (\GreStar).
 
@@ -944,6 +959,7 @@ Records positions to compute the lengths of variable-sized braces and ledger lin
   \#1 & string & unique identifier for the brace within the score.\\
   \#2 & \texttt{0} & Don't shift before recording the position.\\
   & \texttt{1} & Shift back a punctum's width before recording the position.\\
+  & \texttt{2} & Shift back one-half a punctum's width before recording the position.\\
   \#3 & \texttt{1} & Position to save is the start of brace.\\
   & \texttt{2} & Position to save is the end of brace.
 \end{argtable}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -130,7 +130,10 @@ Calculates the raise values for a glyph (glyphraisevalue and addedraisevalue) ba
   & \texttt{10} & case of the low choral sign\\
   & \texttt{11} & case of the high choral sign\\
   & \texttt{12} & case of the low choral sign which is lower than the note\\
-  & \texttt{13} & case of the brace above the bars
+  & \texttt{13} & case of the brace above the bars\\
+  & \texttt{14} & case of the punctum mora in a space with a note on the line below it\\
+  & \texttt{15} & case of the over-the-notes slur\\
+  & \texttt{16} & case of the under-the-notes slur\\
 \end{argtable}
 
 \macroname{\textbackslash gre@stafflinefactor}{}{gregoriotex-spaces.tex}
@@ -313,7 +316,7 @@ Draws a round under-brace using \MP{}.
   \#1 & length & the width of the brace.
 \end{argtable}
 
-\macroname{\textbackslash gre@draw@roundbrace}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash gre@draw@roundbrace}{\#1\#2\#3}{gregoriotex-signs.tex}
 Draws a round over- or under-brace using \MP{}.
 
 \begin{argtable}
@@ -321,6 +324,17 @@ Draws a round over- or under-brace using \MP{}.
   \#2 & number         & the height of the bounding box in em-relative units.\\
   \#3 & \MP{} commands & \MP{} commands to draw the brace outline.
 \end{argtable}
+
+\macroname{\textbackslash gre@draw@slur}{\#1\#2\#3}{gregoriotex-signs.tex}
+Draws a slur using \MP{}.
+
+\begin{argtable}
+  \#1 & length      & the x-dimension of the slur.\\
+  \#2 & length      & the y-dimension of the slur.\\
+  \#3 & \texttt{-1} & draw an under-the-notes slur.\\
+      & \texttt{1}  & draw an over-the-notes slur.\\
+\end{argtable}
+
 
 \macroname{\textbackslash gre@iflatex}{\#1}{gregoriotex.sty \textup{and} gregoriotex.tex}
 Evaluates to \verb=#1= if running under \LaTeX{}.
@@ -1568,6 +1582,9 @@ Working alias for \verb=\gre@skip@temp@one= or \verb=\gre@dimen@temp@one=, as ap
 \macroname{\textbackslash gre@skip@syllablefinalskip}{}{gregoriotex-spaces.tex}
 The final distance to skip at the end of a syllable.
 
+\macroname{\textbackslash greslurheight}{}{gregoriotex-signs.tex}
+Stores the computed height of a variable-length slur.  The control sequence name
+does not have the \texttt{@} symbol because this dimension is used within \MP{}.
 
 \subsection{Penalties}
 These are the macros that Gregorio\TeX\ uses to manipulate the penalties in order to control line and page breaks within a score without affect the surrounding text.

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -87,6 +87,7 @@ Here is a detailed description of each header field:
 \item[language] The language of the lyrics.
 \item[initial-style] The style of the initial letter. 0 means no initial letter, 1 a normal one, and 2 a large one, on two lines. Note that if you want to use the initial on two lines, you have to specify at least the two first line breaks.
 \item[user-notes] This may contain any text in addition to the other headers -- any notes the transcriber may wish. However, it is recommended to use the specific header fields where they are suitable, so that it is easier to find particular information.
+\item[oriscus-orientation] If \texttt{legacy}, the orientation of an unconnected oriscus must be set manually.
 \item[mode] The mode of the piece. This should normally be an arabic
   number between 1 and 8, but may be any text required for unusual
   cases. The mode number will be converted to roman numerals and
@@ -200,6 +201,27 @@ When using this feature with fusion, you will not be able to start or end a
 ledger line in the middle of two-note primitive shapes.  To work around this,
 either adjust the parameters of the ledger line or use manual fusion to break
 up those two notes.
+
+\subsection{Simple Slurs}
+
+To specify a simple slur, use
+\texttt{[oslur:}\textit{shift}\texttt{;}\textit{width}\texttt{,}\textit{height}\texttt{]}
+to create an over-the-notes slur with the specified \textit{width} and
+\textit{height}.  If \textit{shift} is \texttt{0}, the slur will start on the
+right side of the note to which it is atteched.  If \textit{shift} is
+\texttt{1}, the slur will start one punctum's width to the left of the right
+side of the note to which it is attached.  If \textit{shift} is \texttt{2},
+the slur will start one-half punctum's width to the left of the right side of
+the note to which it is attached.
+
+Alternately, use
+\texttt{[oslur:}\textit{shift}\texttt{\{]} to specify the start of an
+over-the-notes slur, followed by \texttt{[oslur:}\textit{shift}\texttt{\}]} at
+some point later to specify its end.  When using this form, \textit{shift} has
+the same meaning as before, but applies to both ends of the slur.
+
+Use \texttt{uslur} instead of \texttt{oslur} (with either form) to create an
+under-the-staff slur.
 
 \subsection{Lyric Centering}
 

--- a/doc/GregorioRef.lua
+++ b/doc/GregorioRef.lua
@@ -142,6 +142,7 @@ local GABC = {
   SharpHole = [[\excluded{g\#{}}]],
   Stropha = [[gs]],
   StrophaAucta = [[gs>]],
+  StrophaAuctaLongtail = [[hs>]],
   Torculus = [[gig]],
   TorculusLiquescens = [[gige]],
   TorculusLiquescensQuilisma = [[gwige]],

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -51,6 +51,9 @@ static int ledger_var[2] = { 0, 0 };
 static unsigned char staff_lines;
 static signed char highest_pitch;
 static bool legacy_oriscus_orientation;
+static int slur_var[2] = { 0, 0 };
+static char slur_shift[2] = { '\0', '\0' };
+static gregorio_note *slur_start[] = { NULL, NULL };
 
 typedef enum ledger_line_type {
     LL_OVER = 0,
@@ -330,6 +333,110 @@ static __inline gregorio_clef letter_to_clef(char letter)
     return CLEF_C;
 }
 
+static __inline void slur_assert(char *fn, bool test) {
+    if (!test) {
+        gregorio_message(_("invalid slur text"), fn, VERBOSITY_FATAL, 0);
+    }
+}
+
+static char *parse_slur_shift(char *shift)
+{
+    char *c;
+
+    c = strchr(gabc_notes_determination_text, ':');
+    slur_assert("parse_slur_shift", c != NULL);
+    slur_assert("parse_slur_shift", *(++c) != '\0');
+    *shift = *c;
+    return c;
+}
+
+static void parse_slur(int direction)
+{
+    char shift, *width, *height, *end;
+
+    if (!current_note || current_note->type != GRE_NOTE) {
+        gregorio_message(
+                _("cannot add a slur to something that is not a note"),
+                "parse_slur", VERBOSITY_ERROR, 0);
+        return;
+    }
+
+    end = parse_slur_shift(&shift);
+    width = strchr(end, ';');
+    slur_assert("parse_slur", width != NULL);
+    height = strchr(++width, ',');
+    slur_assert("parse_slur", height != NULL);
+    *height = '\0';
+    end = strchr(++height, ']');
+    slur_assert("parse_slur", end != NULL);
+    *end = '\0';
+
+    gregorio_snprintf(tempstr, sizeof tempstr,
+            "\\GreSlur{%d}{%d}{%c}{%s}{%s}{}",
+            current_note->u.note.pitch + direction, direction, shift, width,
+            height);
+    gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
+}
+
+static void start_var_slur(int index)
+{
+    if (!current_note || current_note->type != GRE_NOTE) {
+        gregorio_message(
+                _("cannot add a slur to something that is not a note"),
+                "start_var_slur", VERBOSITY_ERROR, 0);
+        return;
+    }
+
+    if (slur_var[index]) {
+        gregorio_message(
+                _("variable slur without termination of previous slur"),
+                "start_var_slur", VERBOSITY_ERROR, 0);
+        return;
+    }
+
+    slur_var[index] = ++brace_var_counter;
+    parse_slur_shift(slur_shift + index);
+    slur_start[index] = current_note;
+}
+
+static void end_var_slur(int direction, int index)
+{
+    char shift;
+
+    if (!current_note || current_note->type != GRE_NOTE) {
+        gregorio_message(
+                _("cannot add a slur to something that is not a note"),
+                "end_var_slur", VERBOSITY_ERROR, 0);
+        return;
+    }
+
+    if (!slur_var[index] || !slur_shift[index] || !slur_start[index]) {
+        gregorio_message(_("variable slur end without variable slur start"),
+                "end_var_slur", VERBOSITY_ERROR, 0);
+        return;
+    }
+
+    parse_slur_shift(&shift);
+
+    gregorio_snprintf(tempstr, sizeof tempstr,
+            "\\GreVarBraceSavePos{%d}{%c}{1}"
+            "\\GreSlur{%d}{%d}{%c}{\\GreVarBraceLength{%d}}{}{%d}",
+            slur_var[index], slur_shift[index],
+            slur_start[index]->u.note.pitch + direction, direction,
+            slur_shift[index], slur_var[index],
+            current_note->u.note.pitch + direction);
+    gregorio_add_texverb_to_note(slur_start[index], gregorio_strdup(tempstr));
+
+    gregorio_snprintf(tempstr, sizeof tempstr,
+            "\\GreVarBraceSavePos{%d}{%c}{2}", slur_var[index], shift);
+    gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
+
+
+    slur_var[index] = 0;
+    slur_shift[index] = '\0';
+    slur_start[index] = NULL;
+}
+
 %}
 
 %option stack
@@ -409,7 +516,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ub:[01]\{\] {
@@ -424,7 +531,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreUnderBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}",
                     underbrace_var, char_for_brace, underbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocb:[01]\{\] {
@@ -440,7 +547,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{0}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocba:[01]\{\] {
@@ -456,7 +563,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{1}"
                     "\\GreOverCurlyBrace{\\GreVarBraceLength{%d}}{0pt}{0pt}{%d}{1}",
                     overbrace_var, char_for_brace, overbrace_var, char_for_brace);
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ob:[01]\}\] {
@@ -475,7 +582,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ub:[01]\}\] {
@@ -489,7 +596,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{2}", underbrace_var,
                     char_for_brace);
             underbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocb:[01]\}\] {
@@ -508,7 +615,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[ocba:[01]\}\] {
@@ -527,12 +634,12 @@ static __inline gregorio_clef letter_to_clef(char letter)
                     "\\GreVarBraceSavePos{%d}{%d}{2}", overbrace_var,
                     char_for_brace);
             overbrace_var = 0;
-            gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+            gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
         }
     }
 <INITIAL>\[nm[1-9]\] {
         if (notesmacros[gabc_notes_determination_text[3]-'0']) {
-            gregorio_add_texverb_to_note(&current_note,
+            gregorio_add_texverb_to_note(current_note,
             gregorio_strdup(notesmacros[gabc_notes_determination_text[3]-'0']));
         } else error();
     }
@@ -585,25 +692,25 @@ static __inline gregorio_clef letter_to_clef(char letter)
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+        gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
     }
 <underbrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreUnderBrace{%s}{0pt}{0pt}{%d}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+        gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
     }
 <overcurlybrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{0}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+        gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
     }
 <overcurlyaccentusbrace>[^\]]+ {
         gregorio_snprintf(tempstr, sizeof tempstr,
                 "\\GreOverCurlyBrace{%s}{0pt}{0pt}{%d}{1}",
                 gabc_notes_determination_text, char_for_brace);
-        gregorio_add_texverb_to_note(&current_note, gregorio_strdup(tempstr));
+        gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
     }
 <choralsign>[^\]]+ {
         gregorio_add_cs_to_note(&current_note,
@@ -614,7 +721,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
                 gregorio_strdup(gabc_notes_determination_text), true);
     }
 <texverbnote>[^\]]+ {
-        gregorio_add_texverb_to_note(&current_note,
+        gregorio_add_texverb_to_note(current_note,
                 gregorio_strdup(gabc_notes_determination_text));
     }
 <texverbglyph>[^\]]+ {
@@ -684,6 +791,24 @@ static __inline gregorio_clef letter_to_clef(char letter)
     }
 <texverbnote,texverbglyph,texverbelement,choralsign,choralnabc,alt,overcurlyaccentusbrace,overcurlybrace,overbrace,underbrace,space,nbspace,endledger>\] {
         BEGIN(INITIAL);
+    }
+<INITIAL>\[oslur:[012];[^,]+,[^\]]+\] {
+        parse_slur(1);
+    }
+<INITIAL>\[oslur:[012]\{\] {
+        start_var_slur(0);
+    }
+<INITIAL>\[oslur:[012]\}\] {
+        end_var_slur(1, 0);
+    }
+<INITIAL>\[uslur:[012];[^,]+,[^\]]+\] {
+        parse_slur(-1);
+    }
+<INITIAL>\[uslur:[012]\{\] {
+        start_var_slur(1);
+    }
+<INITIAL>\[uslur:[012]\}\] {
+        end_var_slur(-1, 1);
     }
 \{  {
         gregorio_add_texverb_as_note(&current_note,

--- a/src/struct.c
+++ b/src/struct.c
@@ -256,24 +256,24 @@ void gregorio_end_autofuse(gregorio_note **current_note,
     element->type = GRE_AUTOFUSE_END;
 }
 
-void gregorio_add_texverb_to_note(gregorio_note **current_note, char *str)
+void gregorio_add_texverb_to_note(gregorio_note *current_note, char *str)
 {
     size_t len;
     char *res;
     if (str == NULL) {
         return;
     }
-    if (*current_note) {
-        if ((*current_note)->texverb) {
-            len = strlen((*current_note)->texverb) + strlen(str) + 1;
+    if (current_note) {
+        if (current_note->texverb) {
+            len = strlen(current_note->texverb) + strlen(str) + 1;
             res = gregorio_malloc(len);
-            strcpy(res, (*current_note)->texverb);
+            strcpy(res, current_note->texverb);
             strcat(res, str);
-            free((*current_note)->texverb);
+            free(current_note->texverb);
             free(str);
-            (*current_note)->texverb = res;
+            current_note->texverb = res;
         } else {
-            (*current_note)->texverb = str;
+            current_note->texverb = str;
         }
     }
 }

--- a/src/struct.h
+++ b/src/struct.h
@@ -867,7 +867,7 @@ void gregorio_start_autofuse(gregorio_note **current_note,
         const gregorio_scanner_location *loc);
 void gregorio_end_autofuse(gregorio_note **current_note,
         const gregorio_scanner_location *loc);
-void gregorio_add_texverb_to_note(gregorio_note **current_note, char *str);
+void gregorio_add_texverb_to_note(gregorio_note *current_note, char *str);
 void gregorio_add_cs_to_note(gregorio_note *const*current_note, char *str,
         bool nabc);
 void gregorio_add_misc_element(gregorio_element **current_element,

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -747,23 +747,91 @@
   }%
 }%
 
+% #1 : x-distance
+% #2 : y-distance
+% #3 : -1 for below, 1 for above
+\def\gre@draw@slur#1#2#3{%
+  \gre@metapost{
+    \grebracemetapostpreamble{\directlua{gregoriotex.hypotenuse([[#1]],[[#2]])}}
+    transform t;
+    t = identity scaled scale;
+    t := t xscaled width;
+    t := t rotated \directlua{gregoriotex.rotation([[#1]],[[#2]])};
+    beginfig(0);
+    fill
+      (  (0,0)
+      .. controls (0.3,#3*0.20) and (0.7,#3*0.20)
+      .. (1,0)
+      -- (1,0)
+      .. controls (0.7,#3*0.22) and (0.3,#3*0.22)
+      .. (0,0)
+      -- cycle
+      ) transformed t withpen pencircle scaled 0.3;
+    endfig;
+  }%
+}%
+
+\newdimen\greslurheight
+% #1 : height
+% #2 : -1 for below, 1 for above
+% #3 : 0 = no left-shift, 1 = left-shift 1 punctum, 2 = left shift 1/2 punctum
+% #4 : x-distance
+% #5 : y-distance
+% #6 : end height if #6 not given
+\def\GreSlur#1#2#3#4#5#6{%
+  \ifnum\number#2 > 0\relax %
+    \gre@calculate@glyphraisevalue{#1}{15}%
+  \else %
+    \gre@calculate@glyphraisevalue{#1}{16}%
+  \fi %
+  \hbox to 0pt{\raise\gre@dimen@glyphraisevalue\hbox{%
+    \ifcase#3 % 0
+    \or % 1
+      \setbox\gre@box@temp@sign=\hbox{\gre@fontchar@punctum}%
+      \kern-\wd\gre@box@temp@sign %
+    \or % 2
+      \setbox\gre@box@temp@sign=\hbox{\gre@fontchar@punctum}%
+      \kern-.5\wd\gre@box@temp@sign %
+    \fi %
+    \if\relax\detokenize{#5}\relax
+      \gre@dimen@temp@five=\gre@dimen@glyphraisevalue\relax %
+      \ifnum\number#2 > 0\relax %
+        \gre@calculate@glyphraisevalue{#6}{15}%
+      \else %
+        \gre@calculate@glyphraisevalue{#6}{16}%
+      \fi %
+      \greslurheight = \dimexpr(\gre@dimen@glyphraisevalue - \gre@dimen@temp@five)\relax %
+    \else %
+      \greslurheight = #5\relax %
+    \fi %
+    \gre@draw@slur{#4}{\the\greslurheight}{#2}%
+  }}%
+}%
+
 % #1: id of the variable length brace within the score
 \def\GreVarBraceLength#1{%
   \directlua{gregoriotex.var_brace_len(#1)}%
 }%
 
 % #1: id of the variable length brace within the score
-% #2: 1 if we shift to the beginning of the last glyph, 0 otherwise
+% #2: 0 = no left-shift, 1 = left-shift 1 punctum, 2 = left shift 1/2 punctum
 % #3: 1 if the start, 2 if the end
 \def\GreVarBraceSavePos#1#2#3{%
-  \ifnum#2=1\relax %
+  \ifcase#2 % 0
+    \gre@debugmsg{general}{save case 0}%
+    \pdfsavepos %
+  \or % 1
+    \setbox\gre@box@temp@sign=\hbox{\gre@fontchar@punctum}%
+    \kern-\wd\gre@box@temp@sign %
+    \pdfsavepos %
+    \kern\wd\gre@box@temp@sign %
+  \or % 2
+    \gre@debugmsg{general}{save case 2}%
     \setbox\gre@box@temp@sign=\hbox{\gre@fontchar@punctum}%
     \gre@dimen@temp@five=\wd\gre@box@temp@sign %
-    \kern-\gre@dimen@temp@five %
+    \kern-.5\wd\gre@box@temp@sign %
     \pdfsavepos %
-    \kern\gre@dimen@temp@five %
-  \else %
-    \pdfsavepos %
+    \kern.5\wd\gre@box@temp@sign %
   \fi %
   \directlua{gregoriotex.var_brace_note_pos(#1, #3)}%
   \relax %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -466,6 +466,8 @@
 %% 12: low choral sign below the note
 %% 13: brace above the bars
 %% 14: punctum mora in a space with a note on the line below it
+%% 15: over slur
+%% 16: under slur
 \def\gre@calculate@glyphraisevalue#1#2{%
   \global\gre@isonalinefalse%
   \ifcase#1%
@@ -635,6 +637,10 @@
     \gre@dimen@addedraisevalue=200 sp%
     \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
     \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+  \or% 15: over slur
+    \global\advance\gre@dimen@glyphraisevalue by \gre@dimen@overslurshift\relax%
+  \or% 16: under slur
+    \global\advance\gre@dimen@glyphraisevalue by \gre@dimen@underslurshift\relax%
   \fi%
   \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@constantglyphraise\relax%
 }%
@@ -1007,6 +1013,8 @@
   \IfStrEq{#1}{initialraise}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{beforealterationspace}{\gre@rubberfalse}{\relax}%
   \IfStrEq{#1}{alterationspace}{\gre@rubberfalse}{\relax}%
+  \IfStrEq{#1}{overslurshift}{\gre@rubberfalse}{\relax}%
+  \IfStrEq{#1}{underslurshift}{\gre@rubberfalse}{\relax}%
 }%
 
 %% an aux function adapting the value #1 from the factor #2 to the factor #3

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -917,6 +917,21 @@ local function width_to_bp(width, value_if_star)
   end
 end
 
+-- computes the hypotenuse given the width and height of the right triangle
+local function hypotenuse(width, height)
+  log("width %s height %s", width, height)
+  local a = tex.sp(width)
+  local b = tex.sp(height)
+  tex.sprint(math.sqrt((a * a) + (b * b)) .. 'sp')
+end
+
+-- computes the rotation angle opposite the height of a right triangle
+local function rotation(width, height)
+  local a = tex.sp(width)
+  local b = tex.sp(height)
+  tex.sprint(math.deg(math.atan2(b, a)))
+end
+
 local function scale_space(factor)
   local skip = tex.getskip('gre@skip@temp@four')
   skip.width = skip.width * factor
@@ -977,6 +992,8 @@ gregoriotex.late_brace_note_pos  = late_brace_note_pos
 gregoriotex.mark_translation     = mark_translation
 gregoriotex.mark_abovelinestext  = mark_abovelinestext
 gregoriotex.width_to_bp          = width_to_bp
+gregoriotex.hypotenuse           = hypotenuse
+gregoriotex.rotation             = rotation
 gregoriotex.scale_space          = scale_space
 gregoriotex.set_header_capture   = set_header_capture
 gregoriotex.capture_header       = capture_header

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -251,4 +251,7 @@
 \grecreatedim{braceshift}{0 cm}{scalable}%
 % a shift you can give to the accentus above the curly brace
 \grecreatedim{curlybraceaccentusshift}{-0.05 cm}{scalable}%
-
+% the amount to shift the over slur up
+\grecreatedim{overslurshift}{0.05000 cm}{scalable}%
+% the amount to shift the under slur up
+\grecreatedim{underslurshift}{0.01000 cm}{scalable}%


### PR DESCRIPTION
Fixes #776.

I created the slur with two simple bezier curves and a rotation to put the slur in place.  This probably needs some tuning, but I think it's a good foundation.

Please review and let me know what I should change, or merge it if it is satisfactory.

Note: I found some discrepancies in the documentation which I fixed incidentally as part of this pull request.

All current tests pass, but I added one to test the slurs.