### PR TITLE
4.1 documentation check

### DIFF
--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -62,7 +62,6 @@ Some headers have special meaning to Gregorio:
 \item[author] The author of the piece, if known; of course, the author of most traditional chant is not known.
 \item[manuscript-reference] A unique reference for the piece, according to some well-known system. For example, the reference beginning cao in the Cantus database of office chants. If the reference is unclear as to which system it uses, it should be prefixed by the name of the system. Note that this should be a reference identifying the piece, not the manuscript as a whole; anything identifying the manuscript as a whole should be put in the manuscript field.
 \item[language] The language of the lyrics.
-\item[initial-style] The style of the initial letter. 0 means no initial letter, 1 a normal one, and 2 a large one, on two lines. Note that if you want to use the initial on two lines, you have to specify at least the two first line breaks.
 \item[oriscus-orientation] If \texttt{legacy}, the orientation of an unconnected oriscus must be set manually.
 \item[mode] The mode of the piece. This should normally be an arabic
   number between 1 and 8, but may be any text required for unusual

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -26,7 +26,6 @@ score-copyright: copyright on the source score;
 author: if known;
 manuscript-reference: e.g. CAO reference;
 language: latin;
-initial-style: 1;
 mode: 6;
 mode-modifier: t.;
 annotation: IN.;

--- a/doc_check.sh
+++ b/doc_check.sh
@@ -28,7 +28,7 @@ grep -h '\\new[a-z]*\\.*' *.tex *.sty > $CODEFILE
 grep -hE '\\[gex]?def\\.*' *.tex *.sty >> $CODEFILE
 grep -hE '\\let\\.*' *.tex *.sty >> $CODEFILE
 grep -h '\\font\\' *.tex *.sty >> $CODEFILE
-grep -n '\\gredefsymbol{.*' *.tex *.sty >> $CODEFILE
+grep -h '\\gredefsymbol{.*' *.tex *.sty >> $CODEFILE
 
 #remove deprecated code
 sed -i.temp 's:.*@empty@.*::' $CODEFILE


### PR DESCRIPTION
Since the `initial-style` header is deprecated, it doesn't need to be in the docs anymore.