### PR TITLE
If macro_name is empty, \gresetheadercapture will stop capture.

### DIFF
--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -940,11 +940,12 @@ a different value be desired.
 
 \macroname{\textbackslash gresetheadercapture}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-main.tex}
 Macro to tell Gregorio\TeX{} to capture a given header by calling a specified
-macro.
+macro.  Passing an empty \#2 will cancel capture of the given header.
 
 \begin{argtable}
   \#1 & string & The name of the header\\
-  \#2 & string & The name of the macro to use (without the leading backslash)\\
+  \#2 & string & The name of the macro to use (without the leading backslash)
+                 or empty to stop capturing the given header\\
   \#3 & string & a comma-separated list of options\\
 \end{argtable}
 

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -939,16 +939,21 @@ local function scale_space(factor)
 end
 
 local function set_header_capture(header, macro_name, flags)
-  local macro = {}
-  macro.name = macro_name
-  flags:gsub("([^,]+)", function(flag)
-    if flag == "string" then macro.takes_string = true
-    elseif flag == "name" then macro.takes_header_name = true
-    else err("unknown header capture flag: %s", flag)
-    end
-  end)
-  capture_header_macro[header] = macro
-  log("capturing header %s using %s, string=%s, name=%s", header, macro.name, macro.takes_string, macro.takes_header_name)
+  if macro_name == '' then
+    capture_header_macro[header] = nil
+    log("no longer capturing header %s", header)
+  else
+    local macro = {}
+    macro.name = macro_name
+    flags:gsub("([^,]+)", function(flag)
+      if flag == "string" then macro.takes_string = true
+      elseif flag == "name" then macro.takes_header_name = true
+      else err("unknown header capture flag: %s", flag)
+      end
+    end)
+    capture_header_macro[header] = macro
+    log("capturing header %s using %s, string=%s, name=%s", header, macro.name, macro.takes_string, macro.takes_header_name)
+  end
 end
 
 local function capture_header(header, value)


### PR DESCRIPTION
Fixes #792.

All tests pass, but I adapted one to test the new feature.

Please review and merge if satisfactory.