### PR TITLE
Corrected the name of the "op" fonts to be different than the normal fonts.

### DIFF
--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -134,12 +134,17 @@ def main():
         pre, ext = os.path.splitext(inputfile)
         outfile = '%s.ttf' % pre
     oldfont = fontforge.open(inputfile)
-    font_name = oldfont.fontname + subspecies
+    if args.subspecies:
+        font_name = '%s-%s' % (oldfont.fontname, args.subspecies)
+        full_name = '%s-%s' % (oldfont.fullname, args.subspecies)
+    else:
+        font_name = oldfont.fontname
+        full_name = oldfont.fullname
     newfont = fontforge.font()
     # newfont.encoding = "UnicodeFull"
     newfont.encoding = "ISO10646-1"
-    newfont.fontname = oldfont.fontname
-    newfont.fullname = oldfont.fullname
+    newfont.fontname = font_name
+    newfont.fullname = full_name
     newfont.familyname = oldfont.familyname
     newfont.version = GREGORIO_VERSION
     newfont.copyright = oldfont.copyright.replace('<<GPLV3>>', GPLV3)


### PR DESCRIPTION
Fixes #851.

This bug can cause the luatex font cache to point greciliae at greciliae-op (and same with the other fonts), so this fix actually fixes tests that might break if the luatex cache has been messed up.  No tests change and all tests pass.

Please review and merge if satisfactory.