### PR TITLE
Added --enable-debug[=sanitize].

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,18 @@ AS_IF([test "x$with_kpathsea" = "xyes"], [
     )
 ])
 
+AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug@<:@=sanitize@:>@], [Enable debugging options [with additional sanitize options].]), [
+    AS_IF([test "x$enableval" != "xno"], [
+        dnl AX_CHECK_COMPILE_FLAG([-g], [CFLAGS+=" -g"])
+        AX_CHECK_COMPILE_FLAG([-Og], [CFLAGS+=" -Og"], [
+            AX_CHECK_COMPILE_FLAG([-O0], [CFLAGS+=" -O0"])
+        ])
+        AS_IF([test "x$enableval" = "xsanitize"], [
+            AX_CHECK_COMPILE_FLAG([-fsanitize=address,undefined], [CFLAGS+=" -fsanitize=address,undefined"])
+        ])
+    ])
+])
+
 AC_CONFIG_HEADERS([src/config_.h])
 AC_CONFIG_FILES([
     Makefile


### PR DESCRIPTION
Fixes #823 

This adds `--enable-debug` which sets `-Og` (if supported, i.e., by gcc) or `-O0` (which clang recommends for debugging).  If passed with the optional argument, `--enable-debug=sanitize` will also add `-fsanitize=undefined,address`.

Note that `--enable-debug` will append the arguments to the `CFLAGS`, which probably already contains `-O2`, but I don't know how to fix that, and don't think it's necessary for prepping a debug build anyway.

Ideally, I'd like to generate `-g` only when enabling debug, but I'm not going to worry too much about that.

Please review and merge if satisfactory.

EDIT: I fixed the issue and this is now ready for review