### PR TITLE
Create def_check.sh

### DIFF
--- a/def_check.sh
+++ b/def_check.sh
@@ -1,0 +1,66 @@
+#! /usr/bin/env bash
+
+# This script is used make sure that all macros which gregoriotex-write.c
+# might write to a gtex file are defined in the TeX code.
+# It does this by creating two lists: one of all the \Gre macros defined in the TeX
+# code, and one of all the macros which might be printed by gregoriotex-write.c.
+# It then compares these two lists and outputs res.tex which contains a list of
+# undefined macros (preceded by >) and macros which are defined but cannot be
+# produced by gregoriotex-write.c
+
+# It is not perfect, and especially has trouble with macros whose names
+# gregoriotex-write.c builds a piece at a time.
+
+HERE=`pwd`
+
+TEXFILE=$HERE/tex.txt
+CFILE=$HERE/c.txt
+DIFFFILE=$HERE/diff.txt
+RESFILE=$HERE/res.txt
+
+#Extraction from TeX code
+cd tex
+
+grep -hE '\\[gex]?def\\Gre' *.tex *.sty > $TEXFILE
+grep -hE '\\let\\Gre.*' *.tex *.sty >> $TEXFILE
+grep -h '\\gredefsymbol{Gre.*' *.tex *.sty >> $TEXFILE
+
+#remove deprecated code
+sed -i.temp 's:.*OBSOLETE.*::' $TEXFILE
+sed -i.temp 's:.*DEPRECATED.*::' $TEXFILE
+
+#Isolate function names
+sed -i.temp 's:.*\(Gre[a-zA-Z]*\).*:\1:' $TEXFILE
+
+#alphabetize and remove duplicates
+sort -u -o$TEXFILE $TEXFILE
+
+
+#Extraction from c code
+cd ../src/gregoriotex
+
+grep -hE '\\\\Gre.*' gregoriotex-write.c > $CFILE
+
+#remove deprecated code
+sed -i.temp 's:.*OBSOLETE.*::' $CFILE
+sed -i.temp 's:.*DEPRECATED.*::' $CFILE
+
+#Isolate function names
+sed -i.temp 's:.*\(Gre[a-zA-Z]*\).*:\1:' $CFILE
+
+#alphabetize and remove duplicates
+sort -u -o$CFILE $CFILE
+
+#find differences
+diff -B $CFILE $TEXFILE > $DIFFFILE
+
+grep -h '[<>]' $DIFFFILE > $RESFILE
+
+sort -u -o$RESFILE $RESFILE
+
+#cleanup
+rm $CFILE.temp
+rm $CFILE
+rm $TEXFILE.temp
+rm $TEXFILE
+rm $DIFFFILE

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3762,7 +3762,7 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
     }
 
     if (score->initial_style != INITIAL_NOT_SPECIFIED) { /* DEPRECATED by 4.1 */
-        fprintf(f, "\\GreSetInitialStyle{%d}%%\n", score->initial_style);
+        fprintf(f, "\\GreSetInitialStyle{%d}%%\n", score->initial_style); /* DEPRECATED by 4.1 */
     }
 
     fprintf(f, "\\GreScoreOpening{%%\n"); /* GreScoreOpening#1 */


### PR DESCRIPTION
Shell script which does a basic comparison between gregoriotex-write.c and the TeX code to make sure the functions written by the former are defined in the latter

Would others find this useful for checking that the code is consistent?  Right now the script is fairly basic and returns about 50 potential false positives.  I don't have time to refine the rules yet to try and close that gap a bit at the moment, but if others see some potential, I'll make the time to do so at some point.