### PR TITLE
fix spurious spaces and missing %

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Gregorio provides an [`.editorconfig` file](../.editorconfig), using an [editorc
 
 Python files must output no error when inspected by `pylint`.
 
-TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -n '^ [^%]\{1,\}$' tex/*.tex` returns only Lua and metapost code.
+TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -n '^ [^%]\+$' tex/*.tex tex/*.sty` returns only Lua and metapost code.
 
 ### Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Gregorio provides an [`.editorconfig` file](../.editorconfig), using an [editorc
 
 Python files must output no error when inspected by `pylint`.
 
-TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -in '^ [^%]\{1,\}$' tex/*.tex` returns only Lua and metapost code.
+TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -n '^ [^%]\{1,\}$' tex/*.tex` returns only Lua and metapost code.
 
 ### Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 You can report a bug and request a new feature on the [bug tracker](https://github.com/gregorio-project/gregorio/issues).
 
-Please search for existing issues before reporting a new one. 
+Please search for existing issues before reporting a new one.
 
 Please do not use the issue tracker for personal support requests, instead use the mailing-list (https://gna.org/mail/?group=gregorio) or IRC: #gregorio on freenode.
 
@@ -63,7 +63,7 @@ Gregorio provides an [`.editorconfig` file](../.editorconfig), using an [editorc
 
 Python files must output no error when inspected by `pylint`.
 
-TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX.
+TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -in '^ [^%]\{1,\}$' tex/*.tex` returns only Lua and metapost code.
 
 ### Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Gregorio provides an [`.editorconfig` file](../.editorconfig), using an [editorc
 
 Python files must output no error when inspected by `pylint`.
 
-TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -n '^ [^%]\+$' tex/*.tex tex/*.sty` returns only Lua and metapost code.
+TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -nE '^( |\\(|g|e|x)def)[^%]+$' tex/*.tex tex/*.sty` returns only Lua and metapost code or other lines where `%` is not needed.
 
 ### Tests
 

--- a/tex/gregoriotex-chars.tex
+++ b/tex/gregoriotex-chars.tex
@@ -42,7 +42,7 @@
     \fi%
   }%
 }%
-\def\gre@def@char@he@porr#1#2{
+\def\gre@def@char@he@porr#1#2{%
   \expandafter\def\csname gre@char@he@#1\endcsname##1##2{%
     \ifcase##1\gre@char@he@punctum{##2}%
     \or\csname GreCPHEpisema#2One\endcsname%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -633,7 +633,7 @@
   \relax %
 }%
 
-\def\GreScoreReference#1{
+\def\GreScoreReference#1{%
   \gre@obsolete{\protect\GreScoreReference}{\protect\grescorereference}%
 }%
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1176,7 +1176,7 @@
   \global\let\gre@save@englishcentering\gre@lyriccentering\relax % OBSOLETE
   \global\let\gre@opening@initialstyle\gre@initiallines\relax % DEPRECATED by 4.1
   \ifgre@justifylastline%
-    \xdef\gre@save@parfillskip{\the\parfillskip}
+    \xdef\gre@save@parfillskip{\the\parfillskip}%
     \parfillskip=0pt plus 0pt minus 0pt\relax%
   \fi %
   \ifgre@usestylefont%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -89,7 +89,7 @@
   \IfStrEq{#1}{visible}%
     {\gre@showcleftrue}%
     {\IfStrEq{#1}{invisible}%
-      {\gre@showcleffalse}
+      {\gre@showcleffalse}%
       {\gre@error{Unrecognized option for \protect\gresetclef}}%
     }%
 }%
@@ -583,7 +583,7 @@
         \else %
           \ifx#7\gre@fontchar@brace %
             \gre@draw@brace{#1}%
-          \else
+          \else %
             \ifx#7\gre@fontchar@underbrace %
               \gre@draw@underbrace{#1}%
             \fi %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -299,7 +299,7 @@
 }%
 
 % typesets a custos for the end of the score
-\def\GreFinalCustos#1{
+\def\GreFinalCustos#1{%
   \GreNoBreak%
   \gre@skip@temp@four = \gre@skip@spacebeforeeolcustos\relax%
   \advance\gre@skip@temp@four by \gre@skip@interelementspace\relax%
@@ -793,7 +793,7 @@
       \setbox\gre@box@temp@sign=\hbox{\gre@fontchar@punctum}%
       \kern-.5\wd\gre@box@temp@sign %
     \fi %
-    \if\relax\detokenize{#5}\relax
+    \if\relax\detokenize{#5}\relax %
       \gre@dimen@temp@five=\gre@dimen@glyphraisevalue\relax %
       \ifnum\number#2 > 0\relax %
         \gre@calculate@glyphraisevalue{#6}{15}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -862,7 +862,7 @@
 %% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
 \newif\ifgre@checklength%
 \def\grecreatedim#1#2#3{%
-  \gre@dimension{#1}{#2}
+  \gre@dimension{#1}{#2}%
   \csname newif\expandafter\endcsname\csname ifgre@scale@#1\endcsname%
   \IfStrEq{#3}{1}%
     {\gre@obsolete{A numerical (1) last argument for \protect\grecreatedim}{'scalable'}}%
@@ -968,7 +968,7 @@
   \input gsp-#1.tex\relax %
   \ifnum\greconffactor=0\relax%
     \gre@error{gsp-#1.tex does not have an assigned staff size.\MessageBreak Please edit it to define \protect\greconffactor}%
-  \fi
+  \fi %
   \ifnum\the\gre@factor=\greconffactor\else %If the space configuration file is designed for a \gre@factor other than the current one, then we need to rescale the distances.
     \gre@changedimenfactor{\greconffactor}{\gre@factor} %
   \fi%
@@ -1052,8 +1052,8 @@
 \newcount\gre@unitfactor%
 \newcount\gre@basefactor%
 \def\gre@convertto#1#2{%
-  \gre@debugmsg{general}{convertto (#1) (#2)}
-  \gre@debugmsg{ifdim}{ #2 = 0pt}
+  \gre@debugmsg{general}{convertto (#1) (#2)}%
+  \gre@debugmsg{ifdim}{ #2 = 0pt}%
   \ifdim#2=0pt\relax%
     \edef\gre@converted{0 #1}%
   \else%
@@ -1066,13 +1066,13 @@
     \ifnum\gre@unitfactor < 0\relax%
       \gre@unitfactor = -\gre@unitfactor%
     \fi%
-    \gre@debugmsg{spacing}{unit: \the\gre@unit ; factor: \the\gre@unitfactor}
+    \gre@debugmsg{spacing}{unit: \the\gre@unit ; factor: \the\gre@unitfactor}%
     \gre@basefactor = \number\gre@maxlen%
     \divide\gre@basefactor by \number\gre@base\relax%
     \ifnum\gre@basefactor < 0\relax%
       \gre@basefactor = -\gre@basefactor%
     \fi%
-    \gre@debugmsg{spacing}{base: \the\gre@base ; factor: \the\gre@basefactor}
+    \gre@debugmsg{spacing}{base: \the\gre@base ; factor: \the\gre@basefactor}%
     \ifnum\gre@basefactor<\gre@unitfactor%
       \multiply\gre@unit by \gre@basefactor%
       \multiply\gre@base by \gre@basefactor%
@@ -1396,5 +1396,5 @@
 %To change all the distances associated with the initial.
 %First three arguments are distances, last is whether they should scale when \gre@factor changes.
 \def\setinitialspacing#1#2#3#4{%
-  \gre@obsolete{\protect\setinitialspacing}{\protect\grechangedim{beforeinitialshift}, \protect\grechangedim{manualinitialwidth}, and \protect\grechangedim{afterinitialshift}}
+  \gre@obsolete{\protect\setinitialspacing}{\protect\grechangedim{beforeinitialshift}, \protect\grechangedim{manualinitialwidth}, and \protect\grechangedim{afterinitialshift}}%
 }%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -580,8 +580,8 @@
   \ifgre@showclef%
     \ifgre@bolshiftsenabled%
       \gre@calculate@bolshift{\gre@dimen@begindifference}%
-      % we don't want to shift right on the first syllable of the score 
-      % because the printing of the initial clef, initial, and/or the staff lines 
+      % we don't want to shift right on the first syllable of the score
+      % because the printing of the initial clef, initial, and/or the staff lines
       % will have already broken TeX's ignorance of spaces.
       \ifgre@beginningofscore%
         \gre@beginningofscorefalse%
@@ -639,7 +639,7 @@
     \ifdim\gre@skip@temp@one > \gre@dimen@maximumspacewithoutdash\relax%
       \gre@debugmsg{hyphen}{spacing requires hyphen}%
       \gre@showhyphenafterthissyllabletrue%
-    \fi
+    \fi %
     \ifgre@showhyphenafterthissyllable\relax%
       \gre@debugmsg{hyphen}{Showing the hyphen}%
       % if it's the last syllable of line, the hyphen will be \GreHyph

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -34,7 +34,7 @@
 % #3 = glyph name or code point
 \def\gredefsymbol#1#2#3{%
   \directlua{gregoriotex.init_variant_font([[#2]],false)}%
-  \directlua{gregoriotex.def_symbol([[#1]],[[#2]],[[#3]],false)}
+  \directlua{gregoriotex.def_symbol([[#1]],[[#2]],[[#3]],false)}%
 }%
 
 % Defines a symbol which takes a point size as argument
@@ -43,7 +43,7 @@
 % #3 = glyph name or code point
 \def\gredefsizedsymbol#1#2#3{%
   \directlua{gregoriotex.init_variant_font([[#2]],false)}%
-  \directlua{gregoriotex.def_symbol([[#1]],[[#2]],[[#3]],true)}
+  \directlua{gregoriotex.def_symbol([[#1]],[[#2]],[[#3]],true)}%
 }%
 
 %%%%%%%%%%%%%

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -186,7 +186,7 @@
 \newenvironment{gre@style@modeline}%
   {\begingroup\begin{scshape}\begin{bfseries}}%
   {\end{bfseries}\end{scshape}\endgroup}%
-  
+
 \newenvironment{gre@style@modemodifier}%
   {\begingroup\begin{itshape}\begin{bfseries}}%
   {\end{bfseries}\end{itshape}\endgroup}%


### PR DESCRIPTION
I've documented a tiny grep command allowing to spot missing `%` introducing spurious spaces in scores, please run it from time to time!