### PR TITLE
Corrected spacing and ledger lines for alterations outside the staff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `<eu>` and `<nlba>` may now be ended on the final divisio maior/finalis (see [#743](https://github.com/gregorio-project/gregorio/issues/743)).
 - Sign positioning on the first note of quadratum figures is now correct (see [#752](https://github.com/gregorio-project/gregorio/issues/752)).
 - Interlinear spacing of annotations when font size was smaller than normal.  You should now see just the spacing specified by `annotationseparation`.
+- Spacing is now correct and ledger lines are now typeset for flats, sharps, and naturals above and below the staff (see [#790](https://github.com/gregorio-project/gregorio/issues/790)).
 
 ### Changed
 - Initial handling has been simplified.  The initial style should now be specified from TeX by using the `\gresetinitiallines` command, rather than from a gabc header.  Big initials and normal initials are now governed by a single `initial` style, meant to be changed between scores as appropriate.  See [UPGRADE.md](UPGRADE.md) and GregorioRef for details (for the change request, see [#632](https://github.com/gregorio-project/gregorio/issues/632)).  Deprecations for this change are listed in the Deprecation section, below.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -373,13 +373,16 @@ many syllables are in the word.
   \#1 & string & Text from the first word.
 \end{argtable}
 
-\macroname{\textbackslash GreFlat}{\#1\#2}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreFlat}{\#1\#2\#3\#4\#5}{gregoriotex-signs.tex}
 Macro to typeset a flat.
 
 \begin{argtable}
   \#1 & integer & Height number of the flat.\\
   \#2 & \texttt{0} & No flat for a key change.\\
   & \texttt{1} & Indicates the flat for a key change.\\
+  \#3 & \TeX\ code & signs to typeset before the glyph (typically additional bars, as they must be "behind" the glyph)\\
+  \#4 & \TeX\ code & signs to typeset after the glyph (almost all signs)\\
+  \#5 & string & the line, byte offset, and column address for textedit links when point-and-click is enabled\\
 \end{argtable}
 
 \macroname{\textbackslash GreForceHyphen}{}{gregoriotex-syllable.tex}
@@ -576,13 +579,16 @@ is used, then this function does nothing.
   \#3 & \TeX\ code & Arbitrary code to typeset, in the \texttt{modedifferentia} style, after \#2.\\
 \end{argtable}
 
-\macroname{\textbackslash GreNatural}{\#1\#2}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreNatural}{\#1\#2\#3\#4\#5}{gregoriotex-signs.tex}
 Macro to typeset a natural.
 
 \begin{argtable}
   \#1 & integer & Height number of the natural.\\
   \#2 & \texttt{0} & No flat for a key change.\\
   & \texttt{1} & Indicates the flat for a key change.\\
+  \#3 & \TeX\ code & signs to typeset before the glyph (typically additional bars, as they must be "behind" the glyph)\\
+  \#4 & \TeX\ code & signs to typeset after the glyph (almost all signs)\\
+  \#5 & string & the line, byte offset, and column address for textedit links when point-and-click is enabled\\
 \end{argtable}
 
 \macroname{\textbackslash GreNewLine}{}{gregoriotex-main.tex}
@@ -854,13 +860,16 @@ Macro to set the text of the current syllable.
   \#3 & string & the end letters, they don't count for alignment\\
 \end{argtable}
 
-\macroname{\textbackslash GreSharp}{\#1\#2}{gregoriotex-signs.tex}
+\macroname{\textbackslash GreSharp}{\#1\#2\#3\#4\#5}{gregoriotex-signs.tex}
 Macro to typeset a sharp.
 
 \begin{argtable}
   \#1 & integer & Height number of the sharp.\\
   \#2 & \texttt{0} & No flat for a key change.\\
   & \texttt{1} & Indicates the flat for a key change.\\
+  \#3 & \TeX\ code & signs to typeset before the glyph (typically additional bars, as they must be "behind" the glyph)\\
+  \#4 & \TeX\ code & signs to typeset after the glyph (almost all signs)\\
+  \#5 & string & the line, byte offset, and column address for textedit links when point-and-click is enabled\\
 \end{argtable}
 
 \macroname{\textbackslash GreSmallCaps}{\#1}{gregoriotex.sty and gregoriotex.tex}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -405,7 +405,7 @@ Macro to increase the space above the lines to account for above lines text.
 \macroname{\textbackslash gre@removespaceabove}{}{gregoriotex-main.tex}
 Macro to decrease the space above the lines as there is no longer any above lines text.
 
-\macroname{\textbackslash gre@alteration}{\#1\#2\#3\#4}{gregoriotex-signs.tex}
+\macroname{\textbackslash gre@alteration}{\#1\#2\#3\#4\#5\#6\#7}{gregoriotex-signs.tex}
 Macro to typeset an alteration.
 
 \begin{argtable}
@@ -414,6 +414,9 @@ Macro to typeset an alteration.
   \#3 & character alias & the hole of the alteration\\
   \#4 & \texttt{1} & the alteration is a flat for a key change\\
   & \texttt{0} & all other cases\\
+  \#5 & \TeX\ code & signs to typeset before the glyph (typically additional bars, as they must be "behind" the glyph)\\
+  \#6 & \TeX\ code & signs to typeset after the glyph (almost all signs)\\
+  \#7 & string & the line, byte offset, and column address for textedit links when point-and-click is enabled\\
 \end{argtable}
 
 \macroname{\textbackslash gre@calculate@clefnum}{\#1\#2}{gregoriotex-signs.tex}

--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -587,6 +587,9 @@ HEPISEMA_GLYPHS = {
     'HEpisemaPunctumLineBLBR': 'PunctumLineBLBR',
     'HEpisemaPunctumAuctusLineBL': 'PunctumAuctusLineBL',
     'HEpisemaSalicusOriscus': 'SalicusOriscus',
+    'HEpisemaFlat': 'Flat',
+    'HEpisemaSharp': 'Sharp',
+    'HEpisemaNatural': 'Natural',
 }
 
 def hepisema():

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -341,14 +341,6 @@ void dump_write_score(FILE *f, gregorio_score *score)
                         }
                         break;
 
-                    case GRE_FLAT:
-                    case GRE_NATURAL:
-                    case GRE_SHARP:
-                        fprintf(f, "       pitch                 %s\n",
-                                dump_pitch(glyph->u.misc.pitched.pitch,
-                                    score->highest_pitch));
-                        break;
-
                     case GRE_GLYPH:
                         fprintf(f, "       glyph_type            %d (%s)\n",
                                 glyph->u.notes.glyph_type,

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -128,17 +128,6 @@ static gregorio_element *gabc_det_elements_from_glyphs(
 
     while (current_glyph) {
         if (current_glyph->type != GRE_GLYPH) {
-            /* we ignore flats and naturals, except if they are alone */
-            if (current_glyph->type == GRE_NATURAL
-                || current_glyph->type == GRE_FLAT
-                || current_glyph->type == GRE_SHARP) {
-                if (!current_glyph->next) {
-                    first_element = current_element;
-                    close_element(&current_element, &first_glyph, current_glyph);
-                }
-                current_glyph = current_glyph->next;
-                continue;
-            }
             /* we must not cut after a glyph-level space */
             if (current_glyph->type == GRE_SPACE) {
                 switch (current_glyph->u.misc.unpitched.info.space) {
@@ -200,6 +189,7 @@ static gregorio_element *gabc_det_elements_from_glyphs(
         }
         switch (current_glyph_type) {
         case G_PUNCTA_ASCENDENS:
+        case G_ALTERATION:
             if (!do_not_cut) {
                 cut_before(current_glyph, &first_glyph, &previous_glyph,
                            &current_element);

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -112,6 +112,12 @@ static char gregorio_add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
         next_glyph_type = G_PUNCTUM;
         *end_of_glyph = DET_END_OF_BOTH;
         break;
+    case S_FLAT:
+    case S_SHARP:
+    case S_NATURAL:
+        next_glyph_type = G_ALTERATION;
+        *end_of_glyph = DET_END_OF_BOTH;
+        break;
     case S_PUNCTUM:
         /*
          * we determine here the shape of the thing if it is made of puncta
@@ -910,12 +916,6 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                 }
                 break;
 
-            case GRE_FLAT:
-            case GRE_SHARP:
-            case GRE_NATURAL:
-                pitch = current_note->u.note.pitch;
-                break;
-
             case GRE_AUTOFUSE_START:
                 autofuse = true;
                 first_autofused_note = true;
@@ -999,7 +999,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                     case S_QUILISMA:
                     case S_QUADRATUM:
                     case S_QUILISMA_QUADRATUM:
-                        /* these are fusable */
+                        /* these are fusible */
                         if (current_glyph_type <= G_PUNCTA_INCLINATA) {
                             /* if we had some puncta inclinata, then end them */
                             close_glyph(&last_glyph, current_glyph_type,
@@ -1016,7 +1016,7 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                         break;
 
                     default:
-                        /* not fusable; will be added normally by the state
+                        /* not fusible; will be added normally by the state
                          * machine */
                         break;
                     }

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -169,13 +169,6 @@ static void add_sign(gregorio_sign sign)
     gregorio_add_sign(current_note, sign, vposition);
 }
 
-static __inline void add_alteration(const gregorio_type type)
-{
-    gregorio_add_alteration_as_note(&current_note, type,
-            pitch_letter_to_height(gabc_notes_determination_text[0]),
-            &notes_lloc);
-}
-
 static void save_before_ledger(const char *const before_ledger)
 {
     if (strcmp(before_ledger, "0") == 0) {
@@ -904,14 +897,16 @@ r4  {
 r5  {
         gregorio_add_special_sign(current_note, _SEMI_CIRCULUS_REVERSUS);
     }
-[a-npA-NP]x {
-        add_alteration(GRE_FLAT);
+x   {
+        gregorio_change_shape(current_note, S_FLAT, legacy_oriscus_orientation);
     }
-[a-npA-NP]# {
-        add_alteration(GRE_SHARP);
+#   {
+        gregorio_change_shape(current_note, S_SHARP,
+                legacy_oriscus_orientation);
     }
-[a-npA-NP]y {
-        add_alteration(GRE_NATURAL);
+y   {
+        gregorio_change_shape(current_note, S_NATURAL,
+                legacy_oriscus_orientation);
     }
 !?\/0 {
         gregorio_add_space_as_note(&current_note, SP_HALF_SPACE, NULL,

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -480,6 +480,15 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
     case S_PUNCTUM_CAVUM_INCLINATUM_AUCTUS:
         fprintf(f, "%cr<", toupper((unsigned char)pitch_letter(note->u.note.pitch)));
         break;
+    case S_FLAT:
+        fprintf(f, "%cx", pitch_letter(note->u.note.pitch));
+        break;
+    case S_NATURAL:
+        fprintf(f, "%cy", pitch_letter(note->u.note.pitch));
+        break;
+    case S_SHARP:
+        fprintf(f, "%c#", pitch_letter(note->u.note.pitch));
+        break;
     case S_VIRGA:
         fprintf(f, "%cv", pitch_letter(note->u.note.pitch));
         break;
@@ -639,19 +648,10 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
         return;
     }
     switch (glyph->type) {
-    case GRE_FLAT:
-        fprintf(f, "%cx", pitch_letter(glyph->u.misc.pitched.pitch));
-        break;
     case GRE_TEXVERB_GLYPH:
         if (glyph->texverb) {
             fprintf(f, "[gv:%s]", glyph->texverb);
         }
-        break;
-    case GRE_NATURAL:
-        fprintf(f, "%cy", pitch_letter(glyph->u.misc.pitched.pitch));
-        break;
-    case GRE_SHARP:
-        fprintf(f, "%c#", pitch_letter(glyph->u.misc.pitched.pitch));
         break;
     case GRE_SPACE:
         if (glyph->next) {

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -88,6 +88,9 @@ OFFSET_CASE(SalicusOriscusOne);
 OFFSET_CASE(LeadingPunctum);
 OFFSET_CASE(LeadingQuilisma);
 OFFSET_CASE(LeadingOriscus);
+OFFSET_CASE(Flat);
+OFFSET_CASE(Sharp);
+OFFSET_CASE(Natural);
 
 static __inline const char *note_before_last_note_case_ignoring_deminutus(
         const gregorio_note *const current_note)
@@ -960,6 +963,15 @@ static gregorio_vposition advise_positioning(const gregorio_glyph *const glyph,
         case S_LINEA:
             note->gtex_offset_case = FinalPunctum;
             break;
+        case S_FLAT:
+            note->gtex_offset_case = Flat;
+            break;
+        case S_SHARP:
+            note->gtex_offset_case = Sharp;
+            break;
+        case S_NATURAL:
+            note->gtex_offset_case = Natural;
+            break;
         default:
             note->gtex_offset_case = last_note_case(glyph,
                     fused_single_note_case(glyph, FinalPunctum, LeadingPunctum),
@@ -1527,6 +1539,9 @@ static __inline int compute_fused_shift(const gregorio_glyph *glyph)
     case S_ORISCUS_CAVUM_ASCENDENS:
     case S_ORISCUS_CAVUM_DESCENDENS:
     case S_ORISCUS_CAVUM_DEMINUTUS:
+    case S_FLAT:
+    case S_SHARP:
+    case S_NATURAL:
         /* if this glyph starts with one of these, it's not fusable */
         return 0;
 
@@ -1559,6 +1574,9 @@ static __inline int compute_fused_shift(const gregorio_glyph *glyph)
     case S_ORISCUS_CAVUM_ASCENDENS:
     case S_ORISCUS_CAVUM_DESCENDENS:
     case S_ORISCUS_CAVUM_DEMINUTUS:
+    case S_FLAT:
+    case S_SHARP:
+    case S_NATURAL:
         /* these don't fuse to anything */
         return 0;
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -5,7 +5,7 @@
  * Copyright (C) 2006-2015 The Gregorio Project (see CONTRIBUTORS.md)
  *
  * This file is part of Gregorio.
- * 
+ *
  * Gregorio is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -23,7 +23,7 @@
 /**
  * @file
  * @brief This file contains a set of function to manipulate the gregorio
- * structure. 
+ * structure.
  *
  * It starts by simple add/delete functions for almost all
  * structs, and ends with more complex functions for manipulating
@@ -200,14 +200,6 @@ void gregorio_add_bar_as_note(gregorio_note **current_note, gregorio_bar bar,
     gregorio_note *element = create_and_link_note(current_note, loc);
     element->type = GRE_BAR;
     element->u.other.bar = bar;
-}
-
-void gregorio_add_alteration_as_note(gregorio_note **current_note,
-        gregorio_type type, signed char pitch,
-        const gregorio_scanner_location *const loc)
-{
-    assert(type == GRE_FLAT || type == GRE_SHARP || type == GRE_NATURAL);
-    add_pitched_item_as_note(current_note, type, pitch, loc);
 }
 
 void gregorio_add_space_as_note(gregorio_note **current_note,
@@ -776,8 +768,7 @@ void gregorio_add_pitched_element_as_glyph(gregorio_glyph **current_glyph,
         gregorio_type type, signed char pitch, bool force_pitch, char *texverb)
 {
     gregorio_glyph *next_glyph = create_and_link_glyph(current_glyph);
-    assert(type == GRE_CUSTOS || type == GRE_FLAT || type == GRE_NATURAL
-           || type == GRE_SHARP);
+    assert(type == GRE_CUSTOS);
     next_glyph->type = type;
     next_glyph->u.misc.pitched.pitch = pitch;
     next_glyph->u.misc.pitched.force_pitch = force_pitch;
@@ -790,8 +781,7 @@ void gregorio_add_unpitched_element_as_glyph(gregorio_glyph **current_glyph,
 {
     gregorio_glyph *next_glyph = create_and_link_glyph(current_glyph);
     assert(type != GRE_NOTE && type != GRE_GLYPH && type != GRE_ELEMENT
-           && type != GRE_CLEF && type != GRE_CUSTOS && type != GRE_FLAT
-           && type != GRE_NATURAL && type != GRE_SHARP);
+           && type != GRE_CLEF && type != GRE_CUSTOS);
     next_glyph->type = type;
     next_glyph->u.misc.unpitched.info = *info;
     next_glyph->u.misc.unpitched.special_sign = sign;
@@ -1333,7 +1323,9 @@ static signed char gregorio_syllable_first_note(gregorio_syllable *syllable)
         if (element->type == GRE_ELEMENT && element->u.first_glyph) {
             glyph = element->u.first_glyph;
             while (glyph) {
-                if (glyph->type == GRE_GLYPH && glyph->u.notes.first_note) {
+                if (glyph->type == GRE_GLYPH
+                        && glyph->u.notes.glyph_type != G_ALTERATION
+                        && glyph->u.notes.first_note) {
                     assert(glyph->u.notes.first_note->type == GRE_NOTE);
                     return glyph->u.notes.first_note->u.note.pitch;
                 }
@@ -1358,7 +1350,9 @@ signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
     if (glyph) {
         glyph = glyph->next;
         while (glyph) {
-            if (glyph->type == GRE_GLYPH && glyph->u.notes.first_note) {
+            if (glyph->type == GRE_GLYPH
+                    && glyph->u.notes.glyph_type != G_ALTERATION
+                    && glyph->u.notes.first_note) {
                 assert(glyph->u.notes.first_note->type == GRE_NOTE);
                 return glyph->u.notes.first_note->u.note.pitch;
             }
@@ -1374,7 +1368,9 @@ signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
         if (element->type == GRE_ELEMENT && element->u.first_glyph) {
             glyph = element->u.first_glyph;
             while (glyph) {
-                if (glyph->type == GRE_GLYPH && glyph->u.notes.first_note) {
+                if (glyph->type == GRE_GLYPH
+                        && glyph->u.notes.glyph_type != G_ALTERATION
+                        && glyph->u.notes.first_note) {
                     assert(glyph->u.notes.first_note->type == GRE_NOTE);
                     return glyph->u.notes.first_note->u.note.pitch;
                 }
@@ -1398,44 +1394,6 @@ signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
     /* here it means that there is no next note, so we return a stupid value,
      * but it won' t be used */
     return DUMMY_PITCH;
-}
-
-/**********************************
- *
- * A function that may be useful (used in xml-write) : we have a
- * tabular of alterations (we must remember all alterations on all
- * notes all the time, they are reinitialized when a bar is found),
- * and we assign all of them to NO_ALTERATION.
- *
- *This function works in fact with a tabular of tabular, one per
- *voice, for polyphony.
- *
- *********************************/
-
-void gregorio_reinitialize_alterations(char alterations[][13],
-        int number_of_voices)
-{
-    int i;
-    int j;
-    for (j = 0; j < number_of_voices; j++) {
-        for (i = 0; i < 13; i++) {
-            alterations[j][i] = NO_ALTERATION;
-        }
-    }
-}
-
-/**********************************
- *
- * The corresponding function for monophony.
- *
- *********************************/
-
-void gregorio_reinitialize_one_voice_alterations(char alterations[13])
-{
-    int i;
-    for (i = 0; i < 13; i++) {
-        alterations[i] = NO_ALTERATION;
-    }
 }
 
 /**********************************

--- a/tex/gregoriotex-chars.tex
+++ b/tex/gregoriotex-chars.tex
@@ -76,6 +76,9 @@
 \gre@def@char@he{oriscus}{Oriscus}%
 \gre@def@char@he{oriscus@line@tr}{OriscusLineTR}%
 \gre@def@char@he{smallpunctum}{HighPes}% "smallpunctum" is the top punctum in a pes
+\gre@def@char@he{flat}{Flat}%
+\gre@def@char@he{sharp}{Sharp}%
+\gre@def@char@he{natural}{Natural}%
 
 \def\gre@fontchar@flat{\gre@font@music\GreCPFlat}%
 \def\gre@fontchar@flathole{\gre@font@music\GreCPFlatHole}%

--- a/tex/gregoriotex-signs.lua
+++ b/tex/gregoriotex-signs.lua
@@ -420,15 +420,35 @@ local offset_cases = {
     v = [[\gre@vepisemaorrareaux{0}{\GreCPPunctum}{0}{0}{#2}{#3}{#4}]],
     h = [[\gre@hepisorlineaux{\GreCPPunctumTwoUp}{\gre@char@he@punctum{#4}}{2}{#3}]],
   },
+  -- qulisma fused to the next note
   {
     case = 'LeadingQuilisma',
     v = [[\gre@vepisemaorrareaux{0}{\GreCPQuilisma}{0}{0}{#2}{#3}{#4}]],
     h = [[\gre@hepisorlineaux{\GreCPQuilismaTwoUp}{\gre@char@he@quilisma{#4}}{2}{#3}]],
   },
+  -- oriscus fused to the next note
   {
     case = 'LeadingOriscus',
     v = [[\gre@vepisemaorrareaux{0}{\GreCPOriscus}{0}{0}{#2}{#3}{#4}]],
     h = [[\gre@hepisorlineaux{\GreCPOriscusTwoUp}{\gre@char@he@oriscus{#4}}{2}{#3}]],
+  },
+  -- flat
+  {
+    case = 'Flat',
+    v = [[\gre@vepisemaorrareaux{0}{\GreCPFlat}{1}{0}{#2}{#3}{#4}]],
+    h = [[\gre@hepisorlineaux{\GreCPFlat}{\gre@char@he@flat{#4}}{2}{#3}]],
+  },
+  -- sharp
+  {
+    case = 'Sharp',
+    v = [[\gre@vepisemaorrareaux{0}{\GreCPSharp}{1}{0}{#2}{#3}{#4}]],
+    h = [[\gre@hepisorlineaux{\GreCPSharp}{\gre@char@he@sharp{#4}}{2}{#3}]],
+  },
+  -- natural
+  {
+    case = 'Natural',
+    v = [[\gre@vepisemaorrareaux{0}{\GreCPNatual}{1}{0}{#2}{#3}{#4}]],
+    h = [[\gre@hepisorlineaux{\GreCPNatural}{\gre@char@he@natural{#4}}{2}{#3}]],
   },
 }
 

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -221,7 +221,7 @@
   \else %
     \gre@skip@temp@four = \gre@skip@clefflatspace\relax%
     \gre@hskip\gre@skip@temp@four %
-    \GreFlat{#4}{1}%
+    \GreFlat{#4}{1}{}{}{}%
   \fi %
   \relax %
 }%
@@ -1863,17 +1863,27 @@
 % #2 is the char of the alteration
 % #3 is the char of the alteration hole
 % #4 is 1 in the case of a flat for a key change, 0 otherwise
-\def\gre@alteration#1#2#3#4{%
-  \setbox\gre@box@temp@width=\hbox{#2}%
+% #5 are the signs to typeset before the glyph (typically additional bars, as they must be "behind" the glyph)
+% #6 are the signs to typeset after the glyph (almost all signs)
+% #7 is the line:char:column for a textedit link
+\def\gre@alteration#1#2#3#4#5#6#7{%
+  \setbox\gre@box@temp@width=\hbox{\gre@pointandclick{#2}{#7}}%
   \ifnum#4=0\relax %
     \gre@newglyphcommon %
   \fi %
+  \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %
+  % the three next lines are a trick to get the additional lines below the glyphs
+  \gre@skip@temp@one = \gre@dimen@lastglyphwidth\relax%
+  \kern\gre@skip@temp@one %
+  #5\relax %
+  \kern-\gre@skip@temp@one %
   \gre@calculate@glyphraisevalue{#1}{0}%
   \ifgre@hidealtlines %
     \gre@fillhole{#3}%
   \fi %
   \raise \gre@dimen@glyphraisevalue\relax%
   \copy\gre@box@temp@width%
+  #6\relax %
   \ifnum#4=0\relax %
     % we try to avoid line breaking after a flat or a natural
     \GreNoBreak %
@@ -1891,28 +1901,29 @@
     \fi %
     \GreNoBreak %
   \fi %
+  \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \relax %
 }%
-  %
+
 % This macro typesets a flat on the height provided by #1. #2 is not used yet, but it
 % will determine if the flat has zero width or not.
 
-\def\GreFlat#1#2{%
-  \gre@alteration{#1}{\gre@fontchar@flat}{\gre@fontchar@flathole}{#2}%
+\def\GreFlat#1#2#3#4#5{%
+  \gre@alteration{#1}{\gre@fontchar@flat}{\gre@fontchar@flathole}{#2}{#3}{#4}{#5}%
   \relax%
 }%
 
 % Same as the one before, but for naturals.
 
-\def\GreNatural#1#2{%
-  \gre@alteration{#1}{\gre@fontchar@natural}{\gre@fontchar@naturalhole}{#2}%
+\def\GreNatural#1#2#3#4#5{%
+  \gre@alteration{#1}{\gre@fontchar@natural}{\gre@fontchar@naturalhole}{#2}{#3}{#4}{#5}%
   \relax%
 }%
 
 % Same as the one before, but for sharps.
 
-\def\GreSharp#1#2{%
-  \gre@alteration{#1}{\gre@fontchar@sharp}{\gre@fontchar@sharphole}{#2}%
+\def\GreSharp#1#2#3#4#5{%
+  \gre@alteration{#1}{\gre@fontchar@sharp}{\gre@fontchar@sharphole}{#2}{#3}{#4}{#5}%
   \relax%
 }%
 

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -38,11 +38,16 @@
 
 \def\gresetpointandclick#1{%
   \IfStrEq{#1}{on}{%
-    \ifpdf %
-      \gre@generate@pointandclick=1\relax %
-    \else %
-      \gre@warning{Unable to enable point-and-click when not generating a PDF}%
+    \ifx\pdfoutput\undefined %
+      \gre@warning{Unable to enable point-and-click because \protect\pdfoutput \MessageBreak is not defined}%
       \gre@generate@pointandclick=0\relax %
+    \else %
+      \ifnum\pdfoutput=1\relax %
+        \gre@generate@pointandclick=1\relax %
+      \else %
+        \gre@warning{Unable to enable point-and-click when not\MessageBreak generating a PDF}%
+        \gre@generate@pointandclick=0\relax %
+      \fi %
     \fi %
   }{%
     \IfStrEq{#1}{off}{%
@@ -54,19 +59,24 @@
 }%
 
 \def\gre@pointandclick#1#2{%
-  \def\gre@@arg{\gre@gabcname#2}%
+  \def\gre@@arg{#2}%
   \ifx\gre@@arg\gre@nothing %
     #1%
   \else %
-    \ifnum\gre@generate@pointandclick=1\relax %
-      \pdfstartlink user{%
-        /Subtype/Link/Border[0 0 0]%
-        /A<</Type/Action/S/URI/URI(textedit://\gre@gabcname:#2)>>%
-      }%
+    \def\gre@@arg{\gre@gabcname}%
+    \ifx\gre@@arg\gre@nothing %
       #1%
-      \pdfendlink %
     \else %
-      #1%
+      \ifnum\gre@generate@pointandclick=1\relax %
+        \pdfstartlink user{%
+          /Subtype/Link/Border[0 0 0]%
+          /A<</Type/Action/S/URI/URI(textedit://\gre@gabcname:#2)>>%
+        }%
+        #1%
+        \pdfendlink %
+      \else %
+        #1%
+      \fi %
     \fi %
   \fi %
 }%
@@ -115,8 +125,7 @@
 \def\GreGlyph#1#2#3#4#5#6#7{%
   \gre@newglyphcommon %
   \setbox\gre@box@temp@width=\hbox{\gre@pointandclick{\gre@font@music #1}{#7}}%
-  \gre@dimen@temp@three=\wd\gre@box@temp@width %
-  \global\gre@dimen@lastglyphwidth=\gre@dimen@temp@three %
+  \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %
   % the three next lines are a trick to get the additional lines below the glyphs
   \gre@skip@temp@one = \gre@dimen@lastglyphwidth\relax%
   \kern\gre@skip@temp@one %
@@ -132,8 +141,6 @@
     \gre@calculate@notesaligncenter{#4}%
     \global\gre@firstglyphfalse%
   \fi%
-  %\gre@dimen@lastglyphwidth=\gre@dimen@temp@three
-  %#5\relax
   #6\relax %
   \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \relax%


### PR DESCRIPTION
Fixes #790.

With this change, I have switched from alteration as element/glyph with a shape-specific `gregorio_type` to a glyph with a `gregorio_glyph_type` of `G_ALTERATION` and whose note has the appropriate `gregorio_shape`.

In so doing, I eliminated some dead code (used for GregorioXML) and fixed a problem with point-and-click and newer versions of lualatex.

Tests have changed appropriately to this fix, and I added a new test to exercise the the ledger line/spacing fix.  I switched the `gabc-output` tests to use the point-and-click feature, which helps both with debugging as well as with exercising that feature itself (which has been broken since some version of TeX Live 2015).

Please review and merge if satisfactory.