### PR TITLE
Code cleanup

### DIFF
--- a/src/characters.c
+++ b/src/characters.c
@@ -806,10 +806,12 @@ static void suppress_this_character(gregorio_character *to_suppress)
         return;
     }
     if (to_suppress->previous_character) {
+        assert(to_suppress->previous_character->next_character == to_suppress);
         to_suppress->previous_character->next_character =
                 to_suppress->next_character;
     }
     if (to_suppress->next_character) {
+        assert(to_suppress->next_character->previous_character == to_suppress);
         to_suppress->next_character->previous_character =
                 to_suppress->previous_character;
     }
@@ -947,8 +949,9 @@ static __inline bool _suppress_char_and_end_c(
         return true;
     } else {
         if ((*ptr_character)->previous_character) {
+            gregorio_character *to_suppress = *ptr_character;
             (*ptr_character) = (*ptr_character)->previous_character;
-            suppress_this_character((*ptr_character)->next_character);
+            suppress_this_character(to_suppress);
         } else {
             suppress_this_character(*ptr_character);
             *ptr_character = NULL;

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -278,8 +278,10 @@ void sha1_process_block(const void *buffer, size_t len, struct sha1_ctx *ctx)
     while (words < endp) {
         uint32_t tm;
         int t;
+        uint32_t v;
         for (t = 0; t < 16; t++) {
-            x[t] = SWAP(*words);
+            memcpy(&v, words, sizeof(uint32_t));
+            x[t] = SWAP(v);
             words++;
         }
 


### PR DESCRIPTION
For #697.

In this edition, I have fixed the `suppress_this_character` static check warnings by adding strategic assertions and code reordering.  Using `-fsanitize=undefined,address` found a potential issue in sha1.c, which I've fixed by forcing alignment with a memcpy to a stack variable.

No tests change.

Same caveats as before; I think it's better to merge these kinds of fixes sooner than to have a big, long-lived pull request.

Please review and merge if satisfactory.