### PR TITLE
Switched to etex computation directives and added @space prefix to textual spaces.

### DIFF
--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1472,9 +1472,11 @@ Box holding the horizontal episema.
 
 
 \subsection{Distances}
-All of the distances listed in \nameref{distances} have an internal
-associated with them, of the form of \verb=\gre@*@*=, which stores the value of the distance (in
-string representation).  The first wildcard is either \texttt{skip} or \texttt{dimen} according to the distance type, while the second is the name of the distance.
+All of the distances listed in \nameref{distances} have an internal associated
+with them, of the form of \verb=\gre@space@*@*=, which stores the value of the
+distance (in string representation).  The first wildcard is either
+\texttt{skip} or \texttt{dimen} according to the distance type, while the
+second is the name of the distance.
 
 These additional distances are calculated by Gregorio based on the values for the user customizable distances and what may be going on in the score at the time of their use.
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -117,7 +117,7 @@ Calculates the baseline correction for the glyphs.  Dependent on \texttt{gre@fac
 Aggregates all of the global distance calculations and calls them in the order needed to respect dependencies.
 
 \macroname{\textbackslash gre@calculate@glyphraisevalue}{\#1\#2}{gregoriotex-spaces.tex}
-Calculates the raise values for a glyph (glyphraisevalue and addedraisevalue) based on where it is to be placed and what kind of a glyph it is.  This is a time of use calculation.
+Calculates the raise value for a glyph (glyphraisevalue) based on where it is to be placed and what kind of a glyph it is.  This is a time of use calculation.
 
 \begin{argtable}
   \#1 & integer & The number for where the glyph is located.  \texttt{a} in gabc is \texttt{1}, \texttt{b} is \texttt{2}, \etc\\
@@ -206,12 +206,6 @@ Strips the units from a distance.
 \begin{argtable}
   \#1 & distance & should be in the form ``[0-9]+.[0-9]+pt’’. (\ie the result of applying \verb=\the= to a distance register)
 \end{argtable}
-
-\macroname{\textbackslash gre@unitfactor}{}{gregoriotex-spaces.tex}
-Temporary count used by \verb=\gre@convertto=.
-
-\macroname{\textbackslash gre@basefactor}{}{gregoriotex-spaces.tex}
-Temporary count used by \verb=\gre@convertto=.
 
 \macroname{\textbackslash gre@count@temp@**}{}{gregoriotex-spaces.tex}
 Temporary count used in calculations.  There are currently three of these.
@@ -1541,9 +1535,6 @@ The space between the lines.
 \macroname{\textbackslash gre@dimen@glyphraisevalue}{}{gregoriotex-spaces.tex}
 The value that a particular glyph must be raised to be set in the correct position.
 
-\macroname{\textbackslash gre@dimen@addedraisevalue}{}{gregoriotex-spaces.tex}
-The additional raise needed for the vertical episema and the puncta.
-
 \macroname{\textbackslash gre@dimen@enddifference}{}{gregoriotex-spaces.tex}
 Distance from the end of the notes to the end of the text for the previous syllable.  Positive values when notes go further than text, negative in the other case.
 
@@ -1567,15 +1558,6 @@ Temporary dimensions used in calculations.  There are currently five of these.
 
 \macroname{\textbackslash gre@skip@temp@**}{}{gregoriotex-spaces.tex}
 Temporary skips used in calculations.  There are currently four of these.
-
-\macroname{\textbackslash gre@unit}{}{gregoriotex-spaces.tex}
-Temporary dimension used by \verb=\gre@convertto=.
-
-\macroname{\textbackslash gre@base}{}{gregoriotex-spaces.tex}
-Temporary dimension used by \verb=\gre@convertto=.
-
-\macroname{\textbackslash gre@maxlen}{}{gregoriotex-spaces.tex}
-Distance holding the maximum legal length in TeX.
 
 \macroname{\textbackslash gre@dimen@savedglyphraise}{}{gregoriotex-signs.tex}
 Macro to hold the value of the glyph raise so that it can be restored after some calculations which may change it are performed.

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -193,18 +193,18 @@ Macro to calculate \texttt{nextbegindifference}.
   & $40 \le$ integer $\le 59$ & Same as below 20 except there is a natural before the notes.  Subtract 40 to get the type of notes alignment.
 \end{argtable}
 
-\macroname{\textbackslash gre@makein}{\#1}{gregoriotex-spaces.tex}
-Strips the decimals and units from a distance.
+\macroname{\textbackslash gre@strip@pt}{\#1}{gregoriotex.sty \textup{and} gregoriotex.tex}
+Strips the units from a distance.  Under \LaTeX{}, this is an alias to \verb=\strip@pt=.
 
 \begin{argtable}
-  \#1 & distance & should be in the form ``[0-9]+.[0-9]+pt’’. (\ie the result of applying \verb=\the= to a distance register)
+  \#1 & control sequence & should be the control sequence for the the distance register (including the leading backslash)\\
 \end{argtable}
 
-\macroname{\textbackslash gre@makenum}{\#1}{gregoriotex-spaces.tex}
-Strips the units from a distance. 
+\macroname{\textbackslash gre@rem@pt}{\#1}{gregoriotex.tex}
+Strips the units from a distance.  Used internally by \verb=\gre@strip@pt=.  Under \LaTeX{}, this is not defined.
 
 \begin{argtable}
-  \#1 & distance & should be in the form ``[0-9]+.[0-9]+pt’’. (\ie the result of applying \verb=\the= to a distance register)
+  \#1 & distance & should be in the form ``[0-9]+.[0-9]+pt’’. (\ie the result of applying \verb=\the= to a distance register)\\
 \end{argtable}
 
 \macroname{\textbackslash gre@count@temp@**}{}{gregoriotex-spaces.tex}

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -126,9 +126,9 @@
 
   \gre@rubberpermit{#1}%
   \ifgre@rubber%
-    Default: \directlua{GregorioRef.emit_dimension("\luaescapestring{\csname gre@skip@#1\endcsname}")}
+    Default: \directlua{GregorioRef.emit_dimension("\luaescapestring{\csname gre@space@skip@#1\endcsname}")}
   \else%
-    Default: \directlua{GregorioRef.emit_dimension("\luaescapestring{\csname gre@dimen@#1\endcsname}")}
+    Default: \directlua{GregorioRef.emit_dimension("\luaescapestring{\csname gre@space@dimen@#1\endcsname}")}
   \fi%
 }
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -366,8 +366,7 @@
   \gre@calculate@annotationtrueraise %
   % we print the initial always at the same place, and then we print the gre@box@annotation, centered
   % first we print the initial
-  \gre@dimen@temp@five = \gre@dimen@textlower\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@initialraise\relax%
+  \gre@dimen@temp@five = \dimexpr(\gre@dimen@textlower+\gre@space@dimen@initialraise)\relax%
   % if it is a big initial we print it on the second line
   \ifnum\gre@biginitial=0\relax %
     \ifvoid\gre@box@initial%
@@ -379,11 +378,11 @@
       \gre@obsolete{\protect\greinitialformat}{\protect\grechangestyle{initial}}%  OBSOLETE
     \fi%  OBSOLETE
     \gre@debugmsg{ifdim}{ manualinitialwidth = 0pt}%
-    \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
+    \ifdim\gre@space@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\gre@box@initial %
     \else%
       \gre@style@initial%
-      \global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth\relax%
+      \global\gre@dimen@initialwidth=\gre@space@dimen@manualinitialwidth\relax%
       \endgre@style@initial%
       \ifx\gre@empty@initialformat\greinitialformat% OBSOLETE
       \else%  OBSOLETE
@@ -398,7 +397,7 @@
     \setbox\gre@box@initial=\hbox to \gre@dimen@initialwidth {\hss\raise \gre@dimen@temp@five\box\gre@box@initial\hss}%
     \gre@debugmsg{annotation}{Initial set.}%
     \gre@style@initial%
-    \global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift\relax%
+    \global\gre@dimen@temp@four = \gre@space@dimen@beforeinitialshift\relax%
     \endgre@style@initial%
     \ifx\gre@empty@initialformat\greinitialformat% OBSOLETE
     \else%  OBSOLETE
@@ -408,14 +407,14 @@
     \ifgre@allowdeprecated%%% DEPRECATED for removal in 5.0
       \gre@warning{biginitial style is deprecated, but the old\MessageBreak behavior will be used since deprecated usage is\MessageBreak currently enabled. This behavior will disappear\MessageBreak in 5.0, so consider disabling deprecated usage\MessageBreak and switching to the initial style instead. (See\MessageBreak UPGRADE.md for more information)}%%% DEPRECATED for removal in 5.0
     \fi%%% DEPRECATED for removal in 5.0
-    \advance\gre@dimen@temp@five by -\gre@dimen@additionalbottomspace\relax%
-    \advance\gre@dimen@temp@five by -\gre@dimen@spacebeneathtext\relax%
-    \advance\gre@dimen@temp@five by -\gre@dimen@spacelinestext\relax%
-    \advance\gre@dimen@temp@five by -4\gre@dimen@interstafflinespace\relax%
-    \advance\gre@dimen@temp@five by -4\gre@dimen@stafflineheight\relax%
-    \advance\gre@dimen@temp@five by -\gre@dimen@currenttranslationheight\relax%
-    \advance\gre@dimen@temp@five by -\f@size pt%
-    \advance\gre@dimen@temp@five by \gre@dimen@initialraise\relax%
+    \advance\gre@dimen@temp@five by \dimexpr(-\gre@dimen@additionalbottomspace %
+      - \gre@space@dimen@spacebeneathtext %
+      - \gre@space@dimen@spacelinestext %
+      - 4\gre@dimen@interstafflinespace %
+      - 4\gre@dimen@stafflineheight %
+      - \gre@dimen@currenttranslationheight %
+      - \f@size pt %
+      + \gre@space@dimen@initialraise)\relax%
     \ifvoid\gre@box@initial%
       \gre@debugmsg{initial}{fill big initial box}%
       \ifgre@allowdeprecated%%% DEPRECATED for removal in 5.0
@@ -429,16 +428,16 @@
       \gre@obsolete{\protect\grebiginitialformat}{\protect\grechangestyle{biginitial}}%  OBSOLETE
     \fi%  OBSOLETE
     \gre@debugmsg{ifdim}{ manualinitialwidth = 0pt}%
-    \ifdim\gre@dimen@manualinitialwidth=0 pt\relax%
+    \ifdim\gre@space@dimen@manualinitialwidth=0 pt\relax%
       \global\gre@dimen@initialwidth=\wd\gre@box@initial %
     \else%
       \ifgre@allowdeprecated%%% DEPRECATED for removal in 5.0
         \gre@style@biginitial%%% DEPRECATED for removal in 5.0
-        \global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth\relax%%% DEPRECATED for removal in 5.0
+        \global\gre@dimen@initialwidth=\gre@space@dimen@manualinitialwidth\relax%%% DEPRECATED for removal in 5.0
         \endgre@style@biginitial%%% DEPRECATED for removal in 5.0
       \else%%% DEPRECATED for removal in 5.0
         \gre@style@initial% keep this line
-        \global\gre@dimen@initialwidth=\gre@dimen@manualinitialwidth\relax% keep this line
+        \global\gre@dimen@initialwidth=\gre@space@dimen@manualinitialwidth\relax% keep this line
         \endgre@style@initial% keep this line
       \fi%%% DEPRECATED for removal in 5.0
       \ifx\gre@empty@biginitialformat\grebiginitialformat% OBSOLETE
@@ -453,11 +452,11 @@
     \setbox\gre@box@initial=\hbox{\vtop to 0pt{\hbox to \gre@dimen@initialwidth {\hss\raise \gre@dimen@temp@five\box\gre@box@initial\hss}\vss}}%
     \ifgre@allowdeprecated%%% DEPRECATED for removal in 5.0
       \gre@style@biginitial%%% DEPRECATED for removal in 5.0
-      \global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift\relax%%% DEPRECATED for removal in 5.0
+      \global\gre@dimen@temp@four = \gre@space@dimen@beforeinitialshift\relax%%% DEPRECATED for removal in 5.0
       \endgre@style@biginitial%%% DEPRECATED for removal in 5.0
     \else%%% DEPRECATED for removal in 5.0
       \gre@style@initial% keep this line
-      \global\gre@dimen@temp@four = \gre@dimen@beforeinitialshift\relax% keep this line
+      \global\gre@dimen@temp@four = \gre@space@dimen@beforeinitialshift\relax% keep this line
       \endgre@style@initial% keep this line
     \fi%%% DEPRECATED for removal in 5.0
     \ifx\gre@empty@biginitialformat\grebiginitialformat% OBSOLETE
@@ -471,7 +470,7 @@
   \box\gre@box@initial%
   \ifnum\gre@biginitial=0\relax%
     \gre@style@initial%
-    \global\gre@dimen@temp@four = \gre@dimen@afterinitialshift\relax%
+    \global\gre@dimen@temp@four = \gre@space@dimen@afterinitialshift\relax%
     \endgre@style@initial%
     \ifx\gre@empty@initialformat\greinitialformat% OBSOLETE
     \else%  OBSOLETE
@@ -480,11 +479,11 @@
   \else%
     \ifgre@allowdeprecated%%% DEPRECATED for removal in 5.0
       \gre@style@biginitial%%% DEPRECATED for removal in 5.0
-      \global\gre@dimen@temp@four = \gre@dimen@afterinitialshift\relax%%% DEPRECATED for removal in 5.0
+      \global\gre@dimen@temp@four = \gre@space@dimen@afterinitialshift\relax%%% DEPRECATED for removal in 5.0
       \endgre@style@biginitial%%% DEPRECATED for removal in 5.0
     \else%%% DEPRECATED for removal in 5.0
       \gre@style@initial% keep this line
-      \global\gre@dimen@temp@four = \gre@dimen@afterinitialshift\relax% keep this line
+      \global\gre@dimen@temp@four = \gre@space@dimen@afterinitialshift\relax% keep this line
       \endgre@style@initial% keep this line
     \fi%%% DEPRECATED for removal in 5.0
     \ifx\gre@empty@biginitialformat\grebiginitialformat% OBSOLETE
@@ -500,9 +499,7 @@
     \gre@debugmsg{annotation}{There is no annotation.}%
   \else %
     \gre@debugmsg{annotation}{Calculate horizontal position.}%
-    \gre@dimen@temp@five=\gre@dimen@initialwidth\relax%
-    \advance\gre@dimen@temp@five by -\wd\gre@box@annotation%
-    \divide\gre@dimen@temp@five by 2 %
+    \gre@dimen@temp@five=\dimexpr((\gre@dimen@initialwidth - \wd\gre@box@annotation) / 2)\relax %
     \gre@skip@temp@four = -\gre@dimen@initialwidth\relax%
     \hskip\gre@skip@temp@four %
     \kern\gre@dimen@temp@five %
@@ -602,20 +599,20 @@
     \ifgre@annotationbottomline%
       \ifcase\gre@count@annotationvalign\relax%
         %case 0 = top of first line
-        \global\gre@dimen@annotationtrueraise=\dimexpr\ht\gre@box@old+\dp\gre@box@old+\gre@dimen@annotationseparation-\ht\gre@box@add\relax%
+        \global\gre@dimen@annotationtrueraise=\dimexpr\ht\gre@box@old+\dp\gre@box@old+\gre@space@dimen@annotationseparation-\ht\gre@box@add\relax%
         \gre@debugmsg{annotation}{Aligning to top of last line: \the\gre@dimen@annotationtrueraise}%
       \or %case 1 = baseline of first line
-        \global\gre@dimen@annotationtrueraise=\dimexpr\ht\gre@box@old+\dp\gre@box@old+\gre@dimen@annotationseparation\relax%
+        \global\gre@dimen@annotationtrueraise=\dimexpr\ht\gre@box@old+\dp\gre@box@old+\gre@space@dimen@annotationseparation\relax%
         \gre@debugmsg{annotation}{Aligning to baseline of last line: \the\gre@dimen@annotationtrueraise}%
       \or %case 2 = bottom of first line
-        \global\gre@dimen@annotationtrueraise=\dimexpr\ht\gre@box@old+\dp\gre@box@old+\gre@dimen@annotationseparation+\dp\gre@box@add\relax%
+        \global\gre@dimen@annotationtrueraise=\dimexpr\ht\gre@box@old+\dp\gre@box@old+\gre@space@dimen@annotationseparation+\dp\gre@box@add\relax%
         \gre@debugmsg{annotation}{Aligning to bottom of last line: \the\gre@dimen@annotationtrueraise}%
       \else% Bug
         \gre@bug{Invalid value for \protect\gre@count@annotationvalign}%
       \fi%
     \fi%
     \endgre@style@annotation%
-    \setbox\gre@box@annotation = \vtop spread \gre@dimen@annotationseparation\relax {\offinterlineskip\box\gre@box@old\vss\box\gre@box@add}%
+    \setbox\gre@box@annotation = \vtop spread \gre@space@dimen@annotationseparation\relax {\offinterlineskip\box\gre@box@old\vss\box\gre@box@add}%
   \fi%
 }%
 
@@ -726,7 +723,7 @@
     \fi%
     \setbox\gre@box@old = \hbox to \gre@dimen@temp@three{\hfill\box\gre@box@commentary}%
     \setbox\gre@box@add = \hbox to \gre@dimen@temp@three{\hfill\gre@style@commentary#2\endgre@style@commentary}%
-    \setbox\gre@box@commentary = \vbox spread \gre@dimen@commentaryseparation{\offinterlineskip\box\gre@box@old\vss\box\gre@box@add}%
+    \setbox\gre@box@commentary = \vbox spread \gre@space@dimen@commentaryseparation{\offinterlineskip\box\gre@box@old\vss\box\gre@box@add}%
   \fi%
 }
 
@@ -747,7 +744,7 @@
 % set space above the text lines - almost the same as for the translation
 \def\gre@addspaceabove{%
   \gre@style@abovelinestext%
-  \global\gre@dimen@currentabovelinestextheight=\gre@dimen@abovelinestextheight\relax%
+  \global\gre@dimen@currentabovelinestextheight=\gre@space@dimen@abovelinestextheight\relax%
   \gre@generatelines %
   \endgre@style@abovelinestext%
   \ifx\gre@empty@abovelinestextstyle\greabovelinestextstyle% OBSOLETE
@@ -764,7 +761,7 @@
   \relax %
 }%
 
-% the code is a bit strange here: we always execute \gre@skip@spaceabovelines at the beginning of a glyph. This will:
+% the code is a bit strange here: we always execute \gre@space@skip@spaceabovelines at the beginning of a glyph. This will:
 % - typeset the text above the lines if relevant, and making sure we execute it only once
 % - not do anything else
 
@@ -781,20 +778,20 @@
 % typesets the text above the line
 \def\gre@typesettextabovelines#1{%
   \gre@style@abovelinestext%
-  \gre@debugmsg{spacing}{Raise alt text: \gre@dimen@abovelinestextraise}%
-  \global\gre@dimen@temp@five=\gre@dimen@abovelinestextraise\relax%
+  \gre@debugmsg{spacing}{Raise alt text: \gre@space@dimen@abovelinestextraise}%
+  \global\gre@dimen@temp@five=\gre@space@dimen@abovelinestextraise\relax%
   \endgre@style@abovelinestext%
   \ifx\gre@empty@abovelinestextstyle\greabovelinestextstyle% OBSOLETE
   \else%  OBSOLETE
     \gre@obsolete{\protect\greabovelinestextstyle}{\protect\grechangestyle{abovelinestext}}%  OBSOLETE
   \fi%  OBSOLETE
   \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
-  \advance\gre@dimen@temp@five by 4\gre@dimen@stafflineheight\relax%
-  \advance\gre@dimen@temp@five by 4\gre@dimen@interstafflinespace\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace\relax%
+  \advance\gre@dimen@temp@five by \dimexpr(4\gre@dimen@stafflineheight %
+    + 4\gre@dimen@interstafflinespace %
+    + \gre@space@dimen@spacebeneathtext %
+    + \gre@dimen@currenttranslationheight %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@additionalbottomspace)\relax%
   \gre@mark@abovelinestext %
   \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
     \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\gre@style@abovelinestext#1\endgre@style@abovelinestext\hss}%
@@ -833,7 +830,7 @@
 %% macro that draws the stafflines on the first line, it is different from others due to the initial that can take some place, without lines
 \def\gre@drawfirstlines{%
   \advance\gre@dimen@stafflinewidth by -\gre@dimen@initialwidth\relax%
-  %\advance\gre@dimen@stafflinewidth by -\gre@dimen@minimalspaceatlinebeginning
+  %\advance\gre@dimen@stafflinewidth by -\gre@space@dimen@minimalspaceatlinebeginning
   %\gre@dimen@initialwidth=0pt
   \hbox to 0pt{%
     \vbox{%
@@ -883,8 +880,8 @@
           \vskip\gre@dimen@stafflineheight\relax%
         \fi %
       \fi %
-      \vskip\gre@dimen@spacelinestext\relax%
-      \vskip\gre@dimen@spacebeneathtext\relax%
+      \vskip\gre@space@dimen@spacelinestext\relax%
+      \vskip\gre@space@dimen@spacebeneathtext\relax%
       \vskip\gre@dimen@currenttranslationheight\relax%
       \vskip\gre@dimen@additionalbottomspace\relax%
       \endgre@style@normalstafflines%
@@ -907,7 +904,7 @@
       \else%  OBSOLETE
         \gre@obsolete{\protect\grenormalstafflinesformat}{\protect\grechangestyle{normalstafflines}}%  OBSOLETE
       \fi%  OBSOLETE
-      \vskip\gre@skip@spaceabovelines\relax%
+      \vskip\gre@space@skip@spaceabovelines\relax%
       \vskip\gre@dimen@currentabovelinestextheight\relax%
       \ifgre@showlines %
         \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
@@ -948,9 +945,9 @@
           \vskip\gre@dimen@stafflineheight\relax%
         \fi %
       \fi %
-      \vskip\gre@dimen@spacelinestext\relax%
+      \vskip\gre@space@dimen@spacelinestext\relax%
       \vskip\gre@dimen@additionalbottomspace\relax%
-      \vskip\gre@dimen@spacebeneathtext\relax%
+      \vskip\gre@space@dimen@spacebeneathtext\relax%
       \vskip\gre@dimen@currenttranslationheight\relax%
       \endgre@style@normalstafflines %
     }%
@@ -1040,13 +1037,11 @@
 
 \def\GreWriteTranslation#1{%
   \ifgre@translationcentering %
-    \gre@dimen@temp@five=\wd\gre@box@syllabletext %
     \setbox\gre@box@temp@width=\hbox{#1}%
-    \advance\gre@dimen@temp@five by -\wd\gre@box@temp@width %
-    \divide\gre@dimen@temp@five by 2\relax %
+    \gre@dimen@temp@five=\dimexpr((\wd\gre@box@syllabletext - \wd\gre@box@temp@width) / 2)\relax%
     \gre@mark@translation %
     \kern\gre@dimen@temp@five %
-    \raise\gre@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
+    \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
     \ifx\gre@empty@translationformat\gretranslationformat% OBSOLETE
     \else%  OBSOLETE
       \gre@obsolete{\protect\gretranslationformat}{\protect\grechangestyle{translation}}%  OBSOLETE
@@ -1054,7 +1049,7 @@
     \kern-\gre@dimen@temp@five %
   \else %
     \gre@mark@translation %
-    \raise\gre@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
+    \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
     \ifx\gre@empty@translationformat\gretranslationformat% OBSOLETE
     \else%  OBSOLETE
       \gre@obsolete{\protect\gretranslationformat}{\protect\grechangestyle{translation}}%  OBSOLETE
@@ -1068,7 +1063,7 @@
   \fi %
   \gre@attr@center=1\relax %
   \gre@mark@translation %
-  \raise\gre@dimen@spacebeneathtext\hbox to 0pt{\kern 0pt\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}\kern 0pt}%
+  \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{\kern 0pt\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}\kern 0pt}%
   \ifx\gre@empty@translationformat\gretranslationformat% OBSOLETE
   \else%  OBSOLETE
     \gre@obsolete{\protect\gretranslationformat}{\protect\grechangestyle{translation}}%  OBSOLETE
@@ -1090,7 +1085,7 @@
     \GreEndNLBArea{0}{1}%
   \fi %
   \gre@attr@center=2\relax %
-  \raise\gre@dimen@spacebeneathtext\hbox to 0pt{}%
+  \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{}%
   \unsetluatexattribute{\gre@attr@center}%
   \relax %
 }%
@@ -1291,19 +1286,19 @@
     \ifdim\gre@dimen@enddifference > 0 pt\relax%
       \gre@debugmsg{ifdim}{ nextbegindifference > 0pt}%
       \ifdim\gre@skip@nextbegindifference > 0 pt\relax%
-        \gre@skip@temp@four = \gre@skip@notebarspace\relax%
+        \gre@skip@temp@four = \gre@space@skip@notebarspace\relax%
         \gre@hskip\gre@skip@temp@four %
       \else % (next begin difference >0pt)
-        \gre@skip@temp@four = \gre@skip@textbartextspace\relax%
+        \gre@skip@temp@four = \gre@space@skip@textbartextspace\relax%
         \gre@hskip\gre@skip@temp@four %
       \fi %
     \else%(enddifference < 0pt)
       \gre@debugmsg{ifdim}{ nextbegindifference < 0pt}%
       \ifdim\gre@skip@nextbegindifference < 0 pt\relax%
-        \gre@skip@temp@four = \gre@skip@textbartextspace\relax%
+        \gre@skip@temp@four = \gre@space@skip@textbartextspace\relax%
         \gre@hskip\gre@skip@temp@four %
       \else %(next begin difference < 0 pt)
-        \gre@skip@temp@four = \gre@skip@interwordspacetext\relax%
+        \gre@skip@temp@four = \gre@space@skip@interwordspacetext\relax%
         \gre@hskip\gre@skip@temp@four %
       \fi %
     \fi %
@@ -1420,7 +1415,7 @@
 }%
 
 \def\GreAdHocSpaceEndOfElement#1#2{%
-  \gre@skip@temp@four = \gre@skip@interelementspace\relax %
+  \gre@skip@temp@four = \gre@space@skip@interelementspace\relax %
   \directlua{gregoriotex.scale_space(#1)}%
   \GreEndOfElement{4}{#2}%
 }%
@@ -1439,16 +1434,16 @@
     \GreNoBreak %
   \fi %
   \ifcase#1%
-    \gre@skip@temp@four = \gre@skip@interelementspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@interelementspace\relax%
     \gre@hskip\gre@skip@temp@four %
   \or% case 1
-    \gre@skip@temp@four = \gre@skip@largerspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@largerspace\relax%
     \gre@hskip\gre@skip@temp@four %
   \or% case 2
-    \gre@skip@temp@four = \gre@skip@glyphspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@glyphspace\relax%
     \gre@hskip\gre@skip@temp@four %
   \or% case 3
-    \gre@skip@temp@four = \gre@skip@zerowidthspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@zerowidthspace\relax%
     \gre@hskip\gre@skip@temp@four %
   \or% case 4
     \gre@hskip\gre@skip@temp@four %
@@ -1487,51 +1482,51 @@
 %% 22: half-space
 \def\gre@get@spaceskip#1{%
   \ifcase#1%
-    \gre@skip@temp@four = \gre@skip@interglyphspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@interglyphspace\relax%
   \or% case 1
-    \gre@skip@temp@four = \gre@dimen@zerowidthspace\relax%
+    \gre@skip@temp@four = \gre@space@dimen@zerowidthspace\relax%
   \or% case 2
-    \gre@skip@temp@four = \gre@dimen@alterationspace\relax%
+    \gre@skip@temp@four = \gre@space@dimen@alterationspace\relax%
   \or% case 3
-    \gre@skip@temp@four = \gre@skip@punctuminclinatumshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@punctuminclinatumshift\relax%
   \or% case 4
-    \gre@skip@temp@four = \gre@skip@bitrivirspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@bitrivirspace\relax%
   \or% case 5
-    \gre@skip@temp@four = \gre@skip@bitristrospace\relax%
+    \gre@skip@temp@four = \gre@space@skip@bitristrospace\relax%
   \or% case 6
-    \gre@skip@temp@four = \gre@skip@spaceaftersigns\relax%
+    \gre@skip@temp@four = \gre@space@skip@spaceaftersigns\relax%
   \or% case 7
-    \gre@skip@temp@four = \gre@skip@punctuminclinatumanddebilisshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@punctuminclinatumanddebilisshift\relax%
   \or% case 8
-    \gre@skip@temp@four = \gre@skip@punctuminclinatumdebilisshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@punctuminclinatumdebilisshift\relax%
   \or% case 9
-    \gre@skip@temp@four = \gre@skip@beforepunctainclinatashift\relax%
+    \gre@skip@temp@four = \gre@space@skip@beforepunctainclinatashift\relax%
   \or% case 10
-    \gre@skip@temp@four = \gre@skip@punctuminclinatumbigshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@punctuminclinatumbigshift\relax%
   \or% case 11
-    \gre@skip@temp@four = \gre@skip@punctuminclinatummaxshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@punctuminclinatummaxshift\relax%
   \or% case 12 (ascending version of 3)
-    \gre@skip@temp@four = \gre@skip@ascendingpunctuminclinatumshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@ascendingpunctuminclinatumshift\relax%
   \or% case 13 (ascending version of 7)
-    \gre@skip@temp@four = \gre@skip@ascendingpunctuminclinatumanddebilisshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@ascendingpunctuminclinatumanddebilisshift\relax%
   \or% case 14 (ascending version of 10)
-    \gre@skip@temp@four = \gre@skip@ascendingpunctuminclinatumbigshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@ascendingpunctuminclinatumbigshift\relax%
   \or% case 15 (ascending version of 11)
-    \gre@skip@temp@four = \gre@skip@ascendingpunctuminclinatummaxshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@ascendingpunctuminclinatummaxshift\relax%
   \or% case 16
-    \gre@skip@temp@four = \gre@skip@descendinginclinatumtonobarshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@descendinginclinatumtonobarshift\relax%
   \or% case 17
-    \gre@skip@temp@four = \gre@skip@descendinginclinatumtonobarbigshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@descendinginclinatumtonobarbigshift\relax%
   \or% case 18
-    \gre@skip@temp@four = \gre@skip@descendinginclinatumtonobarmaxshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@descendinginclinatumtonobarmaxshift\relax%
   \or% case 19
-    \gre@skip@temp@four = \gre@skip@ascendinginclinatumtonobarshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@ascendinginclinatumtonobarshift\relax%
   \or% case 20
-    \gre@skip@temp@four = \gre@skip@ascendinginclinatumtonobarbigshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@ascendinginclinatumtonobarbigshift\relax%
   \or% case 21
-    \gre@skip@temp@four = \gre@skip@ascendinginclinatumtonobarmaxshift\relax%
+    \gre@skip@temp@four = \gre@space@skip@ascendinginclinatumtonobarmaxshift\relax%
   \or% case 22
-    \gre@skip@temp@four = \gre@skip@halfspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@halfspace\relax%
   \fi%
 }%
 
@@ -1712,8 +1707,7 @@
 
 % gregoriostylefont is the font used for additional glyphs
 \def\gre@setstylefont{%
-  \gre@count@temp@three = \the\gre@factor %
-  \multiply\gre@count@temp@three by 100000\relax %
+  \gre@count@temp@three = \numexpr(\gre@factor * 100000)\relax %
   \global\font\gre@font@style={name:greextra} at \the\gre@count@temp@three sp%
   {\gre@font@music\directlua{gregoriotex.check_font_version() gregoriotex.scale_score_fonts([[\the\gre@count@temp@three]], [[\the\gre@factor]])}}%
   \relax%

--- a/tex/gregoriotex-nabc.lua
+++ b/tex/gregoriotex-nabc.lua
@@ -257,16 +257,16 @@ end
 local add_spacing = function(str, len, idx, ret)
   while idx <= len and (str:sub(idx, idx) == "/" or str:sub(idx, idx) == "`") do
     if idx < len and str:sub(idx, idx + 1) == "//" then
-      ret = ret .. "\\hskip \\gre@skip@nabclargerspace"
+      ret = ret .. "\\hskip \\gre@space@skip@nabclargerspace"
       idx = idx + 2
     elseif idx < len and str:sub(idx, idx + 1) == "``" then
-      ret = ret .. "\\hskip -\\gre@skip@nabclargerspace"
+      ret = ret .. "\\hskip -\\gre@space@skip@nabclargerspace"
       idx = idx + 2
     elseif str:sub(idx, idx) == "/" then
-      ret = ret .. "\\hskip \\gre@skip@nabcinterelementspace"
+      ret = ret .. "\\hskip \\gre@space@skip@nabcinterelementspace"
       idx = idx + 1
     else
-      ret = ret .. "\\hskip -\\gre@skip@nabcinterelementspace"
+      ret = ret .. "\\hskip -\\gre@space@skip@nabcinterelementspace"
       idx = idx + 1
     end
   end

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -114,10 +114,10 @@
     \copy\gre@box@lines% draws the lines
     \unkern %
     \ifgre@showclef%
-      \gre@skip@temp@four = \gre@skip@afterclefnospace\relax%
+      \gre@skip@temp@four = \gre@space@skip@afterclefnospace\relax%
       \hbox{\gre@typeclef{#1}{#2}{0}{#3}{#4}{#5}{#6}{#7}\hskip\gre@skip@temp@four}%
     \else %
-      \gre@skip@temp@four = \gre@dimen@noclefspace\relax%
+      \gre@skip@temp@four = \gre@space@dimen@noclefspace\relax%
       \hbox{\kern\gre@skip@temp@four}%
     \fi %
   }%
@@ -160,7 +160,7 @@
     \else %
       \ifnum\numexpr (#7 - #2) * (#7 - #2) = 1 \relax %
         \gre@typesingleclef{#1}{#2}{#3}{#5}%
-        \gre@skip@temp@two=\gre@skip@clefflatspace\relax%
+        \gre@skip@temp@two=\gre@space@skip@clefflatspace\relax%
         \gre@hskip\gre@skip@temp@two %
         \gre@typesingleclef{#6}{#7}{#3}{#8}%
       \else %
@@ -178,9 +178,9 @@
     \global\gre@dimen@clefwidth=\wd\gre@box@temp@width %
   \fi %
   \copy\gre@box@temp@width %
-  \gre@skip@temp@two=\gre@skip@spaceafterlineclef\relax%
+  \gre@skip@temp@two=\gre@space@skip@spaceafterlineclef\relax%
   \ifnum#4=0\relax %
-    \gre@skip@temp@two=\gre@skip@afterclefnospace\relax%
+    \gre@skip@temp@two=\gre@space@skip@afterclefnospace\relax%
   \fi %
   \gre@hskip\gre@skip@temp@two %
 }%
@@ -219,7 +219,7 @@
   \fi%
   \ifnum#4=3%
   \else %
-    \gre@skip@temp@four = \gre@skip@clefflatspace\relax%
+    \gre@skip@temp@four = \gre@space@skip@clefflatspace\relax%
     \gre@hskip\gre@skip@temp@four %
     \GreFlat{#4}{1}{}{}{}%
   \fi %
@@ -234,7 +234,7 @@
   \ifgre@showclef%
     \gre@typeclef{#1}{#2}{0}{1}{#3}{#4}{#5}{#6}%
   \else%
-    \gre@skip@temp@four = \gre@dimen@noclefspace\relax%
+    \gre@skip@temp@four = \gre@space@dimen@noclefspace\relax%
     \hbox{\kern\gre@skip@temp@four}%
   \fi %
   \GreSetLinesClef{#1}{#2}{1}{#3}{#4}{#5}{#6}%
@@ -259,22 +259,22 @@
     \GreSetLinesClef{#1}{#2}{1}{#4}{#5}{#6}{#7}%
   \fi %
   \ifnum#3=1\relax %
-    \gre@skip@temp@four = \gre@skip@clefchangespace\relax%
+    \gre@skip@temp@four = \gre@space@skip@clefchangespace\relax%
     \gre@hskip\gre@skip@temp@four %
   \else %
     % here it means that there is a bar before the clef, so we skip the difference between the normal space and the space around bars with clef changes
-    \gre@skip@temp@four = -\gre@skip@spacearoundclefbars\relax%
+    \gre@skip@temp@four = -\gre@space@skip@spacearoundclefbars\relax%
     \gre@hskip\gre@skip@temp@four %
   \fi %
   \gre@typeclef{#1}{#2}{1}{0}{#4}{#5}{#6}{#7}%
-  \gre@skip@temp@four = \gre@skip@clefchangespace\relax%
+  \gre@skip@temp@four = \gre@space@skip@clefchangespace\relax%
   \gre@hskip\gre@skip@temp@four %
   \relax%
 }%
 
 % custos just typesets a custos, useful for before the key changes for example
 \def\GreCustos#1{%
-  \gre@skip@temp@four = \gre@skip@spacebeforeinlinecustos\relax%
+  \gre@skip@temp@four = \gre@space@skip@spacebeforeinlinecustos\relax%
   \kern\gre@skip@temp@four%
   \gre@calculate@glyphraisevalue{#1}{0}%
   %here we need some tricks to draw the line before the custos (for the color)
@@ -292,7 +292,7 @@
   % for now we consider we always have a bar after the custos
   % we don't want to end the line here
   \GreNoBreak %
-  \gre@skip@temp@four = -\gre@skip@spacearoundclefbars\relax%
+  \gre@skip@temp@four = -\gre@space@skip@spacearoundclefbars\relax%
   \gre@hskip\gre@skip@temp@four %
   \GreNoBreak %
   \relax %
@@ -301,9 +301,8 @@
 % typesets a custos for the end of the score
 \def\GreFinalCustos#1{%
   \GreNoBreak%
-  \gre@skip@temp@four = \gre@skip@spacebeforeeolcustos\relax%
-  \advance\gre@skip@temp@four by \gre@skip@interelementspace\relax%
-  \gre@dimen@temp@four = \gre@skip@temp@four\relax%
+  % yes, we are computing as a glue and then casting to a dimen
+  \gre@dimen@temp@four = \glueexpr(\gre@space@skip@spacebeforeeolcustos+\gre@space@skip@interelementspace)\relax%
   \hbox to \gre@dimen@temp@four{}%
   \GreNoBreak%
   \GreCustos{#1}%
@@ -317,7 +316,7 @@
       %here we need some tricks to draw the line before the custos (for the color)
       \setbox\gre@box@temp@width=\hbox{%
       % we type a hskip and the we type the custos
-      \gre@skip@temp@four = \gre@skip@spacebeforeeolcustos\relax%
+      \gre@skip@temp@four = \gre@space@skip@spacebeforeeolcustos\relax%
       \hskip\gre@skip@temp@four %
       \gre@pickcustos{#1}\relax %
       }%
@@ -345,12 +344,12 @@
 % macro that typesets an additional line at the top for custos at end of line
 
 \def\gre@additionaltopcustoslineend{%
-  \gre@dimen@temp@five=\gre@dimen@staffheight\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@interstafflinespace\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight\relax%
+  \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
+    + \gre@space@dimen@spacebeneathtext %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@interstafflinespace %
+    + \gre@dimen@additionalbottomspace %
+    + \gre@dimen@currenttranslationheight)\relax %
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
     \gre@style@additionalstafflines %
@@ -359,8 +358,7 @@
       \gre@obsolete{\protect\greadditionalstafflinesformat}{\protect\grechangestyle{additionalstafflinesformat}}% OBSOLETE
     \fi% OBSOLETE
     \kern\gre@dimen@temp@three %
-    \gre@dimen@temp@five=\wd\gre@box@temp@sign %
-    \advance\gre@dimen@temp@five by \gre@dimen@additionalcustoslineswidth\relax%
+    \gre@dimen@temp@five=\dimexpr(\wd\gre@box@temp@sign + \gre@space@dimen@additionalcustoslineswidth)\relax%
     \kern-\gre@dimen@temp@five %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight\relax%
     \hss %
@@ -370,12 +368,12 @@
 }%
 
 \def\gre@additionalbottomcustoslineend{%
-  \gre@dimen@temp@five=\gre@dimen@spacebeneathtext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight\relax%
-  \advance\gre@dimen@temp@five by -\gre@dimen@interstafflinespace\relax%
-  \advance\gre@dimen@temp@five by -\gre@dimen@stafflineheight\relax%
+  \gre@dimen@temp@five=\dimexpr(\gre@space@dimen@spacebeneathtext %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@additionalbottomspace %
+    + \gre@dimen@currenttranslationheight %
+    - \gre@dimen@interstafflinespace %
+    - \gre@dimen@stafflineheight)\relax %
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
     \gre@style@additionalstafflines %
@@ -384,8 +382,7 @@
       \gre@obsolete{\protect\greadditionalstafflinesformat}{\protect\grechangestyle{additionalstafflinesformat}}% OBSOLETE
     \fi% OBSOLETE
     \kern\gre@dimen@temp@three %
-    \gre@dimen@temp@five=\wd\gre@box@temp@sign %
-    \advance\gre@dimen@temp@five by \gre@dimen@additionalcustoslineswidth\relax%
+    \gre@dimen@temp@five=\dimexpr(\wd\gre@box@temp@sign+\gre@space@dimen@additionalcustoslineswidth)\relax%
     \kern-\gre@dimen@temp@five %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight\relax%
     \hss %
@@ -397,12 +394,12 @@
 % same macros, but for a custos in the middle
 
 \def\gre@additionaltopcustoslinemiddle{%
-  \gre@dimen@temp@five=\gre@dimen@staffheight\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@interstafflinespace\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight\relax%
+  \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
+    + \gre@space@dimen@spacebeneathtext %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@interstafflinespace %
+    + \gre@dimen@additionalbottomspace %
+    + \gre@dimen@currenttranslationheight)\relax%
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
     \gre@style@additionalstafflines %
@@ -412,9 +409,7 @@
     \fi% OBSOLETE
     \hss %
     \kern\gre@dimen@temp@three %
-    \gre@dimen@temp@five=\gre@dimen@additionalcustoslineswidth\relax%
-    \multiply\gre@dimen@temp@five by 2%
-    \advance\gre@dimen@temp@five by \wd\gre@box@temp@sign %
+    \gre@dimen@temp@five=\dimexpr((\gre@space@dimen@additionalcustoslineswidth*2)+\wd\gre@box@temp@sign)\relax %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight\relax%
     \hss %
     \endgre@style@additionalstafflines%
@@ -423,12 +418,12 @@
 }%
 
 \def\gre@additionalbottomcustoslinemiddle{%
-  \gre@dimen@temp@five=\gre@dimen@spacebeneathtext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@additionalbottomspace\relax%
-  \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight\relax%
-  \advance\gre@dimen@temp@five by -\gre@dimen@interstafflinespace\relax%
-  \advance\gre@dimen@temp@five by -\gre@dimen@stafflineheight\relax%
+  \gre@dimen@temp@five=\dimexpr(\gre@space@dimen@spacebeneathtext %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@additionalbottomspace %
+    + \gre@dimen@currenttranslationheight %
+    - \gre@dimen@interstafflinespace %
+    - \gre@dimen@stafflineheight)\relax%
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
     \gre@style@additionalstafflines %
@@ -438,9 +433,7 @@
     \fi% OBSOLETE
     \hss %
     \kern\gre@dimen@temp@three %
-    \gre@dimen@temp@five=\gre@dimen@additionalcustoslineswidth\relax%
-    \multiply\gre@dimen@temp@five by 2%
-    \advance\gre@dimen@temp@five by \wd\gre@box@temp@sign %
+    \gre@dimen@temp@five=\dimexpr((\gre@space@dimen@additionalcustoslineswidth*2)+\wd\gre@box@temp@sign)\relax %
     \vrule width \gre@dimen@temp@five height \gre@dimen@stafflineheight\relax%
     \hss %
     \endgre@style@additionalstafflines%
@@ -597,7 +590,7 @@
     \hss %
     \ifnum#5=1\relax %
       \gre@calculate@glyphraisevalue{\gre@pitch@overbrace}{13}%
-      \advance\gre@dimen@glyphraisevalue by \gre@dimen@curlybraceaccentusshift\relax%
+      \advance\gre@dimen@glyphraisevalue by \gre@space@dimen@curlybraceaccentusshift\relax%
       \raise\gre@dimen@glyphraisevalue\hbox{%
         \gre@font@music\GreCPAccentus\relax %
       }%
@@ -850,10 +843,10 @@
 \def\GrePunctumMora#1#2#3#4{%
   \GreNoBreak %
   \ifcase#2\relax %
-    \gre@skip@temp@four = \gre@skip@spacebeforesigns\relax%
+    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
     \hskip\gre@skip@temp@four%
   \or %
-    \gre@skip@temp@four = \gre@skip@spacebeforesigns\relax%
+    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
     \kern\gre@skip@temp@four %
   \or %
     % to get the widht of a punctum minus a line, we calculate the width of a flexus (with ambitus of two) minus the width of a punctum
@@ -862,13 +855,13 @@
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPPunctum}%
     \advance\gre@dimen@temp@five by -\wd\gre@box@temp@width %
     \kern-\gre@dimen@temp@five %
-    \gre@skip@temp@four = \gre@skip@spacebeforesigns\relax%
+    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
     \kern\gre@skip@temp@four %
   \or %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPPunctum}%
     \gre@dimen@temp@five=\wd\gre@box@temp@width %
     \kern-\gre@dimen@temp@five %
-    \gre@skip@temp@four = \gre@skip@spacebeforesigns\relax%
+    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
     \kern\gre@skip@temp@four %
   \fi %
   \ifnum#2=1\else %
@@ -884,15 +877,12 @@
   % here we shift a bit left in the case where we have a punctum inclinatum on a line
   \ifnum#4=1\relax %
     \ifgre@isonaline %
-      \gre@dimen@temp@three=3700sp%
-      \multiply\gre@dimen@temp@three by \the\gre@factor %
+      \gre@dimen@temp@three=\dimexpr(3700sp * \gre@factor)\relax %
       \kern-\gre@dimen@temp@three %
-      \gre@dimen@temp@three =4500sp%
-      \multiply\gre@dimen@temp@three by \the\gre@factor %
+      \gre@dimen@temp@three=\dimexpr(4500sp * \gre@factor)\relax%
       \advance\gre@dimen@glyphraisevalue by -\gre@dimen@temp@three %
     \else %
-      \gre@dimen@temp@three =2500sp%
-      \multiply\gre@dimen@temp@three by \the\gre@factor %
+      \gre@dimen@temp@three=\dimexpr(2500sp * \gre@factor)\relax %
       \advance\gre@dimen@glyphraisevalue by -\gre@dimen@temp@three %
     \fi %
   \fi %
@@ -903,20 +893,20 @@
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@punctummora}%
     \gre@skip@temp@four = -\wd\gre@box@temp@width %
     \kern\gre@skip@temp@four%
-    \gre@skip@temp@four = -\gre@skip@spacebeforesigns\relax%
+    \gre@skip@temp@four = -\gre@space@skip@spacebeforesigns\relax%
     \kern\gre@skip@temp@four %
   \or %
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@punctummora}%
     \gre@skip@temp@four = -\wd\gre@box@temp@width %
     \kern\gre@skip@temp@four%
-    \gre@skip@temp@four = -\gre@skip@spacebeforesigns\relax%
+    \gre@skip@temp@four = -\gre@space@skip@spacebeforesigns\relax%
     \kern\gre@skip@temp@four %
     \kern\gre@dimen@temp@five %
   \or %
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@punctummora}%
     \gre@skip@temp@four = -\wd\gre@box@temp@width %
     \kern\gre@skip@temp@four%
-    \gre@skip@temp@four = -\gre@skip@spacebeforesigns\relax%
+    \gre@skip@temp@four = -\gre@space@skip@spacebeforesigns\relax%
     \kern\gre@skip@temp@four %
     \kern\gre@dimen@temp@five %
   \fi %
@@ -940,7 +930,7 @@
 % #3 is 1 if it must be a bit higher
 \def\GreLowChoralSign#1#2#3{%
   \GreNoBreak %
-  \gre@skip@temp@four = \gre@skip@beforelowchoralsignspace\relax%
+  \gre@skip@temp@four = \gre@space@skip@beforelowchoralsignspace\relax%
   \hskip\gre@skip@temp@four %
   \GreNoBreak %
   \ifnum#3=1\relax %
@@ -1005,8 +995,7 @@
   % first we set \gre@dimen@temp@three to the width of the last glyph
   \gre@dimen@temp@three=\gre@dimen@lastglyphwidth\relax%
   \setbox\gre@box@temp@sign=\hbox{\gre@font@music #2}%
-  \gre@dimen@temp@two=\wd\gre@box@temp@sign %
-  \divide\gre@dimen@temp@two by 2\relax %
+  \gre@dimen@temp@two=\dimexpr(\wd\gre@box@temp@sign / 2)\relax %
   \ifcase#3%
   % tempwidth is the width of the last glyph
     \advance\gre@dimen@temp@three by -\gre@dimen@temp@two %
@@ -1014,12 +1003,10 @@
     \gre@dimen@temp@three=\gre@dimen@temp@two %
   \or%
     \setbox\gre@box@temp@sign=\hbox{\gre@font@music #1}%
-    \gre@dimen@temp@three=\wd\gre@box@temp@sign %
-    \advance\gre@dimen@temp@three by -\gre@dimen@temp@two %
+    \gre@dimen@temp@three=\dimexpr(\wd\gre@box@temp@sign - \gre@dimen@temp@two)\relax %
   \or %
     \setbox\gre@box@temp@sign=\hbox{\gre@font@music #1}%
-    \advance\gre@dimen@temp@three by -\wd\gre@box@temp@sign %
-    \advance\gre@dimen@temp@three by \gre@dimen@temp@two %
+    \advance\gre@dimen@temp@three by \dimexpr(-\wd\gre@box@temp@sign + \gre@dimen@temp@two)\relax %
   \fi%
   \kern-\gre@dimen@temp@three % we do it here because of the now-removed ictus (chironomy)
   % then we draw the sign
@@ -1040,8 +1027,7 @@
     }%
   \fi %
   % we set tempwidth to half a punctum malus half the sign width, so that the centers are aligned
-  \gre@dimen@temp@two=\wd\gre@box@temp@sign %
-  \divide\gre@dimen@temp@two by 2 %
+  \gre@dimen@temp@two=\dimexpr(\wd\gre@box@temp@sign / 2)\relax %
   \advance\gre@dimen@temp@three by \gre@dimen@temp@two %
   \kern-\gre@dimen@temp@two%
   \gre@skip@temp@four = #4sp%
@@ -1074,8 +1060,7 @@
       \gre@calculate@glyphraisevalue{\gre@pitch@raresign}{6}%
     \else %
       {%
-        \gre@count@temp@three=#1%
-        \advance\gre@count@temp@three by 1\relax %
+        \gre@count@temp@three=\numexpr(#1 + 1)\relax %
         \gre@calculate@glyphraisevalue{\gre@count@temp@three}{6}%
       }%
     \fi %
@@ -1165,13 +1150,11 @@
     \setbox\gre@box@temp@sign=\hbox{\gre@font@music #1}%
     \gre@dimen@temp@three=\wd\gre@box@temp@sign%
   \or % case 3
-    \gre@dimen@temp@three=\gre@dimen@lastglyphwidth\relax%
     \setbox\gre@box@temp@sign=\hbox{\gre@font@music #1}%
-    \advance\gre@dimen@temp@three by -\wd\gre@box@temp@sign %
+    \gre@dimen@temp@three=\dimexpr(\gre@dimen@lastglyphwidth - \wd\gre@box@temp@sign)\relax %
   \or % case 4
-    \gre@dimen@temp@three=\gre@dimen@lastglyphwidth\relax%
     \setbox\gre@box@temp@sign=\hbox{\gre@font@music #1}%
-    \advance\gre@dimen@temp@three by -\wd\gre@box@temp@sign %
+    \gre@dimen@temp@three=\dimexpr(\gre@dimen@lastglyphwidth - \wd\gre@box@temp@sign)\relax %
     \setbox\gre@box@temp@sign=\hbox{\gre@font@music #2}%
     \advance\gre@dimen@temp@three by \wd\gre@box@temp@sign %
   \fi%
@@ -1207,11 +1190,11 @@
 %    1 for under staff
 % #2 length of line
 % #3 0 for no space before,
-%    1 for \gre@dimen@additionallineswidth before,
+%    1 for \gre@space@dimen@additionallineswidth before,
 %    2 for #4 space before
 % #4 custom space before, used if #2 is 2
 % #5 0 for no space after,
-%    1 for \gre@dimen@additionallineswidth after,
+%    1 for \gre@space@dimen@additionallineswidth after,
 %    2 for #6 space after
 % #6 custom space after, used if #4 is 2
 \def\GreDrawAdditionalLine#1#2#3#4#5#6{%
@@ -1232,37 +1215,37 @@
   \ifcase#3 % 0
     \gre@dimen@temp@five=0pt\relax %
   \or % 1
-    \gre@dimen@temp@five=\gre@dimen@additionallineswidth\relax %
+    \gre@dimen@temp@five=\gre@space@dimen@additionallineswidth\relax %
   \or % 2
     \gre@dimen@temp@five=#4\relax %
   \fi %
   \ifcase#5 % 0
     \gre@dimen@temp@four=0pt\relax %
   \or % 1
-    \gre@dimen@temp@four=\gre@dimen@additionallineswidth\relax %
+    \gre@dimen@temp@four=\gre@space@dimen@additionallineswidth\relax %
   \or % 2
     \gre@dimen@temp@four=#6\relax %
   \fi %
   \gre@dimen@temp@two=%
     \dimexpr(#2 %
-    + \the\gre@dimen@temp@five %
-    + \the\gre@dimen@temp@four)\relax %
+    + \gre@dimen@temp@five %
+    + \gre@dimen@temp@four)\relax %
   \ifcase#1 % 0
     \gre@dimen@glyphraisevalue=%
-      \dimexpr(\the\gre@dimen@additionalbottomspace %
-      + \gre@dimen@spacebeneathtext %
-      + \gre@dimen@spacelinestext %
-      + \the\gre@dimen@currenttranslationheight %
+      \dimexpr(\gre@dimen@additionalbottomspace %
+      + \gre@space@dimen@spacebeneathtext %
+      + \gre@space@dimen@spacelinestext %
+      + \gre@dimen@currenttranslationheight %
       + \gre@stafflines\gre@dimen@interstafflinespace %
       + \gre@stafflines\gre@dimen@stafflineheight)\relax%
   \or % 1
     \gre@dimen@glyphraisevalue=%
-      \dimexpr(\the\gre@dimen@additionalbottomspace %
-      + \gre@dimen@spacebeneathtext %
-      + \gre@dimen@spacelinestext %
-      + \the\gre@dimen@currenttranslationheight %
-      - \the\gre@dimen@interstafflinespace %
-      - \the\gre@dimen@stafflineheight)\relax%
+      \dimexpr(\gre@dimen@additionalbottomspace %
+      + \gre@space@dimen@spacebeneathtext %
+      + \gre@space@dimen@spacelinestext %
+      + \gre@dimen@currenttranslationheight %
+      - \gre@dimen@interstafflinespace %
+      - \gre@dimen@stafflineheight)\relax%
   \fi %
   \raise\gre@dimen@glyphraisevalue\hbox to 0pt{%
     \kern-\gre@dimen@temp@five %
@@ -1517,7 +1500,7 @@
       \setbox\gre@box@temp@width=\hbox{\gre@font@music\gre@fontchar@punctummora}%
       \gre@skip@temp@four = -\wd\gre@box@temp@width %
       \kern\gre@skip@temp@four%
-      \gre@skip@temp@four = -\gre@skip@spacebeforesigns\relax%
+      \gre@skip@temp@four = -\gre@space@skip@spacebeforesigns\relax%
       \kern\gre@skip@temp@four %
     \fi %
   \fi %
@@ -1526,7 +1509,7 @@
   \GreNoBreak %
   \ifcase#1 % 0 : virgula
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1534,12 +1517,12 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPVirgula}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 1 : minima
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1547,12 +1530,12 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioMinima}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundsmallbar\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 2 : minor
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1560,12 +1543,12 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioMinor}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 3 : maior
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundmaior\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundmaior\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1573,12 +1556,12 @@
     \gre@fontchar@divisiomaior %
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundmaior\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundmaior\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 4 : finalis
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1586,12 +1569,12 @@
     #4\relax %
     \gre@fontchar@divisiofinalis%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 5 : finalis
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacebeforefinalfinalis\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacebeforefinalfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1599,7 +1582,7 @@
     #4\relax %
     \gre@fontchar@divisiofinalis%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundfinalis\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 6 : dominican bar 1
@@ -1607,7 +1590,7 @@
     % we need to adjust the height of the bar a little so that it is perfectly aligned with the bottom (or the top for some bars) of the staff line, which is not the case by default if \gre@stafflinefactor is not 10.
     \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1615,14 +1598,14 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 7 : dominican bar 2
     \gre@calculate@glyphraisevalue{\gre@pitch@e}{0}%
     \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1630,12 +1613,12 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 8 : dominican bar 3
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1644,12 +1627,12 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 9 : dominican bar 4
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1658,14 +1641,14 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 10 : dominican bar 5
     \gre@calculate@glyphraisevalue{\gre@pitch@i}{0}%
     \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1673,14 +1656,14 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 11 : dominican bar 6
     \gre@calculate@glyphraisevalue{\gre@pitch@i}{0}%
     \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1688,14 +1671,14 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 12 : dominican bar 7
     \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
     \advance\gre@dimen@glyphraisevalue by -\gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1703,14 +1686,14 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominican}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \or % 13 : dominican bar 8
     \gre@calculate@glyphraisevalue{\gre@pitch@k}{0}%
     \advance\gre@dimen@glyphraisevalue by \gre@dimen@stafflinediff\relax%
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
       \GreNoBreak %
     \fi %
@@ -1718,7 +1701,7 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\GreCPDivisioDominicanAlt}%
     #4\relax %
     \ifnum#2=1\relax %
-      \gre@skip@temp@four = \csname gre@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
+      \gre@skip@temp@four = \csname gre@space@skip@spacearoundminor\gre@bar@text{#3}\endcsname\relax%
       \gre@hskip\gre@skip@temp@four %
     \fi %
   \fi %
@@ -1735,10 +1718,10 @@
   \else %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPDivisioMaior}%
     % we calculate the raise of the bar
-    \gre@dimen@temp@five=\gre@dimen@additionalbottomspace\relax%
-    \advance\gre@dimen@temp@five by \gre@dimen@spacebeneathtext\relax%
-    \advance\gre@dimen@temp@five by \gre@dimen@spacelinestext\relax%
-    \advance\gre@dimen@temp@five by \gre@dimen@currenttranslationheight\relax%
+    \gre@dimen@temp@five=\dimexpr(\gre@dimen@additionalbottomspace %
+      + \gre@space@dimen@spacebeneathtext %
+      + \gre@space@dimen@spacelinestext %
+      + \gre@dimen@currenttranslationheight)\relax%
     % we calculate the height of the bar
     \raise\gre@dimen@temp@five\hbox{\vrule height \gre@dimen@staffheight width \wd\gre@box@temp@width}%
   \fi %
@@ -1748,9 +1731,7 @@
 \def\gre@fontchar@divisiofinalis{%
   \gre@calculate@glyphraisevalue{\gre@pitch@bar}{0}% bar glyphs are made to be at this height
   \gre@fontchar@divisiomaior %
-  \gre@dimen@temp@four = 12000 sp%
-  \multiply\gre@dimen@temp@four by \the\gre@factor%
-  \kern\gre@dimen@temp@four%
+  \kern\dimexpr(12000 sp * \gre@factor)%
   \GreNoBreak %
   \gre@fontchar@divisiomaior %
 }%
@@ -1763,7 +1744,7 @@
   \gre@localrightbox{}%
   %\gre@localleftbox{}
   \GreNoBreak %
-  \gre@skip@temp@four = \gre@skip@spacebeforefinalfinalis\relax%
+  \gre@skip@temp@four = \gre@space@skip@spacebeforefinalfinalis\relax%
   \gre@hskip\gre@skip@temp@four %
   \GreNoBreak %
   \GreBarSyllable{\GreSetThisSyllable{}{}{}{}{}}{}{}{1}{}{}{0}{\GreLastOfLine}{%
@@ -1887,14 +1868,13 @@
   \ifnum#4=0\relax %
     % we try to avoid line breaking after a flat or a natural
     \GreNoBreak %
-    \gre@skip@temp@four = \gre@dimen@alterationspace\relax%
+    \gre@skip@temp@four = \gre@space@dimen@alterationspace\relax%
     \ifgre@firstglyph%
       \gre@debugmsg{bolshift}{making adjustments for leading alteration}%
-      \global\advance\gre@dimen@notesaligncenter by \wd\gre@box@temp@width %
-      \global\advance\gre@dimen@notesaligncenter by \dimexpr\gre@skip@temp@four\relax %
+      \global\advance\gre@dimen@notesaligncenter by %
+        \dimexpr(\wd\gre@box@temp@width + \dimexpr\gre@skip@temp@four)\relax %
       \kern\gre@skip@temp@four %
-      \global\gre@dimen@bolextra = \wd\gre@box@temp@width%
-      \global\advance\gre@dimen@bolextra by \dimexpr\gre@skip@temp@four\relax%
+      \global\gre@dimen@bolextra = \dimexpr(\wd\gre@box@temp@width + \dimexpr\gre@skip@temp@four)\relax%
       \gre@debugmsg{bolshift}{bolextra: \the\gre@dimen@bolextra}%
     \else %
       \gre@hskip\gre@skip@temp@four %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1013,6 +1013,8 @@
 % This function converts a distance to the units indicated in #1 and returns it as a string.
 \def\gre@convertto#1#2{%
   \gre@debugmsg{general}{convertto (#1) (#2)}%
+  % \number\dimexpr returns the dimension in sp, so we must multiply #2 by
+  % 65536 (= 1pt in sp) before divding it by \number\dimexpr 1#1
   \edef\gre@converted{\gre@strip@pt\dimexpr#2*65536/\number\dimexpr 1#1\relax\relax #1}%
   \gre@debugmsg{general}{converted value is \gre@converted}%
 }%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1013,9 +1013,8 @@
 % This function converts a distance to the units indicated in #1 and returns it as a string.
 \def\gre@convertto#1#2{%
   \gre@debugmsg{general}{convertto (#1) (#2)}%
-  % \number\dimexpr returns the dimension in sp, so we must multiply #2 by
-  % 65536 (= 1pt in sp) before divding it by \number\dimexpr 1#1
-  \edef\gre@converted{\gre@strip@pt\dimexpr#2*65536/\number\dimexpr 1#1\relax\relax #1}%
+  % \p@ is equal to 1pt and is used here for a more accurate computation
+  \edef\gre@converted{\gre@strip@pt\dimexpr#2*\p@/\dimexpr 1#1\relax\relax #1}%
   \gre@debugmsg{general}{converted value is \gre@converted}%
 }%
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -749,17 +749,12 @@
 %This function sets the true raises of the two lines above the initial (it has to be called just as the boxes are placed in order to make sure that the values are all correct)
 \def\gre@calculate@annotationtrueraise{%
   \gre@debugmsg{annotation}{Calculating the raise.}%
-  \gre@debugmsg{annnotation}{Added staff height.}%
-  \gre@debugmsg{annnotation}{Added space beneath text.}%
-  \gre@debugmsg{annnotation}{Added translation height.}%
-  \gre@debugmsg{annnotation}{Added spacelinestext.}%
   \global\advance\gre@dimen@annotationtrueraise by %
     \dimexpr(\gre@dimen@staffheight %
     + \gre@space@dimen@spacebeneathtext %
     + \gre@dimen@currenttranslationheight %
     + \gre@space@dimen@spacelinestext %
     + \gre@dimen@additionalbottomspace)\relax%
-  \gre@debugmsg{annnotation}{Added additional bottom space.}%
   \gre@style@annotation%
   \global\advance\gre@dimen@annotationtrueraise by \gre@space@dimen@annotationraise\relax%
   \gre@debugmsg{annnotation}{Added user raise.}%
@@ -1015,20 +1010,11 @@
 }%
 
 
-% These functions are used for stripping out the units and decimal portion of a distance to make it more amenable to being used in the conversion function below
-{\catcode`p=12 \catcode`t=12 \gdef\gre@makein#1.#2pt{#1}}%
-{\catcode`p=12 \catcode`t=12 \gdef\gre@makenum#1pt{#1}}%
-
 % This function converts a distance to the units indicated in #1 and returns it as a string.
 \def\gre@convertto#1#2{%
   \gre@debugmsg{general}{convertto (#1) (#2)}%
-  \gre@debugmsg{ifdim}{ #2 = 0pt}%
-  \ifdim#2=0pt\relax%
-    \edef\gre@converted{0 #1}%
-  \else%
-    \edef\gre@converted{\expandafter\gre@makenum\the\dimexpr#2*65536/\number\dimexpr 1#1\relax\relax #1}%
-    \gre@debugmsg{general}{converted value is \gre@converted}%
-  \fi%
+  \edef\gre@converted{\gre@strip@pt\dimexpr#2*65536/\number\dimexpr 1#1\relax\relax #1}%
+  \gre@debugmsg{general}{converted value is \gre@converted}%
 }%
 
 % This function takes a distance (#2) and formats it as a string so that its units conform to the pattern set by a string representation of a distance (#1)

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -90,7 +90,7 @@
 % textlower is the height of the separation between the bottom line (which is invisible : for the notes which are very low) and the bottom of the text
 \newdimen\gre@dimen@textlower\relax%
 \def\gre@calculate@textlower{%
-  \gre@dimen@textlower=\gre@dimen@spacebeneathtext\relax%
+  \gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax%
   %\advance\gre@dimen@textlower by \translationheight
 }%
 
@@ -112,28 +112,27 @@
 % = 1500 * stafflinefactor
 \newdimen\gre@dimen@stafflineheight\relax%
 \def\gre@calculate@stafflineheight{%
-  \global\gre@dimen@stafflineheight=1500 sp%
-  \global\multiply\gre@dimen@stafflineheight by \gre@stafflinefactor\relax %
+  \global\gre@dimen@stafflineheight=\dimexpr(1500 sp * \gre@stafflinefactor)\relax %
 }%
 
 % interstafflinespace is the space between two lines of staff
 % = (30000 - (stafflineheight/gre@factor - 1500)) * gre@factor = 31500 * gre@factor - stafflineheight
 \newdimen\gre@dimen@interstafflinespace\relax%
 \def\gre@calculate@interstafflinespace{%
-  \global\gre@dimen@interstafflinespace=31500sp%
-  \global\multiply\gre@dimen@interstafflinespace by \gre@factor%
-  \global\advance\gre@dimen@interstafflinespace by -\gre@dimen@stafflineheight\relax%
+  \global\gre@dimen@interstafflinespace=\dimexpr((31500sp * \gre@factor) %
+    - \gre@dimen@stafflineheight)\relax%
 }%
 
 % a distance to help place glyphs when the lines are not their default thickness
 % = (stafflineheight/gre@factor - 1500sp)/2 * gre@factor
 \newdimen\gre@dimen@stafflinediff\relax%
 \def\gre@calculate@stafflinediff{%
-  \global\gre@dimen@stafflinediff = \gre@dimen@stafflineheight\relax%
-  \global\divide\gre@dimen@stafflinediff by \gre@factor\relax%
-  \global\advance\gre@dimen@stafflinediff by -1500sp%
-  \global\divide\gre@dimen@stafflinediff by 2\relax %
-  \global\multiply\gre@dimen@stafflinediff by \the\gre@factor %
+  \global\gre@dimen@stafflinediff = \dimexpr(%
+    ( ( ( \gre@dimen@stafflineheight %
+          / \gre@factor)%
+        - 1500sp)%
+      / 2)%
+    * \gre@factor)\relax%
 }%
 
 % the default factor
@@ -157,18 +156,17 @@
 \newdimen\gre@dimen@constantglyphraise\relax%
 % to calculate that, we take the bottom of the third line : it is at 200 in the fonts, and it must be at grespacelinestext + grespacebeneathtext + 2*greinterstafflinespace + 2*grestafflineheight + translationheight
 \def\gre@calculate@constantglyphraise{%
-  \global\gre@dimen@constantglyphraise = -22000 sp%
-  \global\multiply\gre@dimen@constantglyphraise by \the\gre@factor %
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@additionalbottomspace\relax%
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@spacebeneathtext\relax%
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@spacelinestext\relax%
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@interstafflinespace\relax%
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@interstafflinespace\relax%
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@stafflineheight\relax%
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@stafflineheight\relax%
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@currenttranslationheight\relax%
-  % an adjustment in the case of big lines
-  \global\advance\gre@dimen@constantglyphraise by \gre@dimen@stafflinediff\relax%
+  \global\gre@dimen@constantglyphraise = \dimexpr((-22000 sp * \gre@factor) %
+    + \gre@dimen@additionalbottomspace %
+    + \gre@space@dimen@spacebeneathtext %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@interstafflinespace %
+    + \gre@dimen@interstafflinespace %
+    + \gre@dimen@stafflineheight %
+    + \gre@dimen@stafflineheight %
+    + \gre@dimen@currenttranslationheight %
+    % an adjustment in the case of big lines
+    + \gre@dimen@stafflinediff)\relax%
   \relax %
 }%
 
@@ -179,8 +177,6 @@
     \gre@stafflines\gre@dimen@stafflineheight %
     + \gre@stafflines\gre@dimen@interstafflinespace %
     - \gre@dimen@interstafflinespace\relax%
-  %\global\multiply{\gre@dimen@spacebeneathtext} by \gre@factor % uncomment it if you want
-  % something else than 0
   \relax %
 }%
 
@@ -247,9 +243,9 @@
 %%  min_text_dist = prev_cur_word ? 0 : space_inter_words
   \ifnum#1=1\relax %
     \ifgre@in@euouae %
-      \gre@minTextDistance=\gre@skip@interwordspacetext@euouae\relax%
+      \gre@minTextDistance=\gre@space@skip@interwordspacetext@euouae\relax%
     \else %
-      \gre@minTextDistance=\gre@skip@interwordspacetext\relax%
+      \gre@minTextDistance=\gre@space@skip@interwordspacetext\relax%
     \fi %
   \else %
     \gre@minTextDistance=0pt\relax%
@@ -260,20 +256,20 @@
   \ifcase#2\relax %
     \ifnum#1=1\relax %
       \ifgre@in@euouae %
-        \gre@minNotesDistance=\gre@skip@interwordspacenotes@euouae\relax%
+        \gre@minNotesDistance=\gre@space@skip@interwordspacenotes@euouae\relax%
       \else %
-        \gre@minNotesDistance=\gre@skip@interwordspacenotes\relax%
+        \gre@minNotesDistance=\gre@space@skip@interwordspacenotes\relax%
       \fi %
     \else %
-      \gre@minNotesDistance=\gre@skip@intersyllablespacenotes\relax%
+      \gre@minNotesDistance=\gre@space@skip@intersyllablespacenotes\relax%
     \fi %
   \or %
-    \gre@minNotesDistance=\gre@skip@notebarspace\relax%
+    \gre@minNotesDistance=\gre@space@skip@notebarspace\relax%
   \or %
     \ifnum#1=1\relax %
-      \gre@minNotesDistance=\gre@skip@interwordspacenotes@alteration\relax %
+      \gre@minNotesDistance=\gre@space@skip@interwordspacenotes@alteration\relax %
     \else %
-      \gre@minNotesDistance=\gre@skip@intersyllablespacenotes@alteration\relax%
+      \gre@minNotesDistance=\gre@space@skip@intersyllablespacenotes@alteration\relax%
     \fi %
   \fi %
   \gre@debugmsg{syllablespacing}{ minNotesDistance = \the\gre@minNotesDistance}%
@@ -307,10 +303,8 @@
 %%  min_shift_text = min_dist_text - cur_dist_text
 %%  min_shift_notes = min_dist_notes - cur_dist_notes
 %%  shift = max(min_shift_text, min_shift_notes)
-  \gre@minShiftText = \gre@minTextDistance %
-  \advance\gre@minShiftText by - \gre@curTextDistance %
-  \gre@minShiftNotes = \gre@minNotesDistance %
-  \advance\gre@minShiftNotes by - \gre@curNotesDistance %
+  \gre@minShiftText = \glueexpr(\gre@minTextDistance - \gre@curTextDistance)\relax %
+  \gre@minShiftNotes = \glueexpr(\gre@minNotesDistance - \gre@curNotesDistance)\relax %
   \gre@debugmsg{syllablespacing}{ minShiftNotes = \the\gre@minShiftNotes}%
   \gre@debugmsg{syllablespacing}{ minShiftText = \the\gre@minShiftText}%
   \ifdim\gre@minShiftNotes < \gre@minShiftText %
@@ -339,8 +333,7 @@
   % bolextra is the space taken up by a leading alteration (it's 0 if there is no leading alteration)
   % it's allowed to invade spaceafterlineclef, so long as it leaves at least beforealterationspace between itself and the clef
   % and minimalspaceatlinebeginning between the lyrics and the beginning of the line
-  \gre@skip@temp@one = \gre@skip@spaceafterlineclef\relax%
-  \advance\gre@skip@temp@one by -\gre@dimen@beforealterationspace\relax%
+  \gre@skip@temp@one = \glueexpr(\gre@space@skip@spaceafterlineclef-\gre@space@dimen@beforealterationspace)\relax%
   \ifdim\gre@dimen@bolextra>\gre@skip@temp@one\relax%
     \global\advance\gre@skip@temp@three by \gre@skip@temp@one\relax%
   \else%
@@ -357,13 +350,13 @@
     % we don't want to kern more than clefwidth + spaceafterlineclef - minimalspaceatlinebeginning
     % violating this would mean that either the notes are closer than (clefwidth + spaceafterlineclef)
     % or that the lyrics are closer than minimalspaceatlinebeginning
-    \gre@skip@temp@one = \gre@dimen@clefwidth\relax%
-    \advance\gre@skip@temp@one by \gre@skip@spaceafterlineclef\relax%
-    \advance\gre@skip@temp@one by -\gre@dimen@minimalspaceatlinebeginning\relax%
+    \gre@skip@temp@one = \glueexpr(\gre@dimen@clefwidth %
+      + \gre@space@skip@spaceafterlineclef %
+      - \gre@space@dimen@minimalspaceatlinebeginning)\relax %
     \ifdim\gre@skip@temp@three < \gre@skip@temp@one %
-      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@three\relax%
+      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@three\relax %
     \else%
-      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@one\relax%
+      \global\gre@dimen@bolshift = \dimexpr\gre@skip@temp@one\relax %
     \fi %
   \fi%
   \gre@debugmsg{bolshift}{ bolshift = \the\gre@dimen@bolshift}%
@@ -393,8 +386,8 @@
       % Were the eolshift larger than this the lyrics would stick out
       % into the margin
       \setbox\gre@box@temp@width=\hbox{\gre@pickcustos{\gre@pitch@g}}%
-      \global\advance\gre@skip@temp@three by \wd\gre@box@temp@width %
-      \global\advance\gre@skip@temp@three by \gre@skip@spacebeforeeolcustos \relax%
+      \global\advance\gre@skip@temp@three by %
+        \glueexpr(\wd\gre@box@temp@width+\gre@space@skip@spacebeforeeolcustos)\relax%
       % pick the smaller of the two values calculated above
       \ifdim\gre@skip@temp@two>\gre@skip@temp@three%
         \gre@debugmsg{eolshift}{imposing limit}%
@@ -414,9 +407,6 @@
 
 % glyphraisevalue is the value of which we must raise one glyph (that will vary with every glyph)
 \newdimen\gre@dimen@glyphraisevalue\relax%
-
-% addedraisevalue is for the vertical episema and the puncta
-\newdimen\gre@dimen@addedraisevalue\relax%
 
 \newif\ifgre@useledgerlineheuristic%
 \gre@useledgerlineheuristictrue%
@@ -564,83 +554,60 @@
     \fi%
   \fi%
   \global\advance\gre@count@temp@three by -8 %
-  \global\gre@dimen@glyphraisevalue = 15750 sp %
-  \global\multiply\gre@dimen@glyphraisevalue by \the\gre@factor %
-  \global\multiply\gre@dimen@glyphraisevalue by \the\gre@count@temp@three %
-  \gre@dimen@addedraisevalue= 0 sp%
+  \global\gre@dimen@glyphraisevalue = \dimexpr(15750 sp * \gre@factor * \gre@count@temp@three)\relax %
   \ifcase#2 %
   \or\or\or%3: if it is a vertical episema on a line, we shift it a bit higher, so that it's more beautiful
     \ifgre@isonaline%
-      \gre@dimen@addedraisevalue=7250 sp%
-      \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-      \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(7250 sp * \gre@factor)\relax %
     \else % if it is not on a line, we shift it a bit lower
-      \gre@dimen@addedraisevalue=-1380 sp%
-      \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-      \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(-1380 sp * \gre@factor)\relax %
     \fi %
   \or% 4: if it is a punctum mora on a line, we shift it a bit lower, for the same reason
     \ifgre@isonaline%
-      \gre@dimen@addedraisevalue=-6900 sp%
-      \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-      \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(-6900 sp * \gre@factor)\relax %
     \else %
-      \gre@dimen@addedraisevalue=-2200 sp%
-      \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-      \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(-2200 sp * \gre@factor)\relax %
     \fi%
   \or% 5: if it is a horizontal episema under a note which is on a line, we shift it lower
     \ifgre@isonaline% if it is under a note between two lines, we shift it higher
-      \gre@dimen@addedraisevalue=4000 sp%
-      \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-      \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(4000 sp * \gre@factor)\relax %
     \else %
-      \gre@dimen@addedraisevalue=-4980 sp%
-      \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-      \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(-4980 sp * \gre@factor)\relax %
     \fi %
   \or% 6: if it is a sign, we put it at an arbitrary height
-    \gre@dimen@addedraisevalue=20000 sp%
-    \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-    \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+    \global\advance\gre@dimen@glyphraisevalue by \dimexpr(20000 sp * \gre@factor)\relax %
   \or\or% 8: if it is a punctum mora on a line, we shift it a bit lower, for the same reason
     \ifgre@isonaline%
-      \gre@dimen@addedraisevalue=5000 sp%
-      \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-      \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(5000 sp * \gre@factor)\relax %
     \fi %
   \or% 9: if it is an horizontal episema not on a line, we put it a bit lower
     \ifgre@isonaline%
-      \gre@dimen@addedraisevalue=-5500 sp%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(-5500 sp * \gre@factor)\relax %
     \else %
-      \gre@dimen@addedraisevalue=3000 sp%
+      \global\advance\gre@dimen@glyphraisevalue by \dimexpr(3000 sp * \gre@factor)\relax %
     \fi %
-    \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-    \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
   \or% 10: low choral sign that is not lower than the note
-    \global\advance\gre@dimen@glyphraisevalue by -\gre@dimen@choralsigndownshift\relax%
+    \global\advance\gre@dimen@glyphraisevalue by -\gre@space@dimen@choralsigndownshift\relax%
   \or% 11: high choral sign
     \ifgre@isonaline%
-      \global\advance\gre@dimen@glyphraisevalue by \gre@dimen@choralsignupshift\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \gre@space@dimen@choralsignupshift\relax%
     \else %
-      \global\advance\gre@dimen@glyphraisevalue by -\gre@dimen@choralsigndownshift\relax%
+      \global\advance\gre@dimen@glyphraisevalue by -\gre@space@dimen@choralsigndownshift\relax%
     \fi %
   \or% 12: low choral sign that is lower than the note
     \ifgre@isonaline%
-      \global\advance\gre@dimen@glyphraisevalue by \gre@dimen@choralsignupshift\relax%
+      \global\advance\gre@dimen@glyphraisevalue by \gre@space@dimen@choralsignupshift\relax%
     \else %
-      \global\advance\gre@dimen@glyphraisevalue by -\gre@dimen@choralsigndownshift\relax%
+      \global\advance\gre@dimen@glyphraisevalue by -\gre@space@dimen@choralsigndownshift\relax%
     \fi %
   \or% 13: if it is the brace above the bars, we shift it to a user-defined value
-      \global\advance\gre@dimen@glyphraisevalue by -\gre@dimen@braceshift\relax%
+      \global\advance\gre@dimen@glyphraisevalue by -\gre@space@dimen@braceshift\relax%
   \or% 14: raise the punctum mora in a space a bit higher than case 4
-    \gre@dimen@addedraisevalue=200 sp%
-    \multiply\gre@dimen@addedraisevalue by \the\gre@factor %
-    \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@addedraisevalue\relax%
+    \global\advance\gre@dimen@glyphraisevalue by \dimexpr(200 sp * \gre@factor)\relax%
   \or% 15: over slur
-    \global\advance\gre@dimen@glyphraisevalue by \gre@dimen@overslurshift\relax%
+    \global\advance\gre@dimen@glyphraisevalue by \gre@space@dimen@overslurshift\relax%
   \or% 16: under slur
-    \global\advance\gre@dimen@glyphraisevalue by \gre@dimen@underslurshift\relax%
+    \global\advance\gre@dimen@glyphraisevalue by \gre@space@dimen@underslurshift\relax%
   \fi%
   \global\advance\gre@dimen@glyphraisevalue by \the\gre@dimen@constantglyphraise\relax%
 }%
@@ -655,22 +622,15 @@
 % #4 is if 1 if we have space above the staff
 \def\gre@calculate@additionalspaces#1#2#3#4{%
   \gre@debugmsg{lineheight}{gre@calculate@additional@spaces called with #1 #2 #3 #4}%
-  \gre@count@temp@one=#1\relax %
-  \advance\gre@count@temp@one by -\gre@pitch@adjust@top\relax %
+  \gre@count@temp@one=\numexpr(#1 - \gre@pitch@adjust@top)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionaltopspace=15000 sp%
-    \global\multiply\gre@dimen@additionaltopspace by \the\gre@count@temp@one %
-    \global\multiply\gre@dimen@additionaltopspace by \the\gre@factor %
+    \global\gre@dimen@additionaltopspace=\dimexpr(15000 sp * \gre@count@temp@one * \gre@factor)\relax %
   \else %
     \global\gre@dimen@additionaltopspace=0 sp%
   \fi %
-  \gre@count@temp@one=#2\relax %
-  \advance\gre@count@temp@one by -\gre@pitch@adjust@bottom\relax %
-  \multiply\gre@count@temp@one by -1\relax %
+  \gre@count@temp@one=\numexpr((#2 - \gre@pitch@adjust@bottom) * -1)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionalbottomspace=15000 sp%
-    \global\multiply\gre@dimen@additionalbottomspace by \the\gre@count@temp@one %
-    \global\multiply\gre@dimen@additionalbottomspace by \the\gre@factor %
+    \global\gre@dimen@additionalbottomspace=\dimexpr(15000 sp * \gre@count@temp@one * \gre@factor)\relax %
   \else %
     \global\gre@dimen@additionalbottomspace=0 sp%
   \fi %
@@ -731,10 +691,7 @@
   \ifcase#5\or %
     \global\gre@dimen@previousenddifference=\the\gre@dimen@enddifference\relax%
   \fi %
-  \global\gre@dimen@enddifference=#1%
-  \global\advance\gre@dimen@enddifference by -#2%
-  \global\advance\gre@dimen@enddifference by #3%
-  \global\advance\gre@dimen@enddifference by -#4%
+  \global\gre@dimen@enddifference=\dimexpr(#1 - #2 + #3 - #4)\relax%
   \relax%
 }%
 
@@ -744,9 +701,9 @@
 % macro to tell gregorio to set space for the translation
 \def\gre@addtranslationspace{%
   \gre@style@translation%
-  \global\gre@dimen@currenttranslationheight=\gre@dimen@translationheight\relax%
-  \global\gre@dimen@textlower=\gre@dimen@spacebeneathtext\relax%
-  \global\advance\gre@dimen@textlower by \gre@dimen@translationheight\relax%
+  \global\gre@dimen@currenttranslationheight=\gre@space@dimen@translationheight\relax%
+  \global\gre@dimen@textlower=\dimexpr(\gre@space@dimen@spacebeneathtext %
+    + \gre@space@dimen@translationheight)\relax%
   \gre@generatelines %
   \gre@calculate@constantglyphraise %
   \endgre@style@translation%
@@ -759,7 +716,7 @@
 
 \def\gre@removetranslationspace{%
   \global\gre@dimen@currenttranslationheight=0 sp%
-  \global\gre@dimen@textlower=\gre@dimen@spacebeneathtext\relax%
+  \global\gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax%
   \gre@generatelines %
   \gre@calculate@constantglyphraise %
   \relax %
@@ -792,18 +749,19 @@
 %This function sets the true raises of the two lines above the initial (it has to be called just as the boxes are placed in order to make sure that the values are all correct)
 \def\gre@calculate@annotationtrueraise{%
   \gre@debugmsg{annotation}{Calculating the raise.}%
-  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@staffheight\relax%
   \gre@debugmsg{annnotation}{Added staff height.}%
-  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@spacebeneathtext\relax%
   \gre@debugmsg{annnotation}{Added space beneath text.}%
-  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@currenttranslationheight\relax%
   \gre@debugmsg{annnotation}{Added translation height.}%
-  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@spacelinestext\relax%
   \gre@debugmsg{annnotation}{Added spacelinestext.}%
-  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@additionalbottomspace\relax%
+  \global\advance\gre@dimen@annotationtrueraise by %
+    \dimexpr(\gre@dimen@staffheight %
+    + \gre@space@dimen@spacebeneathtext %
+    + \gre@dimen@currenttranslationheight %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@additionalbottomspace)\relax%
   \gre@debugmsg{annnotation}{Added additional bottom space.}%
   \gre@style@annotation%
-  \global\advance\gre@dimen@annotationtrueraise by \gre@dimen@annotationraise\relax%
+  \global\advance\gre@dimen@annotationtrueraise by \gre@space@dimen@annotationraise\relax%
   \gre@debugmsg{annnotation}{Added user raise.}%
   \endgre@style@annotation%
   \relax %
@@ -815,7 +773,13 @@
 \def\gre@calculate@commentarytrueraise{%
   \gre@style@commentary%
   \gre@debugmsg{commentary}{Calculating the raise.}%
-  \global\advance\gre@dimen@commentarytrueraise by \dimexpr\gre@dimen@staffheight + \gre@dimen@spacebeneathtext + \gre@dimen@currenttranslationheight + \gre@dimen@spacelinestext +  \gre@dimen@additionalbottomspace + \gre@dimen@commentaryraise\relax%
+  \global\advance\gre@dimen@commentarytrueraise by %
+    \dimexpr(\gre@dimen@staffheight %
+    + \gre@space@dimen@spacebeneathtext %
+    + \gre@dimen@currenttranslationheight %
+    + \gre@space@dimen@spacelinestext %
+    + \gre@dimen@additionalbottomspace %
+    + \gre@space@dimen@commentaryraise)\relax%
   \endgre@style@commentary%
 }%
 
@@ -904,7 +868,7 @@
     \gre@debugmsg{spacing}{Changing a dimen.}%
     \def\gre@prefix{dimen}%
   \fi%
-  \ifcsname gre@\gre@prefix @#1\endcsname%
+  \ifcsname gre@space@\gre@prefix @#1\endcsname%
     \gre@debugmsg{spacing}{It does exist.}%
     \gre@dimension{#1}{#2}%
     \IfStrEq{#3}{1}%
@@ -942,7 +906,7 @@
       \def\gre@prefix{dimen}%
     \fi%
   \fi%
-  \expandafter\edef\csname gre@\gre@prefix @#1\endcsname{#2}%
+  \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{#2}%
   \relax %
 }
 
@@ -1032,22 +996,19 @@
 
 %% an aux function adapting the value #1 from the factor #2 to the factor #3
 \def\gre@changeonedimenfactor#1#2#3{%
-  \gre@rubberpermit{#1}%
-  \ifgre@rubber% if we have a rubber allowed length we create a temporary skip
-    \let\gre@scaledist\gre@skip@temp@one%
-  \else% otherwise we create a temporary dimen
-    \let\gre@scaledist\gre@dimen@temp@one%
-  \fi%
   % Math
   \gre@rubberpermit{#1}%
   \ifgre@rubber%
-    \edef\gre@convert{\csname gre@skip@#1\endcsname}%
+    % if we have a rubber allowed length we create a temporary skip
+    \let\gre@scaledist\gre@skip@temp@one%
+    \edef\gre@convert{\csname gre@space@skip@#1\endcsname}%
+    \gre@scaledist=\glueexpr(\gre@convert * \number#3 / \number#2)\relax %
   \else%
-    \edef\gre@convert{\csname gre@dimen@#1\endcsname}%
+    % otherwise we create a temporary dimen
+    \let\gre@scaledist\gre@dimen@temp@one%
+    \edef\gre@convert{\csname gre@space@dimen@#1\endcsname}%
+    \gre@scaledist=\dimexpr(\gre@convert * \number#3 / \number#2)\relax %
   \fi%
-  \gre@scaledist=\gre@convert%
-  \multiply \gre@scaledist by \number #3%
-  \divide \gre@scaledist by \number #2%
   \gre@consistentunits{\gre@convert}{\gre@scaledist}%
   \gre@dimension{#1}{\gre@stringdist}%
   \relax %
@@ -1059,45 +1020,14 @@
 {\catcode`p=12 \catcode`t=12 \gdef\gre@makenum#1pt{#1}}%
 
 % This function converts a distance to the units indicated in #1 and returns it as a string.
-\newdimen\gre@unit%
-\newdimen\gre@base%
-\newdimen\gre@maxlen%
-\newcount\gre@unitfactor%
-\newcount\gre@basefactor%
 \def\gre@convertto#1#2{%
   \gre@debugmsg{general}{convertto (#1) (#2)}%
   \gre@debugmsg{ifdim}{ #2 = 0pt}%
   \ifdim#2=0pt\relax%
     \edef\gre@converted{0 #1}%
   \else%
-    \gre@unit = 1 #1%
-    \gre@base = #2%
-    % Code to increase precision
-    \gre@maxlen = 16383.99999pt\relax%
-    \gre@unitfactor = \number\gre@maxlen%
-    \divide\gre@unitfactor by \number\gre@unit\relax%
-    \ifnum\gre@unitfactor < 0\relax%
-      \gre@unitfactor = -\gre@unitfactor%
-    \fi%
-    \gre@debugmsg{spacing}{unit: \the\gre@unit ; factor: \the\gre@unitfactor}%
-    \gre@basefactor = \number\gre@maxlen%
-    \divide\gre@basefactor by \number\gre@base\relax%
-    \ifnum\gre@basefactor < 0\relax%
-      \gre@basefactor = -\gre@basefactor%
-    \fi%
-    \gre@debugmsg{spacing}{base: \the\gre@base ; factor: \the\gre@basefactor}%
-    \ifnum\gre@basefactor<\gre@unitfactor%
-      \multiply\gre@unit by \gre@basefactor%
-      \multiply\gre@base by \gre@basefactor%
-    \else%
-      \multiply\gre@unit by \gre@unitfactor%
-      \multiply\gre@base by \gre@unitfactor%
-    \fi%
-    \gre@count@temp@one = \expandafter\gre@makein\the\gre@unit%
-    \divide\gre@base by \gre@count@temp@one%
-    \edef\gre@converted{%
-      \expandafter\gre@makenum\the\gre@base #1%
-    }%
+    \edef\gre@converted{\expandafter\gre@makenum\the\dimexpr#2*65536/\number\dimexpr 1#1\relax\relax #1}%
+    \gre@debugmsg{general}{converted value is \gre@converted}%
   \fi%
 }%
 
@@ -1371,9 +1301,7 @@
     \gre@changeonedimenfactor{curlybraceaccentusshift}{#1}{#2}%
   \fi%
   \ifgre@scale@stafflinefactor%
-    \gre@count@temp@two = \gre@stafflinefactor%
-    \multiply\gre@count@temp@two by #2\relax%
-    \divide\gre@count@temp@two by #1\relax%
+    \gre@count@temp@two = \numexpr((\gre@stafflinefactor * #2) / #1)\relax%
     \xdef\gre@stafflinefactor{\the\gre@count@temp@two}%
   \fi%
   \relax %

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -217,9 +217,9 @@
 % if wd(#1/2) > \gre@dimen@textaligncenter then #2
 % else
 %   if lyrics are centered on syllables :
-%     if (\gre@dimen@textaligncenter) > \gre@dimen@clivisalignmentmin -> #2 else #1
+%     if (\gre@dimen@textaligncenter) > \gre@space@dimen@clivisalignmentmin -> #2 else #1
 %   else:
-%     if wd(\gre@endsyllablepart) > \gre@dimen@clivisalignmentmin -> #2 else #1
+%     if wd(\gre@endsyllablepart) > \gre@space@dimen@clivisalignmentmin -> #2 else #1
 %
 % #3 is the same as #2 of previous function
 \def\gre@handleclivisspecialalignment#1#2#3{%
@@ -236,7 +236,7 @@
     \else%
       \ifcase\gre@lyriccentering% 0 == syllable centering
         \gre@debugmsg{ifdim}{ textaligncenter > clivisalignmentmin}%
-        \ifdim\gre@dimen@textaligncenter >\gre@dimen@clivisalignmentmin\relax%
+        \ifdim\gre@dimen@textaligncenter >\gre@space@dimen@clivisalignmentmin\relax%
           \global\setbox\gre@box@temp@width=\hbox{#2}%
         \else%
           \global\setbox\gre@box@temp@width=\hbox{#1}%
@@ -248,7 +248,7 @@
           \gre@widthof{\gre@nextendsyllablepart}%
         \fi%
         \gre@debugmsg{ifdim}{ temp@three > clivisalignmentmin}%
-        \ifdim\gre@dimen@temp@three >\gre@dimen@clivisalignmentmin\relax%
+        \ifdim\gre@dimen@temp@three >\gre@space@dimen@clivisalignmentmin\relax%
           \global\setbox\gre@box@temp@width=\hbox{#2}%
         \else%
           \global\setbox\gre@box@temp@width=\hbox{#1}%
@@ -262,9 +262,7 @@
 % warning: the behaviour of all this is quite difficult to understand: this function is called with simple arguments (between 0 and 20) by the glyph function. In this case we add the align center of the argument to notesaligncenter ; and notesaligncenter can be already set to something by flat and natural.
 \def\gre@calculate@notesaligncenter#1{%
   \gre@calculate@simplenotesaligncenter{#1}{0}%
-  \gre@dimen@temp@five=\wd\gre@box@temp@width %
-  \divide\gre@dimen@temp@five by 2\relax %
-  \global\advance\gre@dimen@notesaligncenter by \gre@dimen@temp@five %
+  \global\advance\gre@dimen@notesaligncenter by \dimexpr(\wd\gre@box@temp@width / 2)\relax %
   \relax %
 }%
 
@@ -272,34 +270,29 @@
 \def\gre@calculate@nextnotesaligncenter#1{%
   \ifnum#1<20\relax %
     \gre@calculate@simplenotesaligncenter{#1}{1}%
-    \gre@dimen@temp@five=\wd\gre@box@temp@width %
-    \divide\gre@dimen@temp@five by 2\relax %
+    \gre@dimen@temp@five=\dimexpr(\wd\gre@box@temp@width / 2)\relax %
     \global\gre@dimen@notesaligncenter=\gre@dimen@temp@five %
   \else %\ifnum#1<20
     \gre@count@temp@three=#1 %
     \ifnum#1<40\relax%
       \advance\gre@count@temp@three by -20\relax %
       \gre@calculate@simplenotesaligncenter{\gre@count@temp@three}{1}%
-      \gre@dimen@temp@five=\wd\gre@box@temp@width %
-      \divide\gre@dimen@temp@five by 2\relax %
+      \gre@dimen@temp@five=\dimexpr(\wd\gre@box@temp@width / 2)\relax %
       \setbox\gre@box@temp@width=\hbox{\gre@fontchar@flat}%
     \else%\ifnum#1<40
       \ifnum#1<60\relax%
         \advance\gre@count@temp@three by -40\relax %
         \gre@calculate@simplenotesaligncenter{\gre@count@temp@three}{1}%
-        \gre@dimen@temp@five=\wd\gre@box@temp@width %
-        \divide\gre@dimen@temp@five by 2\relax %
+        \gre@dimen@temp@five=\dimexpr(\wd\gre@box@temp@width / 2)\relax %
         \setbox\gre@box@temp@width=\hbox{\gre@fontchar@natural}%
       \else%\ifnum#1<60
         \advance\gre@count@temp@three by -60\relax %
         \gre@calculate@simplenotesaligncenter{\gre@count@temp@three}{1}%
-        \gre@dimen@temp@five=\wd\gre@box@temp@width %
-        \divide\gre@dimen@temp@five by 2\relax %
+        \gre@dimen@temp@five=\dimexpr(\wd\gre@box@temp@width / 2)\relax %
         \setbox\gre@box@temp@width=\hbox{\gre@fontchar@sharp}%
       \fi%
     \fi %
-    \advance\gre@dimen@temp@five by \wd\gre@box@temp@width %
-    \advance\gre@dimen@temp@five by \gre@dimen@alterationspace %
+    \advance\gre@dimen@temp@five by \dimexpr(\wd\gre@box@temp@width+\gre@space@dimen@alterationspace)\relax %
     \global\gre@dimen@notesaligncenter=\gre@dimen@temp@five %
   \fi %
   \relax %
@@ -491,7 +484,7 @@
 %% 1. never align clivis this way, align on first punctum
 %% 2. align clivis this way, except if:
 %%    - notes would go left of text
-%%   - consonants after vowels are larger than \gre@dimen@clivisalignmentmin
+%%   - consonants after vowels are larger than \gre@space@dimen@clivisalignmentmin
 \newcount\gre@clivisalignment%
 %% by default we use the mode 2, it seems closest to Solesmes books
 \gre@clivisalignment=2%
@@ -567,8 +560,7 @@
   \gre@calculate@textaligncenter{\gre@firstsyllablepart}{\gre@middlesyllablepart}{0}% we first get the width between the alignment point and the end of the syllable
   \gre@syllablenotes{#9}% we put the notes in a box, so that we have the width of it
   % now we calculate the begin difference, that is to say \gre@dimen@notesaligncenter - \gre@dimen@textaligncenter
-  \gre@dimen@begindifference=\gre@dimen@notesaligncenter\relax%
-  \advance\gre@dimen@begindifference by -\gre@dimen@textaligncenter\relax%
+  \gre@dimen@begindifference=\dimexpr(\gre@dimen@notesaligncenter - \gre@dimen@textaligncenter)\relax %
   % Now, let's go for something I took years to figure out: we want to align
   % scores on the notes (see https://github.com/gregorio-project/gregorio/issues/221)
   % but it means we have to shift lines starting by text by \gre@dimen@bolshift
@@ -640,10 +632,10 @@
       \advance\gre@skip@temp@one by \gre@skip@nextbegindifference\relax%
     \fi %
     %
-    % then we compare it with \gre@dimen@maximumspacewithoutdash, if it is larger, we add a dash
+    % then we compare it with \gre@space@dimen@maximumspacewithoutdash, if it is larger, we add a dash
     %
     \gre@debugmsg{ifdim}{ temp@skip@one > maximumspacewithoutdash}%
-    \ifdim\gre@skip@temp@one > \gre@dimen@maximumspacewithoutdash\relax%
+    \ifdim\gre@skip@temp@one > \gre@space@dimen@maximumspacewithoutdash\relax%
       \gre@debugmsg{hyphen}{spacing requires hyphen}%
       \gre@showhyphenafterthissyllabletrue%
     \fi %
@@ -803,10 +795,8 @@
   \gre@debugmsg{spacing}{Width of bar text: \the\wd\gre@box@syllabletext}%
   \gre@syllablenotes{#9}%
   \gre@debugmsg{spacing}{Width of bar line: \the\wd\gre@box@syllablenotes}%
-  \gre@dimen@notesaligncenter=\wd\gre@box@syllablenotes%
-  \divide\gre@dimen@notesaligncenter by 2\relax %
-  \gre@dimen@begindifference=\gre@dimen@notesaligncenter\relax%
-  \advance\gre@dimen@begindifference by -\gre@dimen@textaligncenter\relax%
+  \gre@dimen@notesaligncenter=\dimexpr(\wd\gre@box@syllablenotes / 2)\relax %
+  \gre@dimen@begindifference=\dimexpr(\gre@dimen@notesaligncenter - \gre@dimen@textaligncenter)\relax%
   \gre@calculate@enddifference{\wd\gre@box@syllablenotes}{\wd\gre@box@syllabletext}{\gre@dimen@textaligncenter}{\gre@dimen@notesaligncenter}{1}%
   #5%
   \gre@calculate@nextbegindifference{\gre@nextfirstsyllablepart}{\gre@nextmiddlesyllablepart}{\gre@nextendsyllablepart}{#7}%
@@ -818,9 +808,9 @@
     % first we need to determine the real space that there will be between the notes. Here again it is not so simple... let's consider these two kinds of spaces :
     %% 1/ the minimal space between a note and the bar + the width of the bar + the minimal space between the bar and the note (that's the global idea, in fact there are nuances) : we assign skip@temp@three to it
     %% 2/ enddifference + begindifference + space between notes and word : we assign skip@temp@two to it
-    \gre@skip@temp@three=\gre@skip@notebarspace\relax%
-    \advance\gre@skip@temp@three by \gre@skip@notebarspace\relax%
-    \advance\gre@skip@temp@three by \wd\gre@box@syllablenotes %
+    \gre@skip@temp@three=\glueexpr(\gre@space@skip@notebarspace %
+      + \gre@space@skip@notebarspace %
+      + \wd\gre@box@syllablenotes)\relax %
     % now let's get skip@temp@two
     \gre@debugmsg{ifdim}{ nextbegindifference < 0pt}%
     \ifdim\gre@skip@nextbegindifference < 0 pt\relax%
@@ -830,10 +820,11 @@
     \fi %
     \gre@debugmsg{ifdim}{ previousenddifference < 0pt}%
     \ifdim\gre@dimen@previousenddifference < 0 pt\relax%
-      \advance\gre@skip@temp@two by -\gre@dimen@previousenddifference\relax%
-      \advance\gre@skip@temp@two by \gre@skip@interwordspacetext\relax%
+      \advance\gre@skip@temp@two by %
+        \glueexpr(-\gre@dimen@previousenddifference %
+        + \gre@space@skip@interwordspacetext)\relax%
     \else %
-      \advance\gre@skip@temp@two by \gre@skip@interwordspacenotes\relax%
+      \advance\gre@skip@temp@two by \gre@space@skip@interwordspacenotes\relax%
     \fi%
     % we take the max of it, then we divide it by two and we substract half of the width of the bar
     \gre@debugmsg{ifdim}{ temp@skip@three < temp@skip@two}%
@@ -841,9 +832,7 @@
       \gre@skip@temp@three=\gre@skip@temp@two %
     \fi %
     \divide\gre@skip@temp@three by 2\relax %
-    \gre@dimen@temp@five=\wd\gre@box@syllablenotes %
-    \divide\gre@dimen@temp@five by 2\relax %
-    \advance\gre@skip@temp@three by -\gre@dimen@temp@five %
+    \advance\gre@skip@temp@three by \dimexpr(\wd\gre@box@syllablenotes / -2)\relax %
     % now we have our skipone
     \gre@skip@temp@two=\gre@skip@temp@three %
     \gre@debugmsg{ifdim}{ previousenddifference < 0pt}%
@@ -875,10 +864,10 @@
       \ifdim\gre@skip@temp@two < -\wd\gre@box@syllablenotes %
         \gre@debugmsg{ifdim}{ nextbegindifference > 0pt}%
         \ifdim\gre@skip@nextbegindifference > 0 pt\relax%
-          \gre@skip@temp@one = \gre@skip@interwordspacetext\relax%
+          \gre@skip@temp@one = \gre@space@skip@interwordspacetext\relax%
           \gre@hskip\gre@skip@temp@one %
         \else % \ifdim\gre@skip@nextbegindifference > 0 pt
-          \gre@skip@temp@one = \gre@skip@interwordspacetext\relax%
+          \gre@skip@temp@one = \gre@space@skip@interwordspacetext\relax%
           \gre@hskip\gre@skip@temp@one %
         \fi %
       \else %

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -48,6 +48,8 @@
 \SetupKeyvalOptions{prefix=gre@}
 \DeclareStringOption{debug}[all]
 
+\let\gre@strip@pt\strip@pt
+
 \long\def\gre@iflatex#1{#1}
 \input gregoriotex-main.tex
 

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -79,6 +79,15 @@
   \endmplibcode%
 }}%
 
+%% This is \strip@pt from LaTeX
+\begingroup%
+  \catcode`P=12%
+  \catcode`T=12%
+  \lowercase{%
+    \def\x{\def\gre@rem@pt##1.##2PT{##1\ifnum##2>\z@.##2\fi}}}%
+  \expandafter\endgroup\x%
+\def\gre@strip@pt{\expandafter\gre@rem@pt\the}%
+
 \long\def\gre@iflatex#1{}%
 \input gregoriotex-main.tex
 


### PR DESCRIPTION
Fixes #739 and #787.

For `\advance`, `\multiply`, and `\divide`, I left macros which do not do their computation in one place.

Some of the tests were actually using the `@dimen` macros for demonstration purposes, so I updated those.  There were also some very slight output differences because (I suppose) the e-TeX directives round rather than truncate; these I have accepted.

Please review and merge if satisfactory.