### PR TITLE
Fixed problems found while testing for code coverage.

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -46,12 +46,18 @@ EOT
     rm -rv coverage.info coverage
     echo "generating report"
     lcov $extra_args --directory . --capture --output-file coverage.info &&
+        lcov --remove coverage.info '*-y.c' '*-l.c' --output-file coverage.info &&
         genhtml coverage.info -o coverage
 
     if test -f __gcovtool.sh
     then
         rm -v __gcovtool.sh
     fi
+    ;;
+reset)
+    echo "resetting coverage files"
+    rm -rv gcovtool.sh coverage coverage.info
+    find . -name '*.gcda' -exec rm -v {} +
     ;;
 clean)
     echo "deleting coverage files"
@@ -60,7 +66,7 @@ clean)
     find . -name '*.gcda' -exec rm -v {} +
     ;;
 '')
-    echo "Usage $0 report|clean"
+    echo "Usage $0 report|reset|clean"
     exit 1
     ;;
 *)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -132,6 +132,10 @@ utf8strings.h: utf8strings.h.in
 encode_utf8strings${EXEEXT}: encode_utf8strings.c
 	$(CC) -o $@ $<
 
+clean-local:
+	find . -name '*.gcno' -print | xargs rm -f --
+	find . -name '*.gcda' -print | xargs rm -f --
+
 BUILT_SOURCES = utf8strings.h \
 					gabc/gabc-notes-determination-l.c \
 					gabc/gabc-score-determination-l.c \

--- a/src/characters.c
+++ b/src/characters.c
@@ -85,7 +85,7 @@ static bool read_vowel_rules(char *const lang) {
     
     filenames = gregorio_malloc(capacity * sizeof(char *));
 
-    file = popen("kpsewhich " VOWEL_FILE, "r");
+    file = popen("kpsewhich -all " VOWEL_FILE, "r");
     if (!file) {
         gregorio_messagef("read_patterns", VERBOSITY_WARNING, 0,
                 _("unable to run kpsewhich %s: %s"), VOWEL_FILE,
@@ -207,6 +207,8 @@ static __inline bool handle_elision(const gregorio_character *const ch,
         break;
 
     case ST_T_NOTHING:
+        /* not reachable unless there's a programming error */
+        assert(false); /* LCOV_EXCL_LINE */
         break;
     }
     return true;
@@ -506,7 +508,8 @@ void gregorio_write_first_letter_alignment_text(
             close_first_letter = first_letter_open != 0;
         } else switch (current_character->cos.s.type) {
         case ST_T_NOTHING:
-            assert(false);
+            /* not reachable unless there's a programming error */
+            assert(false); /* LCOV_EXCL_LINE */
             break;
         case ST_T_BEGIN:
             /* handle styles */
@@ -546,7 +549,8 @@ void gregorio_write_first_letter_alignment_text(
                 break;
             case ST_VERBATIM:
             case ST_SPECIAL_CHAR:
-                assert(false);
+                /* not reachable unless there's a programming error */
+                assert(false); /* LCOV_EXCL_LINE */
                 break;
             case ST_FIRST_WORD:
             case ST_FIRST_SYLLABLE:

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -74,7 +74,8 @@ static const char *dump_pitch(const char height, const char highest_pitch) {
         }
         gregorio_snprintf(buf, 20, "%c", pitch);
     } else {
-        gregorio_snprintf(buf, 20, "?%d", height);
+        /* not reachable unless there's a programming error */
+        gregorio_snprintf(buf, 20, "?%d", height); /* LCOV_EXCL_LINE */
     }
     return buf;
 }
@@ -87,11 +88,8 @@ void dump_write_score(FILE *f, gregorio_score *score)
     gregorio_syllable *syllable;
     gregorio_header *header;
 
-    if (!f) {
-        gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
-                VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(f, dump_write_score, "call with NULL file", return);
+
     fprintf(f,
             "=====================================================================\n"
             " SCORE INFOS\n"
@@ -193,6 +191,10 @@ void dump_write_score(FILE *f, gregorio_score *score)
         if (syllable->no_linebreak_area != NLBA_NORMAL) {
             fprintf(f, "   no line break area        %s\n",
                     gregorio_nlba_to_string(syllable->no_linebreak_area));
+        }
+        if (syllable->euouae != EUOUAE_NORMAL) {
+            fprintf(f, "   euouae                    %s\n",
+                    gregorio_euouae_to_string(syllable->euouae));
         }
         if (syllable->text) {
             if (syllable->translation) {
@@ -354,8 +356,12 @@ void dump_write_score(FILE *f, gregorio_score *score)
                         break;
 
                     default:
-                        fprintf(f, "       !!! UNKNOWN !!!       !!!\n");
+                        /* not reachable unless there's a programming error */
+                        /* LCOV_EXCL_START */
+                        fprintf(f, "         !!! NOT ALLOWED !!!    %s\n",
+                                gregorio_type_to_string(glyph->type));
                         break;
+                        /* LCOV_EXCL_STOP */
                     }
                     if (glyph->type == GRE_GLYPH) {
                         for (note = glyph->u.notes.first_note; note;
@@ -388,8 +394,12 @@ void dump_write_score(FILE *f, gregorio_score *score)
                                 break;
 
                             default:
-                                fprintf(f, "         !!! NOT ALLOWED !!!    !!!\n");
+                                /* not reachable unless there's a programming error */
+                                /* LCOV_EXCL_START */
+                                fprintf(f, "         !!! NOT ALLOWED !!!    %s\n",
+                                        gregorio_type_to_string(note->type));
                                 break;
+                                /* LCOV_EXCL_STOP */
                             }
                             if (note->texverb) {
                                 fprintf(f, "         TeX string             \"%s\"\n",
@@ -466,8 +476,12 @@ void dump_write_score(FILE *f, gregorio_score *score)
                 break;
 
             default:
-                /* do nothing */
+                /* not reachable unless there's a programming error */
+                /* LCOV_EXCL_START */
+                fprintf(f, "         !!! NOT ALLOWED !!!    %s\n",
+                        gregorio_type_to_string(element->type));
                 break;
+                /* LCOV_EXCL_STOP */
             }
             if (element->nabc_lines) {
                 fprintf(f, "     nabc_lines              %d\n",

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -587,10 +587,8 @@ static gregorio_note *next_non_texverb_note(gregorio_note *first_note,
     }
 
     if (first_note == last_note) {
-        if (first_note->type == GRE_TEXVERB_GLYPH) {
-            gregorio_message(_("Unexpected texverb at start of iteration"),
-                    "next_non_texverb_note", VERBOSITY_ERROR, 0);
-        }
+        gregorio_assert_only(first_note->type != GRE_TEXVERB_GLYPH,
+                next_non_texverb_note, "Unexpected texverb at start of iteration");
         return first_note;
     }
 
@@ -601,10 +599,8 @@ static gregorio_note *next_non_texverb_note(gregorio_note *first_note,
         }
     }
 
-    if (first_note && first_note->type == GRE_TEXVERB_GLYPH) {
-        gregorio_message(_("Unexpected texverb at end of iteration"),
-                "next_non_texverb_note", VERBOSITY_ERROR, 0);
-    }
+    gregorio_assert_only(!first_note || first_note->type != GRE_TEXVERB_GLYPH,
+            next_non_texverb_note, "Unexpected texverb at end of iteration");
 
     return last_note;
 }
@@ -636,11 +632,9 @@ static gregorio_note *close_fusion_glyph(gregorio_glyph **last_glyph,
     int prev_shift = 0, shift, shift2;
     gregorio_note *result;
 
-    if ((*first_note)->type == GRE_TEXVERB_GLYPH) {
-        gregorio_message(_("Unexpected texverb at start of fusion"),
-                "close_fusion_glyph", VERBOSITY_ERROR, 0);
-        return real_last_note;
-    }
+    gregorio_assert((*first_note)->type != GRE_TEXVERB_GLYPH,
+            close_fusion_glyph, "Unexpected texverb at start of fusion",
+            return real_last_note);
 
     for (last_note = real_last_note;
             last_note != *first_note && last_note->type == GRE_TEXVERB_GLYPH;
@@ -658,19 +652,16 @@ static gregorio_note *close_fusion_glyph(gregorio_glyph **last_glyph,
                     (*first_note)->type, &((*first_note)->u.other), _NO_SIGN,
                     (*first_note)->texverb);
             (*first_note)->texverb = NULL;
-            if (*first_note == last_note) {
-                gregorio_message(_("Unexpected texverb at end of fusion"),
-                        "close_fusion_glyph", VERBOSITY_ERROR, 0);
-                return last_note;
-            }
+            gregorio_assert(*first_note != last_note,
+                    close_fusion_glyph, "Unexpected texverb at end of fusion",
+                    return last_note);
             gregorio_free_one_note(first_note);
         }
 
-        if (*first_note == last_note || !(next = (*first_note)->next)) {
-            gregorio_message(_("Unexpected single note during fusion"),
-                    "close_fusion_glyph", VERBOSITY_ERROR, 0);
-            return last_note;
-        }
+        gregorio_assert(
+                *first_note != last_note && (next = (*first_note)->next),
+                close_fusion_glyph, "Unexpected single note during fusion",
+                return last_note);
 
         next = next_non_texverb_note(*first_note, last_note);
 
@@ -690,11 +681,8 @@ static gregorio_note *close_fusion_glyph(gregorio_glyph **last_glyph,
         if (prev_shift >= 0 && shift < 0) {
             /* check for a porrectus-like flexus */
             gregorio_note *next_next = next_non_texverb_note(next, last_note);
-            if (!next_next) {
-                gregorio_message(_("Unexpected end of notes during fusion"),
-                        "close_fusion_glyph", VERBOSITY_ERROR, 0);
-                return last_note;
-            }
+            gregorio_assert(next_next, close_fusion_glyph,
+                    "Unexpected end of notes during fusion", return last_note);
             shift2 = next_next->u.note.pitch - next->u.note.pitch;
             if (shift2 > 0) {
                 if (next_next == last_note) {

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -421,7 +421,7 @@ static void rebuild_characters(void)
             } else {
                 if (ch->cos.s.style == ST_ELISION) {
                     gregorio_message(
-                            _("score initial may not be in an elision "),
+                            _("score initial may not be in an elision"),
                             "rebuild_characters", VERBOSITY_ERROR, 0);
                     break;
                 }
@@ -696,9 +696,12 @@ gregorio_score *gabc_read_score(FILE *f_in)
     /* the input file that flex will parse */
     gabc_score_determination_in = f_in;
     if (!f_in) {
-        gregorio_message(_("can't read stream from argument, returning NULL "
-                "pointer"), "det_score", VERBOSITY_ERROR, 0);
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_message(_("can't read stream from NULL"), "gabc_read_score",
+                VERBOSITY_FATAL, 0);
         return NULL;
+        /* LCOV_EXCL_STOP */
     }
     initialize_variables();
     /* the flex/bison main call, it will build the score (that we have
@@ -715,7 +718,7 @@ gregorio_score *gabc_read_score(FILE *f_in)
         gregorio_free_score(score);
         score = NULL;
         gregorio_message(_("unable to determine a valid score from file"),
-                "det_score", VERBOSITY_FATAL, 0);
+                "gabc_read_score", VERBOSITY_FATAL, 0);
     }
     sha1_finish_ctx(&digester, score->digest);
     return score;
@@ -749,8 +752,11 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
             current_element = elements[voice];
         }
         if (!current_element) {
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
             gregorio_message(_("current_element is null, this shouldn't "
                     "happen!"), "gabc_y_add_notes", VERBOSITY_FATAL, 0);
+            /* LCOV_EXCL_STOP */
         }
         if (!current_element->nabc) {
             current_element->nabc = (char **) gregorio_calloc (nabc_lines,

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -44,12 +44,15 @@ static __inline char pitch_letter(const char height) {
     return result;
 }
 
-static __inline void unsupported(const char *fn, const char *type,
-        const char *value)
+/* not reachable unless there's a programming error */
+/* LCOV_EXCL_START */
+static __inline void unsupported(const char *fn, const int line,
+        const char *type, const char *value)
 {
-    gregorio_messagef(fn, VERBOSITY_ERROR, 0, _("unsupported %s %s"), type,
-            value);
+    gregorio_messagef(fn, VERBOSITY_ASSERTION, line, _("unsupported %s %s"),
+            type, value);
 }
+/* LCOV_EXCL_STOP */
 
 /*
  * Output one attribute, allowing for multi-line values 
@@ -113,9 +116,12 @@ static void gabc_write_begin(FILE *f, grestyle_style style)
         /* nothing should be emitted for these */
         break;
     default:
-        unsupported("gabc_write_begin", "style",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_begin", __LINE__, "style",
                 grestyle_style_to_string(style));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -160,9 +166,12 @@ static void gabc_write_end(FILE *f, grestyle_style style)
         /* nothing should be emitted for these */
         break;
     default:
-        unsupported("gabc_write_end", "style",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_end", __LINE__, "style",
                 grestyle_style_to_string(style));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -284,9 +293,12 @@ static void gabc_write_space(FILE *f, gregorio_space type, char *factor,
         fprintf(f, "!/[%s]", factor);
         break;
     default:
-        unsupported("gabc_write_space", "space type",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_space", __LINE__, "space type",
                 gregorio_space_to_string(type));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -339,9 +351,12 @@ static void gabc_write_bar(FILE *f, gregorio_bar type)
         fprintf(f, ";8");
         break;
     default:
-        unsupported("gabc_write_bar", "bar type",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_bar", __LINE__, "bar type",
                 gregorio_bar_to_string(type));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -363,9 +378,12 @@ static void gabc_write_bar_signs(FILE *f, gregorio_sign type)
         /* if there's no sign, don't emit anything */
         break;
     default:
-        unsupported("gabc_write_bar_signs", "bar signs",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_bar_signs", __LINE__, "bar signs",
                 gregorio_sign_to_string(type));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -390,9 +408,12 @@ static void gabc_hepisema(FILE *f, const char *prefix, bool connect,
         /* nothing to print */
         break;
     default:
-        unsupported("gabc_hepisema", "hepisema size",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_hepisema", __LINE__, "hepisema size",
                 grehepisema_size_to_string(size));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -417,9 +438,12 @@ static const char *mora_vposition(gregorio_note *note)
     case VPOS_BELOW:
         return "0";
     default:
-        unsupported("mora_vposition", "vposition",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("mora_vposition", __LINE__, "vposition",
                 gregorio_vposition_to_string(note->mora_vposition));
         return "";
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -442,17 +466,10 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         char glyph_type)
 {
     char shape;
-    if (!note) {
-        gregorio_message(_("call with NULL argument"),
-                "gabc_write_gregorio_note", VERBOSITY_ERROR, 0);
-        return;
-    }
-    if (note->type != GRE_NOTE) {
-        gregorio_message(_("call with argument which type is not GRE_NOTE, "
-                    "wrote nothing"), "gabc_write_gregorio_note",
-                VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(note, gabc_write_gregorio_note, "call with NULL argument",
+            return);
+    gregorio_assert(note->type == GRE_NOTE, gabc_write_gregorio_note,
+            "call with argument which type is not GRE_NOTE", return);
     if (glyph_type == G_PES_QUADRATUM) {
         shape = S_QUADRATUM;
     } else {
@@ -562,10 +579,13 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         fprintf(f, "%cq", pitch_letter(note->u.note.pitch));
         break;
     default:
-        unsupported("gabc_write_gregorio_note", "shape",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_gregorio_note", __LINE__, "shape",
                 gregorio_shape_to_string(shape));
         fprintf(f, "%c", pitch_letter(note->u.note.pitch));
         break;
+        /* LCOV_EXCL_STOP */
     }
     switch (note->signs) {
     case _PUNCTUM_MORA:
@@ -587,9 +607,12 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         /* if there's no sign, don't emit anything */
         break;
     default:
-        unsupported("gabc_write_gregorio_note", "shape signs",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_gregorio_note", __LINE__, "shape signs",
                 gregorio_sign_to_string(note->signs));
         break;
+        /* LCOV_EXCL_STOP */
     }
     switch (note->special_sign) {
     case _ACCENTUS:
@@ -611,9 +634,12 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         /* if there's no sign, don't emit anything */
         break;
     default:
-        unsupported("gabc_write_gregorio_note", "special sign",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_gregorio_note", __LINE__, "special sign",
                 gregorio_sign_to_string(note->special_sign));
         break;
+        /* LCOV_EXCL_STOP */
     }
     if (note->h_episema_above == HEPISEMA_AUTO
             && note->h_episema_below == HEPISEMA_AUTO) {
@@ -648,11 +674,8 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
 
     gregorio_note *current_note;
 
-    if (!glyph) {
-        gregorio_message(_("call with NULL argument"),
-                "gabc_write_gregorio_glyph", VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(glyph, gabc_write_gregorio_glyph, "call with NULL argument",
+            return);
     switch (glyph->type) {
     case GRE_TEXVERB_GLYPH:
         if (glyph->texverb) {
@@ -669,13 +692,19 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
                 fprintf(f, "/0");
                 break;
             default:
-                gregorio_message(_("bad space"), "gabc_write_gregorio_glyph",
-                        VERBOSITY_ERROR, 0);
+                /* not reachable unless there's a programming error */
+                /* LCOV_EXCL_START */
+                unsupported("gabc_write_gregorio_glyph", __LINE__, "space type",
+                        gregorio_space_to_string(
+                            glyph->u.misc.unpitched.info.space));
                 break;
+                /* LCOV_EXCL_STOP */
             }
         } else {
-            gregorio_message(_("bad space"), "gabc_write_gregorio_glyph",
-                    VERBOSITY_ERROR, 0);
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
+            gregorio_fail(gabc_write_gregorio_glyph, "bad space");
+            /* LCOV_EXCL_STOP */
         }
         break;
     case GRE_MANUAL_CUSTOS:
@@ -697,9 +726,12 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
         gabc_write_end_liquescentia(f, glyph->u.notes.liquescentia);
         break;
     default:
-        unsupported("gabc_write_gregorio_glyph", "glyph type",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_gregorio_glyph", __LINE__, "glyph type",
                 gregorio_type_to_string(glyph->type));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -715,11 +747,8 @@ static void gabc_write_gregorio_glyph(FILE *f, gregorio_glyph *glyph)
 static void gabc_write_gregorio_element(FILE *f, gregorio_element *element)
 {
     gregorio_glyph *current_glyph;
-    if (!element) {
-        gregorio_message(_("call with NULL argument"),
-                "gabc_write_gregorio_element", VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(element, gabc_write_gregorio_element,
+            "call with NULL argument", return);
     current_glyph = element->u.first_glyph;
     switch (element->type) {
     case GRE_ELEMENT:
@@ -768,10 +797,30 @@ static void gabc_write_gregorio_element(FILE *f, gregorio_element *element)
             fprintf(f, "z0");
         }
         break;
+    case GRE_NLBA:
+        switch (element->u.misc.unpitched.info.nlba) {
+        case NLBA_BEGINNING:
+            fprintf(f, "<nlba>");
+            break;
+        case NLBA_END:
+            fprintf(f, "</nlba>");
+            break;
+        default:
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
+            unsupported("gabc_write_gregorio_element", __LINE__, "nlba type",
+                    gregorio_nlba_to_string(element->u.misc.unpitched.info.nlba));
+            break;
+            /* LCOV_EXCL_STOP */
+        }
+        break;
     default:
-        unsupported("gabc_write_gregorio_element", "element type",
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        unsupported("gabc_write_gregorio_element", __LINE__, "element type",
                 gregorio_type_to_string(element->type));
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -808,10 +857,13 @@ static void gabc_write_gregorio_syllable(FILE *f, gregorio_syllable *syllable,
         int number_of_voices)
 {
     int voice = 0;
-    if (!syllable) {
-        gregorio_message(_("call with NULL argument"), "gabc_write_syllable",
-                VERBOSITY_ERROR, 0);
-        return;
+    gregorio_assert(syllable, gabc_write_gregorio_syllable,
+            "call with NULL argument", return);
+    if (syllable->no_linebreak_area == NLBA_BEGINNING) {
+        fprintf(f, "<nlba>");
+    }
+    if (syllable->euouae == EUOUAE_BEGINNING) {
+        fprintf(f, "<eu>");
     }
     if (syllable->text) {
         /* we call the magic function (defined in struct_utils.c), that will
@@ -826,6 +878,12 @@ static void gabc_write_gregorio_syllable(FILE *f, gregorio_syllable *syllable,
                 &gabc_write_verb, &gabc_print_char, &gabc_write_begin,
                 &gabc_write_end, &gabc_write_special_char);
         fprintf(f, "]");
+    }
+    if (syllable->euouae == EUOUAE_END) {
+        fprintf(f, "</eu>");
+    }
+    if (syllable->no_linebreak_area == NLBA_END) {
+        fprintf(f, "</nlba>");
     }
     fprintf(f, "(");
     while (voice < number_of_voices - 1) {
@@ -861,9 +919,12 @@ void gabc_write_score(FILE *f, gregorio_score *score)
     gregorio_header *header;
 
     if (!f) {
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
         gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
-                VERBOSITY_ERROR, 0);
+                VERBOSITY_FATAL, 0);
         return;
+        /* LCOV_EXCL_STOP */
     }
 
     for (header = score->headers; header; header = header->next) {

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -655,4 +655,4 @@ int main(int argc, char **argv)
     }
 
     exit(gregorio_get_return_value());
-}
+} /* due to exit on prior line, this will never be reached; LCOV_EXCL_LINE */

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -1543,11 +1543,11 @@ static __inline int compute_fused_shift(const gregorio_glyph *glyph)
     case S_FLAT:
     case S_SHARP:
     case S_NATURAL:
-        /* if this glyph starts with one of these, it's not fusable */
+        /* if this glyph starts with one of these, it's not fusible */
         return 0;
 
     default:
-        /* anything else is potentially fusable */
+        /* anything else is potentially fusible */
         break;
     }
 
@@ -1555,11 +1555,11 @@ static __inline int compute_fused_shift(const gregorio_glyph *glyph)
     case G_PUNCTUM:
     case G_FLEXA:
     case G_VIRGA_REVERSA:
-        /* these are potentially fusable to this note */
+        /* these are potentially fusible to this note */
         break;
 
     default:
-        /* everything else is not fusable */
+        /* everything else is not fusible */
         return 0;
     }
 
@@ -1582,7 +1582,7 @@ static __inline int compute_fused_shift(const gregorio_glyph *glyph)
         return 0;
 
     default:
-        /* anything else is potentially fusable */
+        /* anything else is potentially fusible */
         break;
     }
 
@@ -1598,9 +1598,10 @@ static __inline int compute_fused_shift(const gregorio_glyph *glyph)
     }
 
     /* the FLEXA check below checks for a porrectus-like flexus, which is not
-     * fusable from above */
+     * fusible from above */
     if (shift < 0 && ((next_is_fused && glyph->u.notes.glyph_type == G_FLEXA)
                 || glyph->u.notes.glyph_type == G_PORRECTUS
+                || glyph->u.notes.glyph_type == G_PODATUS
                 || (previous->u.notes.glyph_type == G_PUNCTUM
                     && is_initio_debilis(previous->u.notes.liquescentia)))) {
         /* may not be fused from above */

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -333,11 +333,8 @@ static __inline int compute_ambitus(const gregorio_note *const current_note)
     } else {
         ambitus = first - second;
     }
-    if (ambitus < 1 || ambitus > MAX_AMBITUS) {
-        gregorio_messagef("compute_ambitus", VERBOSITY_ERROR, 0,
-                _("unsupported ambitus: %d"), ambitus);
-        return 0;
-    }
+    gregorio_assert2(ambitus >= 1 && ambitus <= MAX_AMBITUS, compute_ambitus,
+            "unsupported ambitus: %d", ambitus, return 0);
     return ambitus;
 }
 
@@ -357,30 +354,22 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
             ? previous->u.notes.fuse_to_next_glyph : 0;
 
     /* then we start making our formula */
-    if (!glyph) {
-        gregorio_message(_("called with NULL pointer"),
-                "compute_glyph_name", VERBOSITY_ERROR, 0);
-        return "";
-    }
-    if (!glyph->u.notes.first_note) {
-        gregorio_message(_("called with a glyph that have no note"),
-                "compute_glyph_name", VERBOSITY_ERROR, 0);
-        return "";
-    }
+    gregorio_assert(glyph, compute_glyph_name, "called with NULL pointer",
+            return "");
+    gregorio_assert(glyph->u.notes.first_note, compute_glyph_name,
+            "called with a glyph that have no note", return "");
 
     fuse_to_next_note = glyph->u.notes.fuse_to_next_glyph;
 
     switch (glyph->u.notes.glyph_type) {
     case G_PODATUS:
-        if (!is_tail_liquescentia(glyph->u.notes.liquescentia)
-                && fuse_from_previous_note < 0) {
-            /* a normal pes cannot be fused from above */
-            break;
-        }
+        gregorio_assert(is_tail_liquescentia(glyph->u.notes.liquescentia)
+                || fuse_from_previous_note >= 0, compute_glyph_name,
+                "unexpected fusible podatus", break);
         /* else fall through */
     case G_PUNCTUM:
     case G_FLEXA:
-        /* directionally head-fusable */
+        /* directionally head-fusible */
         if (fuse_from_previous_note < -1
                 && glyph->u.notes.first_note->u.note.shape != S_QUILISMA
                 && glyph->u.notes.first_note->u.note.shape
@@ -404,20 +393,20 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
         break;
 
     default:
-        /* not directionally head-fusable */
+        /* not directionally head-fusible */
         break;
     }
 
     switch (glyph->u.notes.glyph_type) {
     case G_FLEXA:
         if (fuse_to_next_note <= 0) {
-            /* a flexa is only fusable up */
+            /* a flexa is only fusible up */
             break;
         }
         /* else fall through */
     case G_VIRGA_REVERSA:
     case G_PUNCTUM:
-        /* tail-fusable */
+        /* tail-fusible */
         if (fuse_to_next_note < 0) {
             fuse_tail = FUSE_Down;
             fuse_ambitus = -fuse_to_next_note;
@@ -432,7 +421,7 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
         break;
 
     default:
-        /* not tail-fusable */
+        /* not tail-fusible */
         break;
     }
 
@@ -469,14 +458,11 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
                 tex_ambitus[fuse_ambitus], liquescentia, fuse_tail);
         return buf;
     }
-    if (!current_note->next) {
-       gregorio_message(_("called with a multi-note glyph that has only "
-                   "one note"), "compute_glyph_name", VERBOSITY_ERROR, 0);
-       return "";
-    }
-    if (!(ambitus1 = compute_ambitus(current_note))) {
-        return "";
-    }
+    gregorio_assert(current_note->next, compute_glyph_name,
+            "called with a multi-note glyph that has only one note", return "");
+    gregorio_assert((ambitus1 = compute_ambitus(current_note)),
+            compute_glyph_name, "unexpected unison on multi-note glyph",
+            return "");
     if (is_fused(glyph->u.notes.liquescentia)) {
         if (shape == SHAPE_Flexus || shape == SHAPE_FlexusLongqueue) {
             if (fuse_to_next_note) {
@@ -508,9 +494,9 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
                 liquescentia, fuse_tail);
         return buf;
     }
-    if (!(ambitus2 = compute_ambitus(current_note))) {
-        return "";
-    }
+    gregorio_assert((ambitus2 = compute_ambitus(current_note)),
+            compute_glyph_name, "unexpected unison on multi-note glyph",
+            return "");
     current_note = current_note->next;
     if (!current_note->next) {
         gregorio_snprintf(buf, BUFSIZE, "%s%s%s%s%s%s%s", fuse_head, shape,
@@ -518,9 +504,9 @@ static const char *compute_glyph_name(const gregorio_glyph *const glyph,
                 tex_ambitus[fuse_ambitus], liquescentia, fuse_tail);
         return buf;
     }
-    if (!(ambitus3 = compute_ambitus(current_note))) {
-        return "";
-    }
+    gregorio_assert((ambitus3 = compute_ambitus(current_note)),
+            compute_glyph_name, "unexpected unison on multi-note glyph",
+            return "");
     gregorio_snprintf(buf, BUFSIZE, "%s%s%s%s%s%s%s%s", fuse_head, shape,
             tex_ambitus[ambitus1], tex_ambitus[ambitus2], tex_ambitus[ambitus3],
             tex_ambitus[fuse_ambitus], liquescentia, fuse_tail);
@@ -533,11 +519,8 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
     static char buf[128];
     const char *name;
 
-    if (!note) {
-        gregorio_message(_("called with NULL pointer"),
-                "gregoriotex_determine_note_glyph_name", VERBOSITY_ERROR, 0);
-        return "";
-    }
+    gregorio_assert(note, gregoriotex_determine_note_glyph_name,
+            "called with NULL pointer", return "");
 
     *type = AT_ONE_NOTE;
     switch (note->u.note.shape) {
@@ -651,10 +634,13 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
     case S_NATURAL:
         return SHAPE_Natural;
     default:
-        gregorio_messagef("gregoriotex_determine_note_glyph_name",
-                VERBOSITY_ERROR, 0, _("called with unknown shape: %s"),
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_fail2(gregoriotex_determine_note_glyph_name,
+                "called with unknown shape: %s",
                 gregorio_shape_to_string(note->u.note.shape));
         return "";
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -669,16 +655,10 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
     const char *shape = NULL;
     gtex_glyph_liquescentia ltype;
     char pitch = 0;
-    if (!glyph) {
-        gregorio_message(_("called with NULL pointer"),
-                "gregoriotex_determine_glyph_name", VERBOSITY_ERROR, 0);
-        return "";
-    }
-    if (!glyph->u.notes.first_note) {
-        gregorio_message(_("called with a glyph that has no note"),
-                "gregorio_tex_determine_glyph_name", VERBOSITY_ERROR, 0);
-        return "";
-    }
+    gregorio_assert(glyph, gregoriotex_determine_glyph_name,
+            "called with NULL pointer", return "");
+    gregorio_assert(glyph->u.notes.first_note, gregoriotex_determine_glyph_name,
+            "called with a glyph that has no note", return "");
     *gtype = T_ONE_NOTE;
     switch (glyph->u.notes.glyph_type) {
     case G_PODATUS:
@@ -953,10 +933,13 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         *type = AT_ONE_NOTE;
         break;
     default:
-        gregorio_messagef("gregoriotex_determine_glyph_name", VERBOSITY_ERROR,
-                0, _("called with unknown glyph: %s"),
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_fail2(gregoriotex_determine_glyph_name,
+                "called with unknown glyph: %s",
                 gregorio_glyph_type_to_string(glyph->u.notes.glyph_type));
         break;
+        /* LCOV_EXCL_STOP */
     }
     if (shape) {
         shape = compute_glyph_name(glyph, shape, ltype, false);
@@ -977,9 +960,8 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
  */
 static void gregoriotex_write_voice_info(FILE *f, gregorio_voice_info *voice_info)
 {
-    if (!f || !voice_info) {
-        return;
-    }
+    gregorio_assert(f && voice_info, gregoriotex_write_voice_info,
+            "file or voice_info passed as NULL", return);
 }
 
 /* this function indicates if the syllable is the last of the line. If it's the
@@ -1031,9 +1013,9 @@ static gregorio_element *gregoriotex_syllable_is_clef_change(gregorio_syllable
         *syllable)
 {
     gregorio_element *element;
-    if (!syllable || !syllable->elements || !syllable->elements[0]) {
-        return NULL;
-    }
+    gregorio_assert(syllable && syllable->elements && syllable->elements[0],
+            gregoriotex_syllable_is_clef_change, "invalid syllable",
+            return NULL);
     element = syllable->elements[0];
     /* we just detect the foud cases */
     if (element->type == GRE_CUSTOS && element->next
@@ -1147,7 +1129,6 @@ static __inline void tex_escape_text(FILE *const f, const char *text)
             fprintf(f, "\\string\\%03d", *text);
             break;
         case '\n':
-            /* currently, we'll never get \n, but handle it anyway */
             fprintf(f, "\\string\\n");
             break;
         case '\r':
@@ -1182,7 +1163,6 @@ static __inline void tex_escape_wtext(FILE *const f, const grewchar *text)
             fprintf(f, "\\string\\%03d", *text);
             break;
         case L'\n':
-            /* currently, we'll never get \n, but handle it anyway */
             fprintf(f, "\\string\\n");
             break;
         case L'\r':
@@ -1248,31 +1228,29 @@ static void gtex_print_char(FILE *f, const grewchar to_print)
 
 /* a function to map the internal ST_* styles to gregoriotex styles as defined
  * in gregoriotex-syllables.tex */
-static unsigned char gregoriotex_internal_style_to_gregoriotex(grestyle_style
-        style)
+static unsigned char gregoriotex_internal_style_to_gregoriotex(
+        const grestyle_style style)
 {
     switch (style) {
     case ST_ITALIC:
         return 1;
-        break;
     case ST_BOLD:
         return 2;
-        break;
     case ST_SMALL_CAPS:
         return 3;
-        break;
     case ST_TT:
         return 4;
-        break;
     case ST_UNDERLINED:
         return 5;
-        break;
     case ST_COLORED:
         return 6;
-        break;
     default:
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_fail2(gregoriotex_internal_style_to_gregoriotex,
+                "unrecognized style: %s", grestyle_style_to_string(style));
         return 0;
-        break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -1281,25 +1259,36 @@ static unsigned char gregoriotex_internal_style_to_gregoriotex(grestyle_style
  * when this style is on all the parts, then we return this style.
  *
  */
+typedef enum {
+    FSS_NONE = 0, FSS_STYLE_FOUND, FSS_STYLE_FOUND_PART_CHANGED
+} fixed_style_state;
 static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
 {
     grestyle_style possible_fixed_style = ST_NO_STYLE;
-    unsigned char state = 0;
+    fixed_style_state state = FSS_NONE;
     /*
-     * states are: - 0: we didn't meet any style yet, which means that if we
-     * encounter: * a character -> we can return, nothing to do * a style -> we
-     * go in state 1 * center or initial: stay in state 0 - 1: we encountered a
-     * style, if we encounter * another style : we can return * something that
-     * makes us change syllable part (like center or initial) -> go in state 2 *
-     * a character : stay in state 1 - 2: if we encounter: * another style, then
-     * return * a character, then return * the same style: go in state 1 
+     * states are:
+     * - FSS_NONE: we didn't meet any style yet, which means that if we encounter:
+     *     * a character -> we can return, nothing to do
+     *     * a style -> we go in state FSS_STYLE_FOUND
+     *     * center or initial: stay in state FSS_NONE
+     * - FSS_STYLE_FOUND: we encountered a style, if we encounter
+     *     * another style : we can return
+     *     * something that makes us change syllable part (like center or
+     *       initial) -> go in state FSS_STYLE_FOUND_PART_CHANGED
+     *     * a character : stay in state FSS_STYLE_FOUND
+     * - FSS_STYLE_FOUND_PART_CHANGED: if we encounter:
+     *     * another style, then return
+     *     * a character, then return
+     *     * the same style: go in state FSS_STYLE_FOUND
      */
     gregorio_character *current_char = first_character;
     while (current_char) {
         switch (state) {
-        case 0:
-            if (current_char->is_character)
-                return 0;
+        case FSS_NONE:
+            if (current_char->is_character) {
+                return ST_NO_STYLE;
+            }
             if (current_char->cos.s.style != ST_CENTER
                     && current_char->cos.s.style != ST_FORCED_CENTER
                     && current_char->cos.s.style != ST_FIRST_WORD
@@ -1309,10 +1298,10 @@ static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
                     && current_char->cos.s.style != ST_VERBATIM
                     && current_char->cos.s.style != ST_INITIAL) {
                 possible_fixed_style = current_char->cos.s.style;
-                state = 1;
+                state = FSS_STYLE_FOUND;
             }
             break;
-        case 1:
+        case FSS_STYLE_FOUND:
             if (!current_char->is_character) {
                 if (!current_char->is_character
                         && current_char->cos.s.style != ST_CENTER
@@ -1321,16 +1310,18 @@ static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
                         && current_char->cos.s.style != ST_FIRST_SYLLABLE
                         && current_char->cos.s.style != ST_FIRST_SYLLABLE_INITIAL
                         && current_char->cos.s.style != ST_INITIAL) {
-                    state = 2;
+                    state = FSS_STYLE_FOUND_PART_CHANGED;
                 } else if (current_char->cos.s.style != possible_fixed_style
                         && current_char->cos.s.style != ST_SPECIAL_CHAR
-                        && current_char->cos.s.style != ST_VERBATIM)
-                    return 0;
+                        && current_char->cos.s.style != ST_VERBATIM) {
+                    return ST_NO_STYLE;
+                }
             }
             break;
-        case 2:
-            if (current_char->is_character)
-                return 0;
+        case FSS_STYLE_FOUND_PART_CHANGED:
+            if (current_char->is_character) {
+                return ST_NO_STYLE;
+            }
             if (current_char->cos.s.style != ST_CENTER
                     && current_char->cos.s.style != ST_FORCED_CENTER
                     && current_char->cos.s.style != ST_FIRST_WORD
@@ -1340,19 +1331,26 @@ static grestyle_style gregoriotex_fix_style(gregorio_character *first_character)
                     && current_char->cos.s.style != ST_VERBATIM
                     && current_char->cos.s.style != ST_INITIAL) {
                 if (current_char->cos.s.style != possible_fixed_style) {
-                    return 0;
+                    return ST_NO_STYLE;
                 } else {
-                    state = 1;
+                    state = FSS_STYLE_FOUND;
                 }
             }
             break;
         default:
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
+            assert(false);
             break;
+            /* LCOV_EXCL_STOP */
         }
         current_char = current_char->next_character;
     }
     /* if we reached here, this means that we there is only one style applied
      * to all the characters */
+    if (possible_fixed_style == ST_ELISION) {
+        return ST_NO_STYLE;
+    }
     return possible_fixed_style;
 }
 
@@ -1404,9 +1402,11 @@ static char clef_flat_height(gregorio_clef clef, signed char line, bool flatted)
             offset = 10;
             break;
         default:
-            gregorio_messagef("clef_flat_height", VERBOSITY_ERROR,
-                    0, _("unknown line number: %d"), line);
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
+            gregorio_fail2(clef_flat_height, "unknown line number: %d", line);
             break;
+            /* LCOV_EXCL_STOP */
         }
         break;
     case CLEF_F:
@@ -1427,15 +1427,19 @@ static char clef_flat_height(gregorio_clef clef, signed char line, bool flatted)
             offset = 7;
             break;
         default:
-            gregorio_messagef("clef_flat_height", VERBOSITY_ERROR,
-                    0, _("unknown line number: %d"), line);
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
+            gregorio_fail2(clef_flat_height, "unknown line number: %d", line);
             break;
+            /* LCOV_EXCL_STOP */
         }
         break;
     default:
-        gregorio_messagef("clef_flat_height", VERBOSITY_ERROR, 0,
-                _("unknown clef type: %d"), clef);
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_fail2(clef_flat_height, "unknown clef type: %d", clef);
         break;
+        /* LCOV_EXCL_STOP */
     }
 
     return pitch_value(LOWEST_PITCH + offset);
@@ -1498,9 +1502,11 @@ static void write_bar(FILE *f, gregorio_bar type,
         fprintf(f, "Dominica{8}");
         break;
     default:
-        gregorio_messagef("write_bar", VERBOSITY_ERROR, 0,
-                _("unknown bar type: %d"), type);
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_fail2(write_bar, "unknown bar type: %d", type);
         break;
+        /* LCOV_EXCL_STOP */
     }
     fprintf(f, "{%c}", has_text? '1' : '0');
     switch (signs) {
@@ -1835,7 +1841,7 @@ static __inline int get_punctum_inclinatum_space_case(
                     }
                 }
             }
-        }
+        } /* LCOV_EXCL_LINE */
         break;
     case S_PUNCTUM_INCLINATUM_AUCTUS:
     case S_PUNCTUM_CAVUM_INCLINATUM_AUCTUS:
@@ -1979,9 +1985,8 @@ static void gregoriotex_write_hepisema(FILE *const f,
 {
     int porrectus_long_episema_index = -1;
 
-    if (!note) {
-        return;
-    }
+    gregorio_assert(note, gregoriotex_write_hepisema,
+            "called with NULL pointer", return);
 
     switch (type) {
     case T_PORRECTUS:
@@ -2011,11 +2016,8 @@ static void write_additional_line(FILE *f, int i, gtex_type type, bool bottom,
         gregorio_note *current_note, const gregorio_score *const score)
 {
     char ambitus = 0;
-    if (!current_note) {
-        gregorio_message(_("called with no note"), "write_additional_line",
-                VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(current_note, write_additional_line, "called with no note",
+            return);
     /* patch to get a line under the full glyph in the case of dbc (for
      * example) */
     switch (type) {
@@ -2137,7 +2139,11 @@ static void gregoriotex_write_rare(FILE *f, gregorio_note *current_note,
         /* the cases of the bar signs are dealt in another function
          * (write_bar) */
     default:
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        assert(false);
         break;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -2153,12 +2159,8 @@ static void gregoriotex_write_note(FILE *f, gregorio_note *note,
     int space_case;
     /* type in the sense of GregorioTeX alignment type */
     gtex_alignment type = AT_ONE_NOTE;
-    if (!note) {
-        gregorio_message(_
-                ("called with NULL pointer"),
-                "gregoriotex_write_note", VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(note, gregoriotex_write_note, "called with NULL pointer",
+            return);
     if (note->u.note.shape == S_PUNCTUM) {
         switch (note->u.note.liquescentia) {
         case L_AUCTUS_ASCENDENS:
@@ -2253,11 +2255,9 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
     int alteration = 0;
     gregorio_glyph *glyph;
     gregorio_element *element;
-    if (!syllable || !syllable->elements) {
-        gregorio_message(_("called with a NULL argument"),
-                "gregoriotex_syllable_first_type", VERBOSITY_ERROR, 0);
-        return 0;
-    }
+    gregorio_assert(syllable && syllable->elements,
+            gregoriotex_syllable_first_type, "called with a NULL argument",
+            return 0);
     element = syllable->elements[0];
     while (element) {
         if (element->type == GRE_BAR) {
@@ -2283,8 +2283,12 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
                 result = 12;
                 break;
             default:
+                /* not reachable unless there's a programming error */
+                /* LCOV_EXCL_START */
+                gregorio_fail(gregoriotex_syllable_first_type, "invalid bar");
                 result = 0;
                 break;
+                /* LCOV_EXCL_STOP */
             }
             return result;
         }
@@ -2305,8 +2309,12 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
                                 alteration = 60;
                                 break;
                             default:
-                                /* do nothing */
+                                /* not reachable unless there's a programming error */
+                                /* LCOV_EXCL_START */
+                                gregorio_fail(gregoriotex_syllable_first_type,
+                                        "invalid alteration");
                                 break;
+                                /* LCOV_EXCL_STOP */
                             }
                         }
                         continue;
@@ -2653,16 +2661,9 @@ static void write_glyph(FILE *f, gregorio_syllable *syllable,
     int fuse_to_next_note, fuse_from_previous_note =
             (prev_glyph && prev_glyph->type == GRE_GLYPH)
             ? prev_glyph->u.notes.fuse_to_next_glyph : 0;
-    if (!glyph) {
-        gregorio_message(_("called with NULL pointer"), "write_glyph",
-                VERBOSITY_ERROR, 0);
-        return;
-    }
-    if (glyph->type != GRE_GLYPH || !glyph->u.notes.first_note) {
-        gregorio_message(_("called with glyph without note"), "write_glyph",
-                VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(glyph, write_glyph, "called with NULL pointer", return);
+    gregorio_assert(glyph->type == GRE_GLYPH && glyph->u.notes.first_note,
+            write_glyph, "called with glyph without note", return);
     fuse_to_next_note = glyph->u.notes.fuse_to_next_glyph;
     if (fuse_from_previous_note) {
         fprintf(f, "\\GreFuse");
@@ -2884,10 +2885,12 @@ static void write_element(FILE *f, gregorio_syllable *syllable,
                     fprintf(f, "\\GreEndOfGlyph{22}%%\n");
                     break;
                 default:
-                    gregorio_message(
-                            _("encountered an unexpected glyph-level space"),
-                            "write_element", VERBOSITY_ERROR, 0);
+                    /* not reachable unless there's a programming error */
+                    /* LCOV_EXCL_START */
+                    gregorio_fail(write_element,
+                            "encountered an unexpected glyph-level space");
                     break;
+                    /* LCOV_EXCL_STOP */
                 }
                 break;
 
@@ -3044,7 +3047,7 @@ static __inline bool next_is_bar(const gregorio_syllable *syllable,
         element = syllable->elements[0];
     }
 
-    assert(false); /* should never reach here */
+    assert(false); /* should never reach here; LCOV_EXCL_LINE */
     return false; /* avoid gcc 5.1 warning */
 }
 
@@ -3430,10 +3433,12 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                             element->u.misc.unpitched.info.ad_hoc_space_factor);
                     break;
                 default:
-                    gregorio_message(
-                            _("encountered an unexpected element-level space"),
-                            "write_syllable", VERBOSITY_ERROR, 0);
+                    /* not reachable unless there's a programming error */
+                    /* LCOV_EXCL_START */
+                    gregorio_fail(write_syllable,
+                            "encountered an unexpected element-level space");
                     break;
+                    /* LCOV_EXCL_STOP */
                 }
                 break;
 
@@ -3669,16 +3674,10 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
 
     initialize_score(&status, score, point_and_click_filename != NULL);
 
-    if (!f) {
-        gregorio_message(_("call with NULL file"), "gregoriotex_write_score",
-                VERBOSITY_ERROR, 0);
-        return;
-    }
+    gregorio_assert(f, gregoriotex_write_score, "call with NULL file", return);
 
-    if (score->number_of_voices != 1) {
-        gregorio_message(_("gregoriotex only works in monophony (for the "
-                    "moment)"), "gregoriotex_write_score", VERBOSITY_ERROR, 0);
-    }
+    gregorio_assert_only(score->number_of_voices == 1, gregoriotex_write_score,
+            "gregoriotex only works in monophony (for the moment)");
 
     fprintf(f, "%% File generated by gregorio %s\n", GREGORIO_VERSION);
     fprintf(f, "\\GregorioTeXAPIVersion{%s}%%\n", VERSION);

--- a/src/gregoriotex/gregoriotex.h
+++ b/src/gregoriotex/gregoriotex.h
@@ -127,10 +127,7 @@ static __inline bool choral_sign_here_is_low(const gregorio_glyph *const glyph,
         if (kind_of_pes) {
             *kind_of_pes = true;
         }
-        if (note->u.note.shape != S_QUILISMA) {
-            return true;
-        }
-        break;
+        return true;
 
     default:
         break;

--- a/src/messages.c
+++ b/src/messages.c
@@ -73,6 +73,12 @@ static const char *verbosity_to_str(const gregorio_verbosity verbosity)
     case VERBOSITY_ERROR:
         str = _("error:");
         break;
+    case VERBOSITY_ASSERTION:
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        str = _("assertion:");
+        break;
+        /* LCOV_EXCL_STOP */
     case VERBOSITY_FATAL:
         str = _("fatal error:");
         break;
@@ -158,6 +164,7 @@ void gregorio_messagef(const char *function_name,
 
     switch (verbosity) {
     case VERBOSITY_ERROR:
+    case VERBOSITY_ASSERTION:
         return_value = 1;
         break;
     case VERBOSITY_FATAL:

--- a/src/messages.h
+++ b/src/messages.h
@@ -42,6 +42,7 @@ typedef enum gregorio_verbosity {
     VERBOSITY_WARNING,
     VERBOSITY_DEPRECATION,
     VERBOSITY_ERROR,
+    VERBOSITY_ASSERTION,
     VERBOSITY_FATAL
 } gregorio_verbosity;
 
@@ -55,5 +56,28 @@ void gregorio_set_verbosity_mode(gregorio_verbosity verbosity);
 void gregorio_set_file_name(const char *new_name);
 void gregorio_set_error_out(FILE *f);
 int gregorio_get_return_value(void);
+
+#define gregorio_assert_only(TEST,FUNCTION,MESSAGE) \
+    if (!(TEST)) { \
+        gregorio_message(_(MESSAGE), #FUNCTION, VERBOSITY_ASSERTION, __LINE__); \
+    }
+
+#define gregorio_assert(TEST,FUNCTION,MESSAGE,ON_FALSE) \
+    if (!(TEST)) { \
+        gregorio_message(_(MESSAGE), #FUNCTION, VERBOSITY_ASSERTION, __LINE__); \
+        ON_FALSE; \
+    }
+
+#define gregorio_assert2(TEST,FUNCTION,FORMAT,ARG,ON_FALSE) \
+    if (!(TEST)) { \
+        gregorio_messagef(#FUNCTION, VERBOSITY_ASSERTION, __LINE__, FORMAT, ARG); \
+        ON_FALSE; \
+    }
+
+#define gregorio_fail(FUNCTION,MESSAGE) \
+    gregorio_message(_(MESSAGE), #FUNCTION, VERBOSITY_ASSERTION, __LINE__)
+
+#define gregorio_fail2(FUNCTION,FORMAT,ARG) \
+    gregorio_messagef(#FUNCTION, VERBOSITY_ASSERTION, __LINE__, FORMAT, ARG)
 
 #endif

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -132,30 +132,6 @@ void *sha1_finish_ctx(struct sha1_ctx *ctx, void *resbuf)
     return sha1_read_ctx(ctx, resbuf);
 }
 
-/* Compute SHA1 message digest for LEN bytes beginning at BUFFER.  The
-   result is always in little endian byte order, so that a byte-wise
-   output yields to the wanted ASCII representation of the message
-   digest.  */
-void *sha1_buffer(const char *buffer, size_t len, void *resblock)
-{
-    struct sha1_ctx ctx;
-
-    /*
-     * Initialize the computation context.  
-     */
-    sha1_init_ctx(&ctx);
-
-    /*
-     * Process whole buffer but last len % 64 bytes.  
-     */
-    sha1_process_bytes(buffer, len, &ctx);
-
-    /*
-     * Put result in desired memory area.  
-     */
-    return sha1_finish_ctx(&ctx, resblock);
-}
-
 void sha1_process_bytes(const void *buffer, size_t len, struct sha1_ctx *ctx)
 {
     /*

--- a/src/struct.c
+++ b/src/struct.c
@@ -285,7 +285,9 @@ void gregorio_add_cs_to_note(gregorio_note *const*const current_note,
 void gregorio_add_special_sign(gregorio_note *note, gregorio_sign sign)
 {
     if (!note) {
-        /* error */
+        gregorio_message(_("trying to add a special sign to something that is "
+                    "not a note"), "gregorio_add_special_sign", VERBOSITY_ERROR,
+                0);
         return;
     }
     note->special_sign = sign;
@@ -386,7 +388,7 @@ void gregorio_change_shape(gregorio_note *note, gregorio_shape shape,
 {
     if (!note || note->type != GRE_NOTE) {
         gregorio_message(_("trying to change the shape of something that is "
-                           "not a note"), "change_shape", VERBOSITY_ERROR, 0);
+                    "not a note"), "change_shape", VERBOSITY_ERROR, 0);
         return;
     }
 
@@ -564,7 +566,7 @@ static void gregorio_activate_isolated_h_episema(gregorio_note *note,
                     "of a note sequence, ignored",
                     "isolated horizontal episema at the beginning of a note "
                     "sequence, ignored", n), "activate_h_isolated_episema",
-                VERBOSITY_WARNING, 0);
+                VERBOSITY_ERROR, 0);
         return;
     }
     if (note->type != GRE_NOTE) {
@@ -572,7 +574,7 @@ static void gregorio_activate_isolated_h_episema(gregorio_note *note,
                     "that is not a note, ignored",
                     "isolated horizontal episema after something that is not "
                     "a note, ignored", n), "activate_h_isolated_episema",
-                VERBOSITY_WARNING, 0);
+                VERBOSITY_ERROR, 0);
         return;
     }
     for (; n > 0; --n) {
@@ -580,7 +582,7 @@ static void gregorio_activate_isolated_h_episema(gregorio_note *note,
         if (!note || note->type != GRE_NOTE) {
             gregorio_message(_("found more horizontal episema than notes "
                         "able to be under"), "activate_h_isolated_episema",
-                    VERBOSITY_WARNING, 0);
+                    VERBOSITY_ERROR, 0);
             return;
         }
     }
@@ -598,9 +600,12 @@ void gregorio_add_h_episema(gregorio_note *note,
         return;
     }
     if (!nbof_isolated_episema) {
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
         gregorio_message(_("NULL argument nbof_isolated_episema"),
                 "add_h_episema", VERBOSITY_FATAL, 0);
         return;
+        /* LCOV_EXCL_STOP */
     }
     if (vposition && *nbof_isolated_episema) {
         gregorio_message(_("trying to add a forced horizontal episema on a "
@@ -634,7 +639,8 @@ void gregorio_add_sign(gregorio_note *note, gregorio_sign sign,
         gregorio_vposition vposition)
 {
     if (!note) {
-        /* error */
+        gregorio_message(_("trying to add a sign to something that is "
+                    "not a note"), "gregorio_add_sign", VERBOSITY_ERROR, 0);
         return;
     }
     switch (sign) {
@@ -1103,11 +1109,8 @@ static void gregorio_free_one_syllable(gregorio_syllable **syllable,
 {
     int i;
     gregorio_syllable *next;
-    if (!syllable || !*syllable) {
-        gregorio_message(_("function called with NULL argument"),
-                "free_one_syllable", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(syllable && *syllable, gregorio_free_one_syllable,
+            "function called with NULL argument", return);
     for (i = 0; i < number_of_voices; i++) {
         gregorio_free_elements((struct gregorio_element **)
                                &((*syllable)->elements[i]));
@@ -1128,11 +1131,8 @@ static void gregorio_free_one_syllable(gregorio_syllable **syllable,
 static void gregorio_free_syllables(gregorio_syllable **syllable,
         int number_of_voices)
 {
-    if (!syllable || !*syllable) {
-        gregorio_message(_("function called with NULL argument"),
-                "free_syllables", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(syllable && *syllable, gregorio_free_one_syllable,
+            "function called with NULL argument", return);
     while (*syllable) {
         gregorio_free_one_syllable(syllable, number_of_voices);
     }
@@ -1149,11 +1149,8 @@ gregorio_score *gregorio_new_score(void)
 
 static void gregorio_free_score_infos(gregorio_score *score)
 {
-    if (!score) {
-        gregorio_message(_("function called with NULL argument"),
-                "gregorio_free_score_infos", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(score, gregorio_free_score_infos,
+            "function called with NULL argument", return);
     /* don't free the strings coming from headers; they will be freed when the
      * headers themselves are freed */
     if (score->first_voice_info) {
@@ -1174,11 +1171,8 @@ static void free_headers(gregorio_score *score) {
 
 void gregorio_free_score(gregorio_score *score)
 {
-    if (!score) {
-        gregorio_message(_("function called with NULL argument"),
-                "free_one_syllable", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(score, gregorio_free_score,
+            "function called with NULL argument", return);
     gregorio_free_syllables(&(score->first_syllable), score->number_of_voices);
     gregorio_free_score_infos(score);
     free_headers(score);
@@ -1197,11 +1191,8 @@ void gregorio_add_voice_info(gregorio_voice_info **current_voice_info)
 void gregorio_free_voice_infos(gregorio_voice_info *voice_info)
 {
     gregorio_voice_info *next;
-    if (!voice_info) {
-        gregorio_message(_("function called with NULL argument"),
-                "free_voice_info", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(voice_info, gregorio_free_voice_infos,
+            "function called with NULL argument", return);
     while (voice_info) {
         next = voice_info->next_voice_info;
         free(voice_info);
@@ -1212,11 +1203,8 @@ void gregorio_free_voice_infos(gregorio_voice_info *voice_info)
 void gregorio_set_score_annotation(gregorio_score *score, char *annotation)
 {
     int annotation_num;
-    if (!score) {
-        gregorio_message(_("function called with NULL argument"),
-                "gregorio_set_annotation", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(score, gregorio_set_score_annotation,
+            "function called with NULL argument", return);
     /* save the annotation in the first spare place. */
     for (annotation_num = 0; annotation_num < MAX_ANNOTATIONS; ++annotation_num) {
         if (score->annotation[annotation_num] == NULL) {
@@ -1233,11 +1221,8 @@ void gregorio_set_score_annotation(gregorio_score *score, char *annotation)
 void gregorio_set_score_staff_lines(gregorio_score *const score,
         const char staff_lines)
 {
-    if (!score) {
-        gregorio_message(_("function called with NULL argument"),
-                "gregorio_set_score_staff_lines", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(score, gregorio_set_score_staff_lines,
+            "function called with NULL argument", return);
     if (staff_lines < 2 || staff_lines > 5) {
         gregorio_message(_("invalid number of staff lines"),
                 "gregorio_set_score_staff_lines", VERBOSITY_ERROR, 0);
@@ -1251,11 +1236,8 @@ void gregorio_set_score_staff_lines(gregorio_score *const score,
 void gregorio_add_score_header(gregorio_score *score, char *name, char *value)
 {
     gregorio_header *header;
-    if (!score) {
-        gregorio_message(_("function called with NULL argument"),
-                "gregorio_add_score_header", VERBOSITY_WARNING, 0);
-        return;
-    }
+    gregorio_assert(score, gregorio_add_score_header,
+            "function called with NULL argument", return);
     header = (gregorio_header *)gregorio_malloc(sizeof(gregorio_header));
     header->name = name;
     header->value = value;
@@ -1299,9 +1281,11 @@ int gregorio_calculate_new_key(gregorio_clef_info clef)
         return (2 * clef.line) - 4;
         break;
     default:
-        gregorio_message(_("can't calculate key"),
-                "gregorio_calculate_new_key", VERBOSITY_ERROR, 0);
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_fail(gregorio_calculate_new_key, "can't calculate key");
         return NO_KEY;
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -1309,10 +1293,8 @@ static signed char gregorio_syllable_first_note(gregorio_syllable *syllable)
 {
     gregorio_element *element;
     gregorio_glyph *glyph;
-    if (!syllable) {
-        gregorio_message(_("called with a NULL argument"),
-                "gregorio_syllable_first_note", VERBOSITY_ERROR, 0);
-    }
+    gregorio_assert(syllable, gregorio_syllable_first_note,
+            "called with a NULL argument", return 0);
     element = syllable->elements[0];
     while (element) {
         if (element->type == GRE_CUSTOS) {
@@ -1339,11 +1321,8 @@ signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
         gregorio_element *element, gregorio_glyph *glyph)
 {
     signed char temp;
-    if (!element || !syllable) {
-        gregorio_message(_("called with a NULL argument"),
-                "gregorio_determine_next_pitch", VERBOSITY_ERROR, 0);
-        return DUMMY_PITCH;
-    }
+    gregorio_assert(element && syllable, gregorio_determine_next_pitch,
+            "called with a NULL argument", return DUMMY_PITCH);
     /* we first explore the next glyphs to find a note, if there is one */
     if (glyph) {
         glyph = glyph->next;
@@ -1500,7 +1479,7 @@ ENUM_TO_STRING(grehepisema_size, GREHEPISEMA_SIZE)
 ENUM_TO_STRING(gregorio_vposition, GREGORIO_VPOSITION)
 ENUM_TO_STRING(gregorio_glyph_type, GREGORIO_GLYPH_TYPE)
 ENUM_TO_STRING(grestyle_style, GRESTYLE_STYLE)
-ENUM_TO_STRING(grestyle_type, GRESTYLE_TYPE)
+ENUM_TO_STRING(grestyle_type, GRESTYLE_TYPE) /* LCOV_EXCL_LINE */
 ENUM_TO_STRING(gregorio_tr_centering, GREGORIO_TR_CENTERING)
 ENUM_TO_STRING(gregorio_nlba, GREGORIO_NLBA)
 ENUM_TO_STRING(gregorio_euouae, GREGORIO_EUOUAE)

--- a/src/struct.h
+++ b/src/struct.h
@@ -35,6 +35,7 @@
 #include "enum_generator.h"
 #include "bool.h"
 #include "sha1.h"
+#include "messages.h"
 
 #ifdef __cplusplus
 #define ENUM_BITFIELD(TYPE) enum TYPE
@@ -868,9 +869,9 @@ static __inline gregorio_note *gregorio_glyph_last_note(
         const gregorio_glyph *const glyph)
 {
     gregorio_note *note;
-    if (!glyph || glyph->type != GRE_GLYPH) {
-        return NULL;
-    }
+    gregorio_assert(glyph && glyph->type == GRE_GLYPH, gregorio_glyph_last_note,
+            "trying to find the last note of something that is not a glyph",
+            return NULL);
     for (note = glyph->u.notes.first_note; note->next; note = note->next) {
         /* iterate to find the last note */
     }

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -47,10 +47,7 @@ static size_t gregorio_mbstowcs(grewchar *dest, const char *src, int n)
     grewchar result = 0;
     unsigned char c;
     size_t res = 0; /* number of bytes we've done so far */
-    if (!src) {
-        gregorio_message(_("call with a NULL argument"), "gregorio_mbstowcs",
-                VERBOSITY_ERROR, 0);
-    }
+    gregorio_assert_only(src, gregorio_mbstowcs, "call with a NULL argument");
     while (*src && ((int) res <= n || !dest)) {
         c = (unsigned char) (*src);
         if (c < 128) { /* 0100xxxx */
@@ -109,8 +106,9 @@ grewchar *gregorio_build_grewchar_string_from_buf(const char *const buf)
 {
     size_t len;
     grewchar *gwstring;
+    /* this doesn't currently happen, but it's safer to keep this check */
     if (buf == NULL) {
-        return NULL;
+        return NULL; /* LCOV_EXCL_LINE */
     }
     len = strlen(buf); /* to get the length of the syllable in ASCII */
     gwstring = (grewchar *) gregorio_malloc((len + 1) * sizeof(grewchar));
@@ -125,8 +123,9 @@ gregorio_character *gregorio_build_char_list_from_buf(const char *const buf)
     int i = 0;
     grewchar *gwstring;
     gregorio_character *current_character = NULL;
+    /* this doesn't currently happen, but it's safer to keep this check */
     if (buf == NULL) {
-        return NULL;
+        return NULL; /* LCOV_EXCL_LINE */
     }
     gwstring = gregorio_build_grewchar_string_from_buf(buf);
     /* we add the corresponding characters in the list of gregorio_characters */
@@ -137,37 +136,6 @@ gregorio_character *gregorio_build_char_list_from_buf(const char *const buf)
     free(gwstring);
     gregorio_go_to_first_character_c(&current_character);
     return current_character;
-}
-
-/* the function to compare a grewchar * and a buf. Returns 1 if different, 0
- * if not. */
-
-unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf)
-{
-    int i = 0;
-    size_t len;
-    grewchar *gwbuf;
-    if (!buf || !wstr) {
-        return 1;
-    }
-    len = strlen(buf); /* to get the length of the syllable in ASCII */
-    gwbuf = (grewchar *) gregorio_malloc((len + 1) * sizeof(grewchar));
-    gregorio_mbstowcs(gwbuf, buf, len); /* converting into wchar_t */
-    /* we add the corresponding characters in the list of gregorio_characters */
-    while (gwbuf[i] && wstr[i]) {
-        if (gwbuf[i] != wstr[i]) {
-            free(gwbuf);
-            return 1;
-        }
-        i = i + 1;
-    }
-    /* we finished the two strings */
-    if (gwbuf[i] == 0 && wstr[i] == 0) {
-        free(gwbuf);
-        return 0;
-    }
-    free(gwbuf);
-    return 1;
 }
 
 void gregorio_print_unichar(FILE *f, const grewchar to_print)

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -35,7 +35,6 @@ typedef uint32_t grewchar;
 
 void gregorio_print_unichar(FILE *f, grewchar to_print);
 void gregorio_print_unistring(FILE *f, const grewchar *first_char);
-unsigned char gregorio_wcsbufcmp(grewchar *wstr, const char *buf);
 grewchar *gregorio_build_grewchar_string_from_buf(const char *buf);
 
 static __inline size_t gregorio_wcstrlen(const grewchar *wstr)

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -131,9 +131,12 @@ static __inline void character_set_grow(character_set *const set) {
     assert(set);
 
     if (set->bins >= 0x4000L) {
+        /* this should not realistically be reached */
+        /* LCOV_EXCL_START */
         gregorio_message(_("character set too large"), "character_set_grow",
                 VERBOSITY_FATAL, 0);
         return;
+        /* LCOV_EXCL_STOP */
     }
 
     old_table = set->table;
@@ -250,8 +253,12 @@ void gregorio_vowel_tables_load(const char *const filename,
         fclose(gregorio_vowel_rulefile_in);
         gregorio_vowel_rulefile_in = NULL;
     } else {
+        /* tests cannot be expected to simulate the system error that would
+         * cause gregorio_vowel_rulefile_in to be NULL */
+        /* LCOV_EXCL_START */
         gregorio_messagef("gregorio_vowel_tables_load", VERBOSITY_WARNING, 0,
                 _("unable to open %s: %s"), filename, strerror(errno));
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -414,7 +421,11 @@ bool gregorio_find_vowel_group(const grewchar *const string, int *const start,
             break;
 
         default:
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
             assert(false);
+            break;
+            /* LCOV_EXCL_STOP */
         }
 
         if (!*subject) {


### PR DESCRIPTION
- Enhanced the coverage script for usability.
- Corrected to find all vowel files in TEXMF.
- Added lcov tokens to mark code that should not be reachable unless there is a
  programming error, a system fault, or gregorio runs out of memory.
- Added an assertion message level for programming assertions.
- Added some assertions based on coverage testing.
- Fixed missing nlba and/or euouae in dump and gabc output.
- Fixed bug with fusing down to a podatus.
- Corrected spelling of fusible.
- Changed gregorio_fix_style states to be an enum.
- Removed dead code.
For #697.

With this and the gregorio-project/gregorio-test#119, we are at 95.9% function coverage and 87.4% line coverage, not counting the flex- and bison-generated code (which I will analyze later).

There is still much work to do, since this preliminary result indicates there are a number of cases not covered by the tests and that gregorio-test will need to be enhanced for "should fail" tests and tests that involve running the gregorio executable to do things like get the usage or pass bad filenames, etc.

Please review this one carefully, as I have done quite a bit of refactoring, especially with respect to assertions.  The tests do pass in an acceptable manner (at least as far as I can tell).

If this is fit to merge, please merge it (and the corresponding tests).  As a modus operandi, I continue to believe smaller merges are better than a huge one for this particular issue.