### PR TITLE
Added support for ad hoc enabling/disabling custos at forced line breaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - More control over the placement of the commentary.  You can now set the amount of space between the lines of a multi-line commentary with `commentaryseparation` and the distance from the top line of the staff to the baseline of the bottom line of the commentary with `commentaryraise`.  See [#662](https://github.com/gregorio-project/gregorio/issues/662) for original request.
 - Styles for the annotation and the commentary.  `annotation` has no default styling.  `commentary` defaults to footnote sized italics.
 - `\grecommentary` now takes an optional argument which will add extra space between the commentary and the score for just the next score.
+- The custos can now be selectively enabled/disabled at forced line breaks by appending `+` (to enable) or `-` (to disable) after the `z` or `Z` (see [#800](https://github.com/gregorio-project/gregorio/issues/800)).
 
 
 ### Deprecated

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -961,6 +961,14 @@ Returns its argument as-is.
   \#1 & string & Text to typeset without any extra styling.\\
 \end{argtable}
 
+\macroname{\textbackslash GreUpcomingNewLineForcesCustos}{\#1}{gregoriotex-syllable.tex}
+Indicates that the new line in the next syllable forces a custos.
+
+\begin{argtable}
+  \#1 & \texttt{0} & The custos is forced off.\\
+      & \texttt{1} & The custos is forced on.\\
+\end{argtable}
+
 \macroname{\textbackslash GreVarBraceLength}{\#1}{gregoriotex-signs.tex}
 Returns the computed length of the given brace or ledger line.
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -372,6 +372,9 @@ Macro to pick the appropriate custos character.
   \#1 & integer & height of the custos character to be placed\\
 \end{argtable}
 
+\macroname{\textbackslash gre@nextcustos}{}{gregoriotex-signs.tex}
+Macro that saves the next custos height.
+
 \macroname{\textbackslash gre@beginnotes}{}{gregoriotex-main.tex}
 Macro to draw the staff lines.  Comes after the initial but before the clef.
 

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -298,11 +298,13 @@ void dump_write_score(FILE *f, gregorio_score *score)
                 }
                 break;
             case GRE_END_OF_LINE:
-                if (element->u.misc.unpitched.info.sub_type) {
-                    fprintf(f, "     sub_type                %d (%s)\n",
-                            element->u.misc.unpitched.info.sub_type,
-                            gregorio_type_to_string(element->u.misc.unpitched.
-                                                    info.sub_type));
+                if (element->u.misc.unpitched.info.eol_ragged) {
+                    fprintf(f, "         ragged                 true\n");
+                }
+                if (element->u.misc.unpitched.info.eol_forces_custos) {
+                    fprintf(f, "         forces custos          %s\n",
+                            dump_bool(element
+                                ->u.misc.unpitched.info.eol_forces_custos_on));
                 }
                 break;
             case GRE_ELEMENT:

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -819,15 +819,31 @@ static void end_var_slur(int direction, int index)
                 &notes_lloc);
     }
 [\t\r\n]+ /* ignore ends of line and tabs */;
-z   {
-        gregorio_add_end_of_line_as_note(&current_note, GRE_END_OF_LINE,
-                &notes_lloc);
-    }
 z0  {
         gregorio_add_custo_as_note(&current_note, &notes_lloc);
     }
+z   {
+        gregorio_add_end_of_line_as_note(&current_note, false, false, false,
+                &notes_lloc);
+    }
+z\+ {
+        gregorio_add_end_of_line_as_note(&current_note, false, true, true,
+                &notes_lloc);
+    }
+z-  {
+        gregorio_add_end_of_line_as_note(&current_note, false, true, false,
+                &notes_lloc);
+    }
 Z   {
-        gregorio_add_end_of_line_as_note(&current_note, GRE_END_OF_PAR,
+        gregorio_add_end_of_line_as_note(&current_note, true, false, false,
+                &notes_lloc);
+    }
+Z\+ {
+        gregorio_add_end_of_line_as_note(&current_note, true, true, true,
+                &notes_lloc);
+    }
+Z-  {
+        gregorio_add_end_of_line_as_note(&current_note, true, true, false,
                 &notes_lloc);
     }
 [cf][1-5] {

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -745,7 +745,15 @@ static void gabc_write_gregorio_element(FILE *f, gregorio_element *element)
         gabc_write_clef(f, element->u.misc.clef);
         break;
     case GRE_END_OF_LINE:
-        fprintf(f, "z");
+        if (element->u.misc.unpitched.info.eol_ragged) {
+            fprintf(f, "Z");
+        } else {
+            fprintf(f, "z");
+        }
+        if (element->u.misc.unpitched.info.eol_forces_custos) {
+            fprintf(f, element->u.misc.unpitched.info.eol_forces_custos_on? "+"
+                    : "-");
+        }
         break;
     case GRE_CUSTOS:
         if (element->u.misc.pitched.force_pitch) {

--- a/src/struct.c
+++ b/src/struct.c
@@ -142,11 +142,14 @@ static void add_pitched_item_as_note(gregorio_note **current_note,
 }
 
 void gregorio_add_end_of_line_as_note(gregorio_note **current_note,
-        gregorio_type sub_type, const gregorio_scanner_location *const loc)
+        bool eol_ragged, bool eol_forces_custos, bool eol_forces_custos_on,
+        const gregorio_scanner_location *const loc)
 {
     gregorio_note *element = create_and_link_note(current_note, loc);
     element->type = GRE_END_OF_LINE;
-    element->u.other.sub_type = sub_type;
+    element->u.other.eol_ragged = eol_ragged;
+    element->u.other.eol_forces_custos = eol_forces_custos;
+    element->u.other.eol_forces_custos_on = eol_forces_custos_on;
 }
 
 void gregorio_add_custo_as_note(gregorio_note **current_note,

--- a/src/struct.h
+++ b/src/struct.h
@@ -72,7 +72,6 @@ typedef struct gregorio_scanner_location {
     E(GRE_END_OF_LINE) \
     E(GRE_SPACE) \
     E(GRE_BAR) \
-    E(GRE_END_OF_PAR) \
     E(GRE_CUSTOS) \
     E(GRE_MANUAL_CUSTOS) \
     /* I don't really know how I could use the a TEXVERB_NOTE in gregoriotex,
@@ -366,11 +365,12 @@ ENUM(gregorio_word_position, GREGORIO_WORD_POSITION);
 
 typedef struct gregorio_extra_info {
     char *ad_hoc_space_factor;
-    /* the sub-type of GRE_END_OF_LINE */
-    ENUM_BITFIELD(gregorio_type) sub_type:8;
-    ENUM_BITFIELD(gregorio_bar) bar:8;
-    ENUM_BITFIELD(gregorio_space) space:8;
-    ENUM_BITFIELD(gregorio_nlba) nlba:8;
+    ENUM_BITFIELD(gregorio_bar) bar:4;
+    ENUM_BITFIELD(gregorio_space) space:4;
+    ENUM_BITFIELD(gregorio_nlba) nlba:2;
+    bool eol_ragged:1;
+    bool eol_forces_custos:1;
+    bool eol_forces_custos_on:1;
 } gregorio_extra_info;
 
 typedef struct gregorio_clef_info {
@@ -809,7 +809,8 @@ void gregorio_add_unpitched_element_as_glyph(gregorio_glyph **current_glyph,
         gregorio_type type, gregorio_extra_info *info, gregorio_sign sign,
         char *texverb);
 void gregorio_add_end_of_line_as_note(gregorio_note **current_note,
-        gregorio_type sub_type, const gregorio_scanner_location *loc);
+        bool eol_ragged, bool eol_forces_custos, bool eol_forces_custos_on,
+        const gregorio_scanner_location *loc);
 void gregorio_add_custo_as_note(gregorio_note **current_note,
         const gregorio_scanner_location *loc);
 void gregorio_add_manual_custos_as_note(gregorio_note **current_note,

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -262,6 +262,7 @@
     \gre@penalty{-10001}%
   \fi %
   \gre@adjustlineifnecessary\relax %
+  \gre@reseteolcustos\relax %
 }%
 
 \def\gre@mark@translation{\directlua{gregoriotex.mark_translation()}}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -309,8 +309,10 @@
 }
 
 % the argument is the height
+\edef\gre@nextcustos{\gre@pitch@dummy}%
 \def\GreNextCustos#1{%
   \ifnum\gre@insidediscretionary=0\relax %
+    \edef\gre@nextcustos{#1}%
     \ifgre@blockeolcustos\else%
       \gre@calculate@glyphraisevalue{#1}{0}%
       %here we need some tricks to draw the line before the custos (for the color)

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -973,6 +973,15 @@
   \def\gre@opening@syllabletext{}%
 }%
 
+\def\GreUpcomingNewLineForcesCustos#1{%
+  \ifcase#1\relax % 0 - forced off
+    \gre@usemanualeolcustos %
+  \or % 1 - forced on
+    \gre@useautoeolcustos %
+    \GreNextCustos{\gre@nextcustos}%
+  \fi %
+}%
+
 %% opens a score
 %% #1 - macros rendering the things after the initial but before the notes
 %% #2 - macros rendering the things after starting notes but before the syllable


### PR DESCRIPTION
Fixes #800.

I also found/fixed a bug generating `Z` when writing gabc.

gabc-dump expectations are updated because of the new feature.  gabc-gabc expectations are updated because of the bug fix.  Everything else passes, and I added some new tests to exercise the new feature.

Please review and merge if satisfactory.