### PR TITLE
Used __attribute__((unused)) to disable the unused parameter warning correctly.

### DIFF
--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3096,10 +3096,9 @@ static __inline void write_syllable_point_and_click(FILE *const f,
 }
 
 static void write_syllable_text(FILE *f, const char *const syllable_type, 
-        const gregorio_character *text, bool ignored)
+        const gregorio_character *text, bool ignored __attribute__((unused)))
 {
     if (syllable_type != NULL) {
-        ignored = false; /* to avoid the warning */
         fprintf(f, "%s{\\GreSetThisSyllable", syllable_type);
         write_text(f, text);
         fprintf(f, "}");


### PR DESCRIPTION
This is a better fix for the unused parameter warning.  The function prototype must include this `bool` parameter, though it doesn't use it, in order to be used interchangeably with `write_first_syllable_text` when calling `write_syllable`.

This compiles without warnings under both clang and gcc.  Since this is a very small change and doesn't change any functionality, I will merge it.