### PR TITLE
fix #821

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,12 +47,9 @@ OTHERARGS=
 FORCE_AUTORECONF=
 FORCE_FONTS=
 
-CFLAGS="$CFLAGS -Wdeclaration-after-statement"
-
 until [ -z "$1" ]; do
   case "$1" in
     --mingw     ) MINGWCROSS=TRUE ;;
-    --warn      ) WARN=TRUE ;;
     --host=*    ) CONFHOST="$1" ;;
     --build=*   ) CONFBUILD="$1" ;;
     --arch=*    ) MACCROSS=TRUE; ARCH=`echo $1 | sed 's/--arch=\(.*\)/\1/' ` ;;
@@ -67,14 +64,6 @@ done
 B=build
 
 ARCHFLAGS=
-
-if [ "$WARN" = "TRUE" ]
-then
-  CFLAGS="-Wall -Wextra \
- -Wformat-y2k -Wno-format-extra-args\
- -Wno-format-zero-length -Wformat-nonliteral\
- -Wformat-security -Wformat=2 -Wnormalized=nfc $CFLAGS"
-fi
 
 if [ "$MINGWCROSS" = "TRUE" ]
 then
@@ -93,7 +82,7 @@ then
   fi
   OLDPATH=$PATH
   PATH=/usr/$MINGWSTR/bin:$PATH
-  CFLAGS="-mtune=pentiumpro -msse2 -O2 $CFLAGS"
+  CFLAGS="-mtune=pentiumpro -msse2 -g -O2 $CFLAGS"
   LDFLAGS="-Wl,--large-address-aware $CFLAGS"
   ARCHFLAGS="--target=\"$MINGWSTR\" \
     --with-gnu-ld \

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AM_INIT_AUTOMAKE([-Wall -Wno-portability subdir-objects foreign dist-bzip2 no-dist-gzip])
 
-AC_PROG_CC_C89
+AC_PROG_CC
 dnl AM_PROG_CC_C_O is deprecated since Automake 1.14, to be removed in the future
 AM_PROG_CC_C_O
 AC_PROG_CPP
@@ -43,9 +43,10 @@ AX_CHECK_COMPILE_FLAG([-pedantic], [CFLAGS+=" -pedantic"])
 dnl AX_CHECK_COMPILE_FLAG([-pedantic-errors], [CFLAGS+=" -pedantic-errors"])
 AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [CFLAGS+=" -fstack-protector-strong"])
 AX_CHECK_COMPILE_FLAG([-fPIE], [CFLAGS+=" -fPIE"])
-AX_CHECK_COMPILE_FLAG([-Wformat], [CFLAGS+=" -Wformat"])
+AX_CHECK_COMPILE_FLAG([-Wformat=2], [CFLAGS+=" -Wformat=2"])
 AX_CHECK_COMPILE_FLAG([-Werror=format-security], [CFLAGS+=" -Werror=format-security"])
 AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], [CFLAGS+=" -Wstrict-prototypes"])
+AX_CHECK_COMPILE_FLAG([-Wdeclaration-after-statement], [CFLAGS+=" -Wdeclaration-after-statement"])
 AX_CHECK_COMPILE_FLAG([-Wall], [CFLAGS+=" -Wall"])
 AX_CHECK_COMPILE_FLAG([-Wextra], [CFLAGS+=" -Wextra"])
 CPPFLAGS+=" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 "


### PR DESCRIPTION
- add relevant warnings from build.sh into configure.ac
- remove --warn option of build.sh
- remove hardcoded warning from build.sh (fixes #821)
- AC_PROC_CC_C89 -> AC_PROG_CC