### PR TITLE
Allowed the fixed text style to affect the initial.

### DIFF
--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -741,14 +741,15 @@ Macro for typesetting a reversed semicirculus.
   \#2 & string  & Type of glyph the semicirculus is attached to. See \nameref{EpisemaSpecial} argument for description of options.\\
 \end{argtable}
 
-\macroname{\textbackslash GreScoreOpening}{\#1\#2\#3\#4}{gregoriotex-syllable.tex}
+\macroname{\textbackslash GreScoreOpening}{\#1\#2\#3\#4\#5}{gregoriotex-syllable.tex}
 Opens the score.
 
 \begin{argtable}
   \#1 & \TeX\ code & Macros rendering the things after the initial but before the notes.\\
   \#2 & \TeX\ code & Macros rendering the things after starting notes but before the syllable.\\
-  \#3 & \TeX\ control sequence & Control sequence for the syllable.\\
-  \#4 & \TeX\ code & Macros rendering the first syllable; should emit the initial and populate \verb=\gre@opening@syllabletext=.\\
+  \#3 & \TeX\ code & Macros rendering the things before the initial.\\
+  \#4 & \TeX\ control sequence & Control sequence for the syllable.\\
+  \#5 & \TeX\ code & Macros rendering the first syllable; should emit the initial and populate \verb=\gre@opening@syllabletext=.\\
 \end{argtable}
 
 \macroname{\textbackslash GreScoreReference}{\#1}{gregoriotex-main.tex}

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3783,6 +3783,7 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
             gregorio_clef_to_char(clef.secondary_clef), clef.secondary_line,
             clef_flat_height(clef.secondary_clef, clef.secondary_line,
                     clef.secondary_flatted));
+    fprintf(f, "}{%%\n"); /* GreScoreOpening#3 */
     current_syllable = score->first_syllable;
     if (current_syllable) {
         write_syllable(f, current_syllable, 0, &status, score,

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -372,7 +372,7 @@
   \ifnum\gre@biginitial=0\relax %
     \ifvoid\gre@box@initial%
       \gre@debugmsg{initial}{Fill initial box a}%
-      \setbox\gre@box@initial=\hbox{\gre@style@initial#1\endgre@style@initial}%
+      \setbox\gre@box@initial=\hbox{\gre@style@initial\gre@fixedtextformat{#1}\endgre@style@initial}%
     \fi%
     \ifx\gre@empty@initialformat\greinitialformat% OBSOLETE
     \else%  OBSOLETE
@@ -419,9 +419,9 @@
     \ifvoid\gre@box@initial%
       \gre@debugmsg{initial}{fill big initial box}%
       \ifgre@allowdeprecated%%% DEPRECATED for removal in 5.0
-        \setbox\gre@box@initial=\hbox{\gre@style@biginitial#1\endgre@style@biginitial}% DEPRECATED for removal in 5.0
+        \setbox\gre@box@initial=\hbox{\gre@style@biginitial\gre@fixedtextformat{#1}\endgre@style@biginitial}% DEPRECATED for removal in 5.0
       \else%%% DEPRECATED for removal in 5.0
-        \setbox\gre@box@initial=\hbox{\gre@style@initial#1\endgre@style@initial}% keep this line
+        \setbox\gre@box@initial=\hbox{\gre@style@initial\gre@fixedtextformat{#1}\endgre@style@initial}% keep this line
       \fi%%% DEPRECATED for removal in 5.0
     \fi%
     \ifx\gre@empty@biginitialformat\grebiginitialformat% OBSOLETE

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -985,11 +985,13 @@
 %% opens a score
 %% #1 - macros rendering the things after the initial but before the notes
 %% #2 - macros rendering the things after starting notes but before the syllable
-%% #3 - control sequence for the syllable
-%% #4 - macros rendering the first syllable; should emit the initial and
+%% #3 - macros rendering the things before the initial
+%% #4 - control sequence for the syllable
+%% #5 - macros rendering the first syllable; should emit the initial and
 %%      populate \gre@opening@syllabletext (even if that should be empty)
-\def\GreScoreOpening#1#2#3#4{%
-  #4\relax % should emit the initial
+\def\GreScoreOpening#1#2#3#4#5{%
+  #3\relax % fixed styles, etc.
+  #5\relax % should emit the initial
   \ifnum\gre@biginitial=1\relax %
     \gre@debugmsg{general}{making adjustment NECESSARY}%
     \gre@thirdlineadjustmentnecessarytrue %
@@ -1000,5 +1002,5 @@
   #1\relax % score reference, voice info, etc.
   \gre@beginnotes\relax %
   #2\relax % initial clef, etc.
-  #3{\gre@opening@syllabletext}%
+  #4{\gre@opening@syllabletext}%
 }%


### PR DESCRIPTION
Fixes #807.

I changed the `\GreScoreOpening` macro, which breaks all the gabc-gtex tests.  Everything else passes.  I added the test from the issue.

Please review and merge if satisfactory.