### PR TITLE
TeXshop and TeXworks configuration scripts

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU General Public License
 # along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
-EXTRA_DIST = gprocess gabc.xml gabc.lang gabc.vim 900_gregorio.xml gregorio-scribus.lua gregorio.png gabc-syntax.plist README.md TeXShop system-setup.sh system-setup.bat config-texworks-mac.command
+EXTRA_DIST = gprocess gabc.xml gabc.lang gabc.vim 900_gregorio.xml gregorio-scribus.lua gregorio.png gabc-syntax.plist README.md TeXShop system-setup.sh system-setup.bat config-texworks.command

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU General Public License
 # along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
-EXTRA_DIST = gprocess gabc.xml gabc.lang gabc.vim 900_gregorio.xml gregorio-scribus.lua gregorio.png gabc-syntax.plist README.md TeXShop system-setup.sh system-setup.bat
+EXTRA_DIST = gprocess gabc.xml gabc.lang gabc.vim 900_gregorio.xml gregorio-scribus.lua gregorio.png gabc-syntax.plist README.md TeXShop system-setup.sh system-setup.bat config-texworks-mac.command

--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # This script is designed to automatically configure a TeXShop distribution.
+# You should be able to direct it to run by double clicking on it.
 
 #Copy the engine file from its instalation directory to the TeXShop Engines directory
 ENGINEDIR="$HOME/Library/TeXShop/Engines"

--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -3,13 +3,26 @@
 # This script is designed to automatically configure a TeXShop distribution.
 # You should be able to direct it to run by double clicking on it.
 
+#This trap combination allows the window to linger long enough for the user to
+#inspect the output, but still get closed when all is said and done.
+function quit {
+    read -n1 -r -p "Press any key to close window." key
+    osascript -e 'tell application "Terminal" to close front window' > /dev/null 2>&1 &
+}
+
+trap quit EXIT
+
+
 #Copy the engine file from its instalation directory to the TeXShop Engines directory
 ENGINEDIR="$HOME/Library/TeXShop/Engines"
 if [ ! -d "$ENGINEDIR" ]; then
-    mkdir -p "$ENGINEDIR"
+    echo "Cannot Find TeXShop configuration directory!"
+    echo "Please open and close TeXShop and try running this script again."
+    exit 1
 fi
 SOURCE="/Users/Shared/Gregorio/contrib/TeXShop/LuaLaTeX+se.engine"
 if [ -e "$SOURCE" ]; then
+    echo "Copying LuaLaTeX+se.engine into TeXShop configuration"
     cp "$SOURCE" "$ENGINEDIR"
 else
     echo "Cannot find LuaLaTeX+se.engine"
@@ -20,6 +33,7 @@ fi
 #Add 'gabc' to the list of file extensions which TeXShop knows
 TeXShopDir=`osascript -e 'POSIX path of (path to app "TeXShop")'`
 
+echo "Adding gabc to list of valid extensions in TeXShop"
 defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -array-add '<dict>
 <key>CFBundleTypeExtensions</key>
 <array>
@@ -45,9 +59,13 @@ defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -array-ad
 <string>Binary</string>
 </dict>'
 
+echo "Adding Gregorio file extensions to appropriate preference lists"
 #enable syntax coloring and the Typeset button for gabc files
 defaults write TeXShop OtherTeXExtensions -array-add "gabc"
 
 #Add gtex and gaux to the list of aux files deleted with Trash Aux Files
 defaults write TeXShop OtherTrashExtensions -array-add "gtex"
 defaults write TeXShop OtherTrashExtensions -array-add "gaux"
+
+echo "Configuration complete"
+exit 0

--- a/contrib/TeXShop/auto-configure.sh
+++ b/contrib/TeXShop/auto-configure.sh
@@ -2,6 +2,7 @@
 
 # This script is designed to automatically configure a TeXShop distribution.
 
+#Copy the engine file from its instalation directory to the TeXShop Engines directory
 ENGINEDIR="$HOME/Library/TeXShop/Engines"
 if [ ! -d "$ENGINEDIR" ]; then
     mkdir -p "$ENGINEDIR"
@@ -14,4 +15,38 @@ else
     echo "Please try running the Gregorio intaller again"
     exit 1
 fi
+
+#Add 'gabc' to the list of file extensions which TeXShop knows
+TeXShopDir=`osascript -e 'POSIX path of (path to app "TeXShop")'`
+
+defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -array-add '<dict>
+<key>CFBundleTypeExtensions</key>
+<array>
+<string>gabc</string>
+</array>
+<key>CFBundleTypeName</key>
+<string>gabc</string>
+<key>CFBundleTypeOSTypes</key>
+<array>
+<string>GABC</string>
+</array>
+<key>CFBundleTypeRole</key>
+<string>Editor</string>
+<key>LSItemContentTypes</key>
+<array>
+<string>com.unknown.gabc</string>
+</array>
+<key>LSTypeIsPackage</key>
+<false/>
+<key>NSDocumentClass</key>
+<string>TSDocument</string>
+<key>NSPersistentStoreTypeKey</key>
+<string>Binary</string>
+</dict>'
+
+#enable syntax coloring and the Typeset button for gabc files
 defaults write TeXShop OtherTeXExtensions -array-add "gabc"
+
+#Add gtex and gaux to the list of aux files deleted with Trash Aux Files
+defaults write TeXShop OtherTrashExtensions -array-add "gtex"
+defaults write TeXShop OtherTrashExtensions -array-add "gaux"

--- a/contrib/config-texworks-mac.command
+++ b/contrib/config-texworks-mac.command
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 
-# This script is designed to automatically configure a TeXworks distribution.
+# This script is designed to automatically configure a TeXworks distribution on a Mac.
+# You should be able to direct it to run by double clicking on it.
+
+
+#This trap combination allows the window to linger long enough for the user to
+#inspect the output, but still get closed when all is said and done.
+function quit {
+    read -n1 -r -p "Press any key to close window." key
+    osascript -e 'tell application "Terminal" to close front window' > /dev/null 2>&1 &
+}
+
+trap quit EXIT
 
 # Add the typesetting tool
 TOOLS="$HOME/Library/TeXworks/configuration/tools.ini"

--- a/contrib/config-texworks-mac.command
+++ b/contrib/config-texworks-mac.command
@@ -15,6 +15,11 @@ trap quit EXIT
 
 # Add the typesetting tool
 TOOLS="$HOME/Library/TeXworks/configuration/tools.ini"
+if [ ! -e "$TOOLS" ]; then
+    echo "Cannot find TeXworks configuration"
+    echo "Please open and close TeXworks and try running this script again"
+    exit 1
+fi
 oldTOOLS="$TOOLS.old"
 cp "$TOOLS" "$oldTOOLS"
 last=`grep -E "^\[[0-9]+\]$" "$TOOLS" | tail -1`

--- a/contrib/config-texworks-mac.command
+++ b/contrib/config-texworks-mac.command
@@ -20,6 +20,7 @@ if [ ! -e "$TOOLS" ]; then
     echo "Please open and close TeXworks and try running this script again"
     exit 1
 fi
+echo "Adding LuaLaTeX+se Typesetting tool"
 oldTOOLS="$TOOLS.old"
 cp "$TOOLS" "$oldTOOLS"
 last=`grep -E "^\[[0-9]+\]$" "$TOOLS" | tail -1`
@@ -40,6 +41,7 @@ CONFIG="$HOME/Library/TeXworks/configuration/texworks-config.txt"
 oldCONFIG="$CONFIG.old"
 mv "$CONFIG" "$oldCONFIG"
 cleanup=false
+echo "Adding Gregorio files to Open dialog and Trash Aux Files list"
 while read line; do
     if [[ $line == "# file-open-filter:"* ]]; then
         line=${line:2}
@@ -60,3 +62,6 @@ while read line; do
     fi
     echo "$line" >> "$CONFIG"
 done < "$oldCONFIG"
+
+echo "Configuration Complete"
+exit 0

--- a/contrib/config-texworks-mac.command
+++ b/contrib/config-texworks-mac.command
@@ -44,6 +44,9 @@ while read line; do
     if [[ $line == "# file-open-filter:"* ]]; then
         line=${line:2}
     fi
+    if [[ $line == *"Auxiliary files"* ]]; then
+        line="${line%?} *.gaux)"
+    fi
     if [[ $line == *"All files"* ]]; then
         echo "file-open-filter:	Gabc score (*.gabc)" >> "$CONFIG"
     fi

--- a/contrib/config-texworks.command
+++ b/contrib/config-texworks.command
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # This script is designed to automatically configure a TeXworks distribution.
-# You should be able to direct it to run by double clicking on it.
+# You can run it by double clicking on it on a Mac.
+# On Linux this behavior is controlled by a preference.  See http://askubuntu.com/questions/286621/how-do-i-run-executable-scripts-in-nautilus for details.
+# If prompted, you need to select "Run in Terminal" to see the output.
 
 
 #This trap combination allows the window to linger long enough for the user to
@@ -40,6 +42,8 @@ TOOLS="$ToolsDir/configuration/tools.ini"
 if [ ! -e "$TOOLS" ]; then
     echo "Cannot find TeXworks configuration"
     echo "Please open and close TeXworks and try running this script again"
+    echo "If this still does not work, then Add and Remove a dummy typesetting"
+    echo " tool from the Preferences dialog."
     exit 1
 fi
 echo "Adding LuaLaTeX+se Typesetting tool"

--- a/contrib/config-texworks.command
+++ b/contrib/config-texworks.command
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script is designed to automatically configure a TeXworks distribution on a Mac.
+# This script is designed to automatically configure a TeXworks distribution.
 # You should be able to direct it to run by double clicking on it.
 
 
@@ -8,13 +8,35 @@
 #inspect the output, but still get closed when all is said and done.
 function quit {
     read -n1 -r -p "Press any key to close window." key
-    osascript -e 'tell application "Terminal" to close front window' > /dev/null 2>&1 &
+    if $mac; then
+        osascript -e 'tell application "Terminal" to close front window' > /dev/null 2>&1 &
+    else
+        exit
+    fi
 }
 
 trap quit EXIT
 
+case "$(uname -s)" in
+    Darwin)
+        echo 'Mac OS X detected'
+        mac=true
+        ToolsDir="$HOME/Library/TeXworks"
+        ;;
+    Linux)
+        echo 'Linux detected'
+        mac=false
+        ToolsDir="$HOME/.TeXworks"
+        ;;
+    *)
+        echo 'Unsupported OS detected'
+        echo "Please configure TeXworks manually"
+        exit 1
+        ;;
+esac
+
 # Add the typesetting tool
-TOOLS="$HOME/Library/TeXworks/configuration/tools.ini"
+TOOLS="$ToolsDir/configuration/tools.ini"
 if [ ! -e "$TOOLS" ]; then
     echo "Cannot find TeXworks configuration"
     echo "Please open and close TeXworks and try running this script again"
@@ -37,7 +59,7 @@ echo "arguments=--shell-escape, \$synctexoption, \$fullname" >> "$TOOLS"
 echo "showPdf=true" >> "$TOOLS"
 
 # Add the file filter and cleanup patterns to the configuration
-CONFIG="$HOME/Library/TeXworks/configuration/texworks-config.txt"
+CONFIG="$ToolsDir/configuration/texworks-config.txt"
 oldCONFIG="$CONFIG.old"
 mv "$CONFIG" "$oldCONFIG"
 cleanup=false

--- a/macosx/postflight.sh
+++ b/macosx/postflight.sh
@@ -29,8 +29,10 @@ writelog 6 "Running mktexlsr"
 
 # Change permisions on the installed supplemental files
 cd /Users/Shared/Gregorio
-writelog 6 "Setting Permissions for examples and doc"
+writelog 6 "Setting Permissions for examples, doc, and configuration scripts"
 chmod -R 777 examples/
 chmod -R 777 doc/
+chmod +x contrib/TeXShop/auto-configure.command
+chmod +x contrib/config-texworks-mac.command
 
 writelog 6 "Installation Complete"


### PR DESCRIPTION
I originally wrote these scripts to speed up installation testing on my VMs.  This PR robustifies them to make the more portable to other people's systems (including allowing the TeXworks one to work on Linux).

I've also endeavored to make them as user friendly as possible: the `.command` extension makes them double-click executable on Mac so that the user need not be familiar with Terminal.  This sort of behavior is preference controlled on Ubuntu, so with the right preference settings, the TeXworks configuration script also can be double-click run there.

TeXworks for Windows is not configured by the TeXworks configuration script because Bash doesn't run on Windows.  Suggestions on how to deal with this are welcome.