### PR TITLE
Added support for coverage testing with gcov/lcov.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@
 *.lo
 *.la
 
+# Coverage
+*.gcno
+*.gcda
+/coverage
+/coverage.info
 
 # Libraries
 *.lib

--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ AS_IF([test "x$with_kpathsea" = "xyes"], [
     )
 ])
 
-AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug@<:@=sanitize@:>@], [Enable debugging options [with additional sanitize options].]), [
+AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug@<:@=sanitize,coverage@:>@], [Enable debugging options [with additional sanitize options].]), [
     AS_IF([test "x$enableval" != "xno"], [
         dnl AX_CHECK_COMPILE_FLAG([-g], [CFLAGS+=" -g"])
         AX_CHECK_COMPILE_FLAG([-Og], [CFLAGS+=" -Og"], [
@@ -90,6 +90,10 @@ AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug@<:@=sanitize@:>@], [Enable
         ])
         AS_IF([test "x$enableval" = "xsanitize"], [
             AX_CHECK_COMPILE_FLAG([-fsanitize=address,undefined], [CFLAGS+=" -fsanitize=address,undefined"])
+        ])
+        AS_IF([test "x$enableval" = "xcoverage"], [
+            AX_CHECK_COMPILE_FLAG([--coverage], [CFLAGS+=" --coverage"])
+            AX_CHECK_LINK_FLAG([--coverage], [LDFLAGS+=" --coverage"])
         ])
     ])
 ])

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright (C) 2016 The Gregorio Project (see CONTRIBUTORS.md)
+# 
+# This file is part of Gregorio.
+#
+# Gregorio is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Gregorio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+
+######################################################################
+# This script helps with code coverage testing.  It's meant to be run
+# from the directory where it resides.
+
+case "$1" in
+report)
+    eval `grep '^CC=' config.log`
+    case "$CC" in
+    gcc*)
+        extra_args=''
+        ;;
+    clang*)
+        echo "creating __gcovtool.sh for $CC"
+        cat <<'EOT' > __gcovtool.sh
+#!/bin/bash
+exec llvm-cov gcov "$@"
+EOT
+        chmod +x __gcovtool.sh
+        extra_args="--gcov-tool ${PWD}/__gcovtool.sh"
+        ;;
+    *)
+        echo "compiler '$CC' not supported"
+        exit 1
+        ;;
+    esac
+
+    rm -rv coverage.info coverage
+    echo "generating report"
+    lcov $extra_args --directory . --capture --output-file coverage.info &&
+        genhtml coverage.info -o coverage
+
+    if test -f __gcovtool.sh
+    then
+        rm -v __gcovtool.sh
+    fi
+    ;;
+clean)
+    echo "deleting coverage files"
+    rm -rv gcovtool.sh coverage coverage.info
+    find . -name '*.gcno' -exec rm -v {} +
+    find . -name '*.gcda' -exec rm -v {} +
+    ;;
+'')
+    echo "Usage $0 report|clean"
+    exit 1
+    ;;
+*)
+    echo "command '$1' not recognized"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -144,7 +144,7 @@ static __inline void character_set_grow(character_set *const set) {
     set->mask = (set->mask << 1) | 0x01;
     set->table = gregorio_calloc(set->bins, sizeof(grewchar));
     if (old_next) {
-        set->table = gregorio_calloc(set->bins, sizeof(character_set *));
+        set->next = gregorio_calloc(set->bins, sizeof(character_set *));
     }
     for (i = 0; i < old_bins; ++i) {
         if (old_table[i]) {


### PR DESCRIPTION
For #697.

In preliminary testing, I also found/fixed a bug in the vowel-subsystem buffer allocation which is not currently covered by the tests.

Note: I haven't yet added the new tests that will result from further coverage testing as part of gregorio-project/gregorio-test#112 and supported by this code.  Those will come as additional pull requests, along with fixing of any bugs found in testing.

All current tests pass given the caveat above.

Please review and merge if satisfactory.