### PR TITLE
Fixed problems found in coverage testing.

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -56,12 +56,12 @@ EOT
     ;;
 reset)
     echo "resetting coverage files"
-    rm -rv gcovtool.sh coverage coverage.info
+    rm -frv coverage coverage.info
     find . -name '*.gcda' -exec rm -v {} +
     ;;
 clean)
     echo "deleting coverage files"
-    rm -rv gcovtool.sh coverage coverage.info
+    rm -frv coverage coverage.info
     find . -name '*.gcno' -exec rm -v {} +
     find . -name '*.gcda' -exec rm -v {} +
     ;;

--- a/src/characters.c
+++ b/src/characters.c
@@ -290,9 +290,8 @@ static bool go_to_end_initial(gregorio_character **param_character)
 static void style_push(det_style **current_style, grestyle_style style)
 {
     det_style *element;
-    if (!current_style) {
-        return;
-    }
+    gregorio_assert(current_style, style_push, "current_style may not be NULL",
+            return);
     element = (det_style *) gregorio_malloc(sizeof(det_style));
     element->style = style;
     element->previous_style = NULL;
@@ -309,9 +308,8 @@ static void style_push(det_style **current_style, grestyle_style style)
 
 static void style_pop(det_style **first_style, det_style *element)
 {
-    if (!element || !first_style || !*first_style) {
-        return;
-    }
+    gregorio_assert(element && first_style && *first_style, style_pop,
+            "invalid arguments", return);
     if (element->previous_style) {
         assert(*first_style != element);
         element->previous_style->next_style = element->next_style;
@@ -426,9 +424,8 @@ void gregorio_write_text(const gregorio_write_text_phase phase,
         void (*const end) (FILE *, grestyle_style),
         void (*const printspchar) (FILE *, const grewchar *))
 {
-    if (current_character == NULL) {
-        return;
-    }
+    gregorio_assert(current_character, gregorio_write_text,
+            "current_character may not be NULL", return);
     while (current_character) {
         if (current_character->is_character) {
             printchar(f, current_character->cos.character);
@@ -487,9 +484,9 @@ void gregorio_write_first_letter_alignment_text(
     det_style *last_style = NULL;
     int first_letter_open = (phase == WTP_FIRST_SYLLABLE)? 2 : 1;
 
-    if (!current_character) {
-        return;
-    }
+    gregorio_assert(current_character,
+            gregorio_write_first_letter_alignment_text,
+            "current_character may not be NULL", return);
 
     /* go to the first character */
     gregorio_go_to_first_character(&current_character);
@@ -611,85 +608,6 @@ void gregorio_write_first_letter_alignment_text(
     }
 
     free_styles(&first_style);
-}
-
-/* the default behaviour is to write only the initial, that is to say things
- * between the styles ST_INITIAL */
-void gregorio_write_initial(const gregorio_character *current_character,
-        FILE *const f, void (*const printverb) (FILE *, const grewchar *),
-        void (*const printchar) (FILE *, grewchar),
-        void (*const begin) (FILE *, grestyle_style),
-        void (*const end) (FILE *, grestyle_style),
-        void (*const printspchar) (FILE *, const grewchar *))
-{
-    /* we loop until we see the beginning of the initial style */
-    gregorio_go_to_first_character(&current_character);
-    while (current_character) {
-        if (!current_character->is_character
-                && current_character->cos.s.type == ST_T_BEGIN
-                && current_character->cos.s.style == ST_INITIAL) {
-            current_character = current_character->next_character;
-            break;
-        }
-
-        current_character = current_character->next_character;
-    }
-    /* then we loop until we see the end of the initial style, but we print */
-    while (current_character) {
-        if (current_character->is_character) {
-            printchar(f, current_character->cos.character);
-        } else {
-            if (current_character->cos.s.type == ST_T_BEGIN) {
-                switch (current_character->cos.s.style) {
-                case ST_VERBATIM:
-                    verb_or_sp(&current_character, ST_VERBATIM, f, printverb);
-                    break;
-                case ST_SPECIAL_CHAR:
-                    verb_or_sp(&current_character, ST_SPECIAL_CHAR, f,
-                            printspchar);
-                    break;
-                default:
-                    begin(f, current_character->cos.s.style);
-                    break;
-                }
-            } else { /* ST_T_END */
-                if (current_character->cos.s.style == ST_INITIAL) {
-                    return;
-                } else {
-                    end(f, current_character->cos.s.style);
-                }
-            }
-        }
-        current_character = current_character->next_character;
-    }
-}
-
-/*
- * 
- * A very simple function that returns the first text of a score, or the null
- * character if there is no such thing.
- * 
- */
-
-gregorio_character *gregorio_first_text(gregorio_score *score)
-{
-    gregorio_syllable *current_syllable;
-    if (!score || !score->first_syllable) {
-        gregorio_message(_("unable to find the first letter of the score"),
-                "gregorio_first_text", VERBOSITY_ERROR, 0);
-        return NULL;
-    }
-    current_syllable = score->first_syllable;
-    while (current_syllable) {
-        if (current_syllable->text) {
-            return current_syllable->text;
-        }
-        current_syllable = current_syllable->next_syllable;
-    }
-
-    gregorio_message(_("unable to find the first letter of the score"),
-            "gregorio_first_text", VERBOSITY_ERROR, 0);
-    return NULL;
 }
 
 /*
@@ -838,9 +756,8 @@ static void suppress_current_character(
 
 static void suppress_this_character(gregorio_character *to_suppress)
 {
-    if (!to_suppress) {
-        return;
-    }
+    gregorio_assert(to_suppress, suppress_this_character,
+            "to_suppress may not be NULL", return);
     if (to_suppress->previous_character) {
         assert(to_suppress->previous_character->next_character == to_suppress);
         to_suppress->previous_character->next_character =
@@ -1263,9 +1180,8 @@ void gregorio_rebuild_first_syllable(gregorio_character **param_character,
     /* first we look at the styles, to see if there is a FORCED_CENTER
      * somewhere and we also remove the CENTER styles if the syllable starts at
      * CENTER */
-    if (!param_character) {
-        return;
-    }
+    gregorio_assert(param_character, gregorio_rebuild_first_syllable,
+            "param_character may not be NULL", return);
     while (current_character) {
         if (!current_character->is_character) {
             if (current_character->cos.s.style == ST_FORCED_CENTER) {

--- a/src/characters.h
+++ b/src/characters.h
@@ -55,8 +55,6 @@ typedef struct det_style {
     struct det_style *next_style;
 } det_style;
 
-gregorio_character *gregorio_first_text(gregorio_score *score);
-
 typedef enum gregorio_write_text_phase {
     WTP_NORMAL,
     WTP_FIRST_SYLLABLE
@@ -78,16 +76,7 @@ void gregorio_write_first_letter_alignment_text(gregorio_write_text_phase phase,
         void (*end) (FILE *, grestyle_style),
         void (*printspchar) (FILE *, const grewchar *));
 
-void gregorio_write_initial(const gregorio_character *current_character,
-        FILE *f, void (*printverb) (FILE *, const grewchar *),
-        void (*printchar) (FILE *, grewchar),
-        void (*begin) (FILE *, grestyle_style),
-        void (*end) (FILE *, grestyle_style),
-        void (*printspchar) (FILE *, const grewchar *));
-
 void gregorio_set_centering_language(char *language);
-
-gregorio_character *gregorio_first_text(gregorio_score *score);
 
 void gregorio_rebuild_characters(gregorio_character **param_character,
         gregorio_center_determination center_is_determined, bool skip_initial);

--- a/src/dump/dump.c
+++ b/src/dump/dump.c
@@ -184,10 +184,6 @@ void dump_write_score(FILE *f, gregorio_score *score)
                     syllable->position,
                     gregorio_word_position_to_string(syllable->position));
         }
-        if (syllable->special_sign) {
-            fprintf(f, "   special sign                       %s\n",
-                    gregorio_sign_to_string(syllable->special_sign));
-        }
         if (syllable->no_linebreak_area != NLBA_NORMAL) {
             fprintf(f, "   no line break area        %s\n",
                     gregorio_nlba_to_string(syllable->no_linebreak_area));
@@ -327,19 +323,6 @@ void dump_write_score(FILE *f, gregorio_score *score)
                                 glyph->u.misc.unpitched.info.space,
                                 gregorio_space_to_string(glyph->u.misc.
                                                          unpitched.info.space));
-                        break;
-
-                    case GRE_BAR:
-                        fprintf(f, "       glyph_type            %d (%s)\n",
-                                glyph->u.misc.unpitched.info.bar,
-                                gregorio_bar_to_string(glyph->u.misc.unpitched.
-                                                       info.bar));
-                        if (glyph->u.misc.unpitched.special_sign) {
-                            fprintf(f, "       special sign          %d (%s)\n",
-                                    glyph->u.misc.unpitched.special_sign,
-                                    gregorio_sign_to_string(glyph->
-                                            u.misc.unpitched.special_sign));
-                        }
                         break;
 
                     case GRE_GLYPH:

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -70,9 +70,15 @@ static void close_element(gregorio_element **current_element,
 {
     gregorio_add_element(current_element, *first_glyph);
     if (*first_glyph && (*first_glyph)->previous) {
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
+        gregorio_fail(close_element, "previous element was not closed");
         (*first_glyph)->previous->next = NULL;
         (*first_glyph)->previous = NULL;
     }
+    /* for some reason (optimization?), the previous line is not counted as
+     * covered even though the start of the condition IS covered */
+    /* LCOV_EXCL_STOP */
     *first_glyph = current_glyph->next;
 }
 
@@ -119,9 +125,8 @@ static gregorio_element *gabc_det_elements_from_glyphs(
     /* a char that is necesarry to determine the type of the current_glyph */
     char current_glyph_type;
 
-    if (!current_glyph) {
-        return NULL;
-    }
+    gregorio_assert(current_glyph, gabc_det_elements_from_glyphs,
+            "called with NULL glyph", return NULL);
     /* first we go to the first glyph in the chained list of glyphs (maybe to
      * suppress ?) */
     gregorio_go_to_first_glyph(&current_glyph);

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -55,10 +55,10 @@ static int slur_var[2] = { 0, 0 };
 static char slur_shift[2] = { '\0', '\0' };
 static gregorio_note *slur_start[] = { NULL, NULL };
 
-typedef enum ledger_line_type {
-    LL_OVER = 0,
-    LL_UNDER = 1
-} ledger_line_type;
+typedef enum sign_orientation {
+    SO_OVER = 0,
+    SO_UNDER = 1
+} sign_orientation;
 
 static __inline char pitch_letter_to_height(const char pitch) {
     char result = pitch - 'a' + LOWEST_PITCH;
@@ -90,12 +90,12 @@ static __inline void lex_add_note(int i, gregorio_shape shape, char signs,
             tolower((unsigned char)gabc_notes_determination_text[i])),
             shape, signs, liquescentia, NULL, &notes_lloc);
 
-    if (ledger_var[LL_OVER]) {
+    if (ledger_var[SO_OVER]) {
         current_note->supposed_high_ledger_line = true;
         current_note->explicit_high_ledger_line = true;
     }
 
-    if (ledger_var[LL_UNDER]) {
+    if (ledger_var[SO_UNDER]) {
         current_note->supposed_low_ledger_line = true;
         current_note->explicit_low_ledger_line = true;
     }
@@ -144,10 +144,12 @@ static void add_h_episema(void)
             size = H_SMALL_RIGHT;
             break;
         default:
-            gregorio_messagef("gabc_notes_determination", VERBOSITY_ERROR, 0,
-                    _("unrecognized horizontal episema modifier: %c"),
-                    current);
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
+            gregorio_fail2(gabc_notes_determination,
+                    "unrecognized horizontal episema modifier: %c", current);
             break;
+            /* LCOV_EXCL_STOP */
         };
     }
 
@@ -183,7 +185,7 @@ static void save_before_ledger(const char *const before_ledger)
     }
 }
 
-static void add_static_ledger(const ledger_line_type type, const char *length) {
+static void add_static_ledger(const sign_orientation type, const char *length) {
     gregorio_snprintf(tempstr, sizeof tempstr,
             "\\GreDrawAdditionalLine{%d}{%s}{%d}{%s}{0}{}",
             type, length + 1, before_ledger_type, before_ledger_length);
@@ -197,23 +199,25 @@ static void add_static_ledger(const ledger_line_type type, const char *length) {
             GRE_TEXVERB_GLYPH, &notes_lloc);
 }
 
-static __inline const char *ledger_type_name(const ledger_line_type type) {
+static __inline const char *sign_orientation_name(const sign_orientation type) {
     switch (type) {
-    case LL_OVER:
+    case SO_OVER:
         return "over";
-    case LL_UNDER:
+    case SO_UNDER:
         return "under";
     }
-    gregorio_messagef("ledger_type_name", VERBOSITY_ERROR, 0,
-            _("invalid ledger type %d"), type);
-    return NULL;
+    /* not reachable unless there's a programming error */
+    /* LCOV_EXCL_START */
+    gregorio_fail2(sign_orientation_name, "invalid ledger type %d", type);
+    return "";
+    /* LCOV_EXCL_STOP */
 }
 
-static void add_variable_ledger(const ledger_line_type type,
+static void add_variable_ledger(const sign_orientation type,
         const char *after_ledger)
 {
     if (ledger_var[type]) {
-        const char *const typename = ledger_type_name(type);
+        const char *const typename = sign_orientation_name(type);
         gregorio_messagef("add_variable_ledger", VERBOSITY_ERROR, 0,
                 _("variable %s-staff ledger line without termination of "
                 "previous %s-staff ledger line"), typename, typename);
@@ -252,10 +256,10 @@ static void add_variable_ledger(const ledger_line_type type,
     }
 }
 
-static void end_variable_ledger(const ledger_line_type type)
+static void end_variable_ledger(const sign_orientation type)
 {
     if (!ledger_var[type]) {
-        const char *const typename = ledger_type_name(type);
+        const char *const typename = sign_orientation_name(type);
         gregorio_messagef("end_variable_ledger", VERBOSITY_ERROR, 0,
                 _("variable %s-staff ledger line termination without variable "
                 "%s-staff ledger line start"), typename, typename);
@@ -285,7 +289,7 @@ static __inline gregorio_bar parse_dominican_bar(char bar)
     bar -= '0';
     if (bar < 1 || bar > (2 * (staff_lines - 1))) {
         gregorio_messagef("parse_dominican_line", VERBOSITY_ERROR, 0,
-                _("invalid dominican bar for %u lines: ;%d"),
+                _("invalid Dominican bar for %u lines: ;%d"),
                 (unsigned int)staff_lines, (int)bar);
     }
 
@@ -307,10 +311,11 @@ static __inline gregorio_bar parse_dominican_bar(char bar)
     case 8:
         return B_DIVISIO_MINOR_D8;
     }
-
-    gregorio_messagef("check_dominican_line", VERBOSITY_ERROR, 0,
-            _("invalid dominican bar: %d"), (int)bar);
+    /* not reachable unless there's a programming error */
+    /* LCOV_EXCL_START */
+    gregorio_fail2(check_dominican_line, "invalid dominican bar: %d", (int)bar);
     return B_NO_BAR;
+    /* LCOV_EXCL_STOP */
 }
 
 static __inline gregorio_clef letter_to_clef(char letter)
@@ -321,15 +326,21 @@ static __inline gregorio_clef letter_to_clef(char letter)
     case 'f':
         return CLEF_F;
     }
-    gregorio_messagef("letter_to_clef", VERBOSITY_ERROR, 0,
-            _("invalid clef: %c"), letter);
+    /* not reachable unless there's a programming error */
+    /* LCOV_EXCL_START */
+    gregorio_fail2(letter_to_clef, "invalid clef: %c", letter);
     return CLEF_C;
+    /* LCOV_EXCL_STOP */
 }
 
+/* this assertion should only fail if the lex rules are incorrect */
 static __inline void slur_assert(char *fn, bool test) {
     if (!test) {
+        /* not reachable unless there's a programming error */
+        /* LCOV_EXCL_START */
         gregorio_message(_("invalid slur text"), fn, VERBOSITY_FATAL, 0);
         exit(1);
+        /* LCOV_EXCL_STOP */
     }
 }
 
@@ -372,7 +383,7 @@ static void parse_slur(int direction)
     gregorio_add_texverb_to_note(current_note, gregorio_strdup(tempstr));
 }
 
-static void start_var_slur(int index)
+static void start_var_slur(const sign_orientation index)
 {
     if (!current_note || current_note->type != GRE_NOTE) {
         gregorio_message(
@@ -382,9 +393,9 @@ static void start_var_slur(int index)
     }
 
     if (slur_var[index]) {
-        gregorio_message(
-                _("variable slur without termination of previous slur"),
-                "start_var_slur", VERBOSITY_ERROR, 0);
+        gregorio_messagef("start_var_slur", VERBOSITY_ERROR, 0,
+                _("variable %s-note slur without termination of previous slur"),
+                sign_orientation_name(index));
         return;
     }
 
@@ -393,7 +404,7 @@ static void start_var_slur(int index)
     slur_start[index] = current_note;
 }
 
-static void end_var_slur(int direction, int index)
+static void end_var_slur(const int direction, const sign_orientation index)
 {
     char shift;
 
@@ -405,8 +416,9 @@ static void end_var_slur(int direction, int index)
     }
 
     if (!slur_var[index] || !slur_shift[index] || !slur_start[index]) {
-        gregorio_message(_("variable slur end without variable slur start"),
-                "end_var_slur", VERBOSITY_ERROR, 0);
+        gregorio_messagef("end_var_slur", VERBOSITY_ERROR, 0,
+                _("variable %s-note slur end without start"),
+                sign_orientation_name(index));
         return;
     }
 
@@ -429,6 +441,36 @@ static void end_var_slur(int direction, int index)
     slur_var[index] = 0;
     slur_shift[index] = '\0';
     slur_start[index] = NULL;
+}
+
+void gabc_det_notes_finish(void)
+{
+    sign_orientation orientation;
+    if (overbrace_var) {
+        gregorio_message(_("unclosed variable over-staff brace"),
+                "gabc_det_notes_finish", VERBOSITY_ERROR, 0);
+        overbrace_var = 0;
+    }
+    if (underbrace_var) {
+        gregorio_message(_("unclosed variable under-staff brace"),
+                "gabc_det_notes_finish", VERBOSITY_ERROR, 0);
+        underbrace_var = 0;
+    }
+    for (orientation = SO_OVER; orientation <= SO_UNDER; ++orientation) {
+        const char *name = sign_orientation_name(orientation);
+        if (ledger_var[orientation]) {
+            gregorio_messagef("gabc_det_notes_finish", VERBOSITY_ERROR, 0,
+                    _("unclosed variable %s-staff ledger line"), name);
+            ledger_var[orientation] = 0;
+        }
+        if (slur_var[orientation]) {
+            gregorio_messagef("gabc_det_notes_finish", VERBOSITY_ERROR, 0,
+                    _("unclosed variable %s-note slur"), name);
+            slur_var[orientation] = 0;
+            slur_shift[orientation] = '\0';
+            slur_start[orientation] = NULL;
+        }
+    }
 }
 
 %}
@@ -748,7 +790,7 @@ static void end_var_slur(int direction, int index)
                 gregorio_strdup(gabc_notes_determination_text), &notes_lloc);
     }
 <INITIAL>\[oll:\}\] {
-        end_variable_ledger(LL_OVER);
+        end_variable_ledger(SO_OVER);
     }
 <INITIAL>\[oll: {
         BEGIN(overledger);
@@ -758,15 +800,15 @@ static void end_var_slur(int direction, int index)
         BEGIN(overledger2);
     }
 <overledger2>;[^\]]+ {
-        add_static_ledger(LL_OVER, gabc_notes_determination_text);
+        add_static_ledger(SO_OVER, gabc_notes_determination_text);
         BEGIN(endledger);
     }
 <overledger2>\{[^\]]+ {
-        add_variable_ledger(LL_OVER, gabc_notes_determination_text);
+        add_variable_ledger(SO_OVER, gabc_notes_determination_text);
         BEGIN(endledger);
     }
 <INITIAL>\[ull:\}\] {
-        end_variable_ledger(LL_UNDER);
+        end_variable_ledger(SO_UNDER);
     }
 <INITIAL>\[ull: {
         BEGIN(underledger);
@@ -776,11 +818,11 @@ static void end_var_slur(int direction, int index)
         BEGIN(underledger2);
     }
 <underledger2>;[^\]]+ {
-        add_static_ledger(LL_UNDER, gabc_notes_determination_text);
+        add_static_ledger(SO_UNDER, gabc_notes_determination_text);
         BEGIN(endledger);
     }
 <underledger2>\{[^\]]+ {
-        add_variable_ledger(LL_UNDER, gabc_notes_determination_text);
+        add_variable_ledger(SO_UNDER, gabc_notes_determination_text);
         BEGIN(endledger);
     }
 <texverbnote,texverbglyph,texverbelement,choralsign,choralnabc,alt,overcurlyaccentusbrace,overcurlybrace,overbrace,underbrace,space,nbspace,endledger>\] {
@@ -790,19 +832,19 @@ static void end_var_slur(int direction, int index)
         parse_slur(1);
     }
 <INITIAL>\[oslur:[012]\{\] {
-        start_var_slur(0);
+        start_var_slur(SO_OVER);
     }
 <INITIAL>\[oslur:[012]\}\] {
-        end_var_slur(1, 0);
+        end_var_slur(1, SO_OVER);
     }
 <INITIAL>\[uslur:[012];[^,]+,[^\]]+\] {
         parse_slur(-1);
     }
 <INITIAL>\[uslur:[012]\{\] {
-        start_var_slur(1);
+        start_var_slur(SO_UNDER);
     }
 <INITIAL>\[uslur:[012]\}\] {
-        end_var_slur(-1, 1);
+        end_var_slur(-1, SO_UNDER);
     }
 \{  {
         gregorio_add_texverb_as_note(&current_note,
@@ -1031,8 +1073,7 @@ q   {
                 legacy_oriscus_orientation);
     }
 o   {
-        gregorio_change_shape(current_note, legacy_oriscus_orientation
-                ? S_ORISCUS_ASCENDENS : S_ORISCUS_UNDETERMINED,
+        gregorio_change_shape(current_note, S_ORISCUS_UNDETERMINED,
                 legacy_oriscus_orientation);
     }
 O   {
@@ -1075,7 +1116,7 @@ s   {
         current_note->supposed_low_ledger_line = false;
         current_note->explicit_low_ledger_line = true;
     }
-.   {
+.|\n {
         gregorio_messagef("det_notes_from_string", VERBOSITY_ERROR, 0,
                 _("unrecognized character: \"%c\""),
                 gabc_notes_determination_text[0]);

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -130,7 +130,7 @@ semicolon. */
                 gregorio_strdup(gabc_score_determination_text);
         return ATTRIBUTE;
     }
-<attribute>;(;|[\n\r]+) {
+<attribute>;;?[\n\r]+ {
          BEGIN(INITIAL);
          return SEMICOLON;
     }
@@ -212,10 +212,10 @@ semicolon. */
                 gregorio_strdup(gabc_score_determination_text);
         return OTHER_HEADER;
     }
-<INITIAL>--(.*) {
+<INITIAL>--+(\n|\r)+ {
        return VOICE_CHANGE;
     }
-<INITIAL>%(%)*(\n|\r)+ {
+<INITIAL>%%+(\n|\r)+ {
        BEGIN(score);
        return END_OF_DEFINITIONS;
     }
@@ -434,6 +434,11 @@ semicolon. */
         } else {
             yyterminate();
         }
+    }
+.|\n {
+        gregorio_messagef("gabc_score_determination_lex", VERBOSITY_ERROR, 0,
+                _("unrecognized character: \"%c\""),
+                gabc_score_determination_text[0]);
     }
 %%
 

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -181,9 +181,8 @@ static void fix_custos(gregorio_score *score_to_check)
 
 static int check_score_integrity(gregorio_score *score_to_check)
 {
-    if (!score_to_check) {
-        return 0;
-    }
+    gregorio_assert(score_to_check, check_score_integrity, "score is NULL",
+            return 0);
     return 1;
 }
 
@@ -462,15 +461,17 @@ static void close_syllable(YYLTYPE *loc)
 
                 case ST_T_END:
                     --i;
-                    if (i < 0) {
-                        gregorio_message(_("elision end with no beginning"),
-                                "close_syllable", VERBOSITY_ERROR, 0);
-                    }
+                    /* the parser precludes this from failing here */
+                    gregorio_assert_only(i >= 0, close_syllable,
+                            "encountered elision end with no beginning");
                     break;
 
                 case ST_T_NOTHING:
-                    /* nothing */
+                    /* not reachable unless there's a programming error */
+                    /* LCOV_EXCL_START */
+                    gregorio_fail(close_syllable, "encountered ST_T_NOTHING");
                     break;
+                    /* LCOV_EXCL_STOP */
                 }
                 break;
 
@@ -487,10 +488,9 @@ static void close_syllable(YYLTYPE *loc)
             }
         }
     }
-    if (i > 0) {
-        gregorio_message(_("elision beginning with no end"), "close_syllable",
-                VERBOSITY_ERROR, 0);
-    }
+    /* the parser precludes this from failing here */
+    gregorio_assert_only(i == 0, close_syllable,
+            "encountered elision beginning with no end");
 
     gregorio_add_syllable(&current_syllable, number_of_voices, elements,
             first_text_character, first_translation_character, position,
@@ -621,10 +621,14 @@ static void determine_oriscus_orientation(gregorio_score *score) {
                                                     S_ORISCUS_CAVUM_DESCENDENS;
                                             break;
                                         default:
-                                            gregorio_message(_("bad shape"),
-                                                    "determine_oriscus_orientation",
-                                                    VERBOSITY_ERROR, 0);
+                                            /* not reachable unless there's a
+                                             * programming error */
+                                            /* LCOV_EXCL_START */
+                                            gregorio_fail(
+                                                    determine_oriscus_orientation,
+                                                    "bad_shape");
                                             break;
+                                            /* LCOV_EXCL_STOP */
                                         }
                                     } else { /* ascending or the same */
                                         switch(oriscus->u.note.shape) {
@@ -637,10 +641,14 @@ static void determine_oriscus_orientation(gregorio_score *score) {
                                                     S_ORISCUS_CAVUM_ASCENDENS;
                                             break;
                                         default:
-                                            gregorio_message(_("bad shape"),
-                                                    "determine_oriscus_orientation",
-                                                    VERBOSITY_ERROR, 0);
+                                            /* not reachable unless there's a
+                                             * programming error */
+                                            /* LCOV_EXCL_START */
+                                            gregorio_fail(
+                                                    determine_oriscus_orientation,
+                                                    "bad_shape");
                                             break;
+                                            /* LCOV_EXCL_STOP */
                                         }
                                     }
                                     oriscus = NULL;
@@ -673,9 +681,11 @@ static void determine_oriscus_orientation(gregorio_score *score) {
             oriscus->u.note.shape = S_ORISCUS_CAVUM_DESCENDENS;
             break;
         default:
-            gregorio_message(_("bad shape"), "determine_oriscus_orientation",
-                    VERBOSITY_ERROR, 0);
+            /* not reachable unless there's a programming error */
+            /* LCOV_EXCL_START */
+            gregorio_fail(determine_oriscus_orientation, "bad_shape");
             break;
+            /* LCOV_EXCL_STOP */
         }
     }
 }
@@ -695,14 +705,8 @@ gregorio_score *gabc_read_score(FILE *f_in)
     sha1_process_bytes(GREGORIO_VERSION, strlen(GREGORIO_VERSION), &digester);
     /* the input file that flex will parse */
     gabc_score_determination_in = f_in;
-    if (!f_in) {
-        /* not reachable unless there's a programming error */
-        /* LCOV_EXCL_START */
-        gregorio_message(_("can't read stream from NULL"), "gabc_read_score",
-                VERBOSITY_FATAL, 0);
-        return NULL;
-        /* LCOV_EXCL_STOP */
-    }
+    gregorio_assert(f_in, gabc_read_score, "can't read stream from NULL",
+            return NULL);
     initialize_variables();
     /* the flex/bison main call, it will build the score (that we have
      * initialized) */
@@ -712,6 +716,7 @@ gregorio_score *gabc_read_score(FILE *f_in)
     }
     gregorio_fix_initial_keys(score, gregorio_default_clef);
     fix_custos(score);
+    gabc_det_notes_finish();
     free_variables();
     /* the we check the validity and integrity of the score we have built. */
     if (!check_score_integrity(score)) {
@@ -751,13 +756,9 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
             gregorio_add_element(&elements[voice], NULL);
             current_element = elements[voice];
         }
-        if (!current_element) {
-            /* not reachable unless there's a programming error */
-            /* LCOV_EXCL_START */
-            gregorio_message(_("current_element is null, this shouldn't "
-                    "happen!"), "gabc_y_add_notes", VERBOSITY_FATAL, 0);
-            /* LCOV_EXCL_STOP */
-        }
+        gregorio_assert(current_element, gabc_y_add_notes,
+                "current_element is null, this shouldn't happen!",
+                return);
         if (!current_element->nabc) {
             current_element->nabc = (char **) gregorio_calloc (nabc_lines,
                     sizeof (char *));

--- a/src/gabc/gabc.h
+++ b/src/gabc/gabc.h
@@ -30,6 +30,7 @@
 /* functions to read gabc */
 gregorio_note *gabc_det_notes_from_string(char *str, char *macros[10],
         gregorio_scanner_location *loc, const gregorio_score *score);
+void gabc_det_notes_finish(void);
 gregorio_element *gabc_det_elements_from_string(char *str, int *current_key,
         char *macros[10], gregorio_scanner_location *loc,
         const gregorio_score *const score);

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -908,7 +908,6 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
         break;
     case G_ONE_NOTE:
     case G_PUNCTUM_INCLINATUM:
-    case G_TRIGONUS:
     case G_PUNCTA_INCLINATA:
     case G_2_PUNCTA_INCLINATA_DESCENDENS:
     case G_3_PUNCTA_INCLINATA_DESCENDENS:
@@ -1678,7 +1677,6 @@ static void gregoriotex_write_punctum_mora(FILE *f, gregorio_glyph *glyph,
     }
     /* we enter here in any case */
     switch (glyph->u.notes.glyph_type) {
-    case G_TRIGONUS:
     case G_PUNCTA_INCLINATA:
     case G_2_PUNCTA_INCLINATA_DESCENDENS:
     case G_3_PUNCTA_INCLINATA_DESCENDENS:
@@ -2318,7 +2316,6 @@ static int gregoriotex_syllable_first_type(gregorio_syllable *syllable)
                             }
                         }
                         continue;
-                    case G_TRIGONUS:
                     case G_PUNCTA_INCLINATA:
                     case G_2_PUNCTA_INCLINATA_DESCENDENS:
                     case G_3_PUNCTA_INCLINATA_DESCENDENS:
@@ -2675,7 +2672,6 @@ static void write_glyph(FILE *f, gregorio_syllable *syllable,
      * in general, and torculus resupinus and torculus resupinus flexus, so
      * we first divide the glyph into real gregoriotex glyphs */
     switch (glyph->u.notes.glyph_type) {
-    case G_TRIGONUS:
     case G_PUNCTA_INCLINATA:
     case G_2_PUNCTA_INCLINATA_DESCENDENS:
     case G_3_PUNCTA_INCLINATA_DESCENDENS:

--- a/src/messages.c
+++ b/src/messages.c
@@ -80,8 +80,11 @@ static const char *verbosity_to_str(const gregorio_verbosity verbosity)
         break;
         /* LCOV_EXCL_STOP */
     case VERBOSITY_FATAL:
+        /* all fatal errors should not be reasonably testable */
+        /* LCOV_EXCL_START */
         str = _("fatal error:");
         break;
+        /* LCOV_EXCL_STOP */
     default:
         /* INFO, for example */
         str = " ";
@@ -97,7 +100,7 @@ void gregorio_messagef(const char *function_name,
     va_list args;
     const char *verbosity_str;
 
-    if (!debug_messages) {
+    if (!debug_messages && verbosity != VERBOSITY_ASSERTION) {
         line_number = 0;
         function_name = NULL;
     }
@@ -168,8 +171,11 @@ void gregorio_messagef(const char *function_name,
         return_value = 1;
         break;
     case VERBOSITY_FATAL:
+        /* all fatal errors should not be reasonably testable */
+        /* LCOV_EXCL_START */
         exit(1);
         break;
+        /* LCOV_EXCL_STOP */
     default:
         break;
     }

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -114,7 +114,7 @@ void *sha1_finish_ctx(struct sha1_ctx *ctx, void *resbuf)
      */
     ctx->total[0] += bytes;
     if (ctx->total[0] < bytes)
-        ++ctx->total[1];
+        ++ctx->total[1]; /* data-sepcific; LCOV_EXCL_LINE */
 
     /*
      * Put the 64-bit file length in *bits* at the end of the buffer.  
@@ -165,6 +165,7 @@ void sha1_process_bytes(const void *buffer, size_t len, struct sha1_ctx *ctx)
      * Process available complete blocks.  
      */
     if (len >= 64) {
+        /* architecture and data-specific; LCOV_EXCL_START */
 #if !_STRING_ARCH_unaligned
 #define UNALIGNED_P(p) ((uintptr_t) (p) % alignof (uint32_t) != 0)
         if (UNALIGNED_P(buffer)) {
@@ -180,6 +181,7 @@ void sha1_process_bytes(const void *buffer, size_t len, struct sha1_ctx *ctx)
             buffer = (const char *) buffer + (len & ~63);
             len &= 63;
         }
+        /* LCOV_EXCL_STOP */
     }
 
     /*
@@ -191,10 +193,12 @@ void sha1_process_bytes(const void *buffer, size_t len, struct sha1_ctx *ctx)
         memcpy(&((char *) ctx->buffer)[left_over], buffer, len);
         left_over += len;
         if (left_over >= 64) {
+            /* data-specific; LCOV_EXCL_START */
             sha1_process_block(ctx->buffer, 64, ctx);
             left_over -= 64;
             memcpy(ctx->buffer, &ctx->buffer[16], left_over);
         }
+        /* LCOV_EXCL_STOP */
         ctx->buflen = left_over;
     }
 }

--- a/src/struct.h
+++ b/src/struct.h
@@ -250,7 +250,6 @@ ENUM(gregorio_vposition, GREGORIO_VPOSITION);
     E(G_3_PUNCTA_INCLINATA_ASCENDENS) \
     E(G_4_PUNCTA_INCLINATA_ASCENDENS) \
     E(G_5_PUNCTA_INCLINATA_ASCENDENS) \
-    E(G_TRIGONUS) \
     E(G_PUNCTA_INCLINATA) \
     /* !!! DO NOT CHANGE THE ENUM ORDERING BEFORE THIS LINE !!! */ \
     E(G_UNDETERMINED) \
@@ -629,8 +628,6 @@ typedef struct gregorio_syllable {
     /* a syllable can be a GRE_SYLLABLE, a GRE_*_KEY_CHANGE or a
      * GRE_BAR. It is useful when there is only that in a syllable. */
     ENUM_BITFIELD(gregorio_type) type:8;
-    /* again, an additional field to put some signs or other things... */
-    ENUM_BITFIELD(gregorio_sign) special_sign:8;
     /* type of translation (with center beginning or only center end) */
     ENUM_BITFIELD(gregorio_tr_centering) translation_type:2;
     /* beginning or end of area without linebreak? */

--- a/src/vowel/vowel-rules.y
+++ b/src/vowel/vowel-rules.y
@@ -33,12 +33,6 @@
 #include "vowel-rules.h"
 #include "vowel-rules-l.h"
 
-#if ! defined lint || defined __GNUC__
-# define IGNORE(e) ((void) (e))
-#else
-# define IGNORE(e) /* empty */
-#endif
-
 /* NOTE: This parser might allocate a new value for language; this value MUST
  *       BE FREED after the parser returns (if the value of the language pointer
  *       changes, then free the pointer).  This parser DOES free the language
@@ -49,11 +43,10 @@
 /*int gregorio_vowel_rulefile_debug=1;*/
 
 static void gregorio_vowel_rulefile_error(const char *const filename,
-        char **const language, rulefile_parse_status *const status,
+        char **const language __attribute__((__unused__)),
+        rulefile_parse_status *const status __attribute__((__unused__)),
         const char *const error_str)
 {
-    IGNORE(language);
-    IGNORE(status);
     gregorio_messagef("gregorio_vowel_rulefile_parse", VERBOSITY_ERROR, 0,
             _("%s: %s"), filename, error_str);
 }

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -158,12 +158,7 @@
     \ifcase#7%
       \gre@typesingleclef{#1}{#2}{#3}{#5}%
     \else %
-      \ifnum\numexpr (#7 - #2) * (#7 - #2) = 1 \relax %
-        \gre@typesingleclef{#1}{#2}{#3}{#5}%
-        \gre@skip@temp@two=\gre@space@skip@clefflatspace\relax%
-        \gre@hskip\gre@skip@temp@two %
-        \gre@typesingleclef{#6}{#7}{#3}{#8}%
-      \else %
+      \ifnum\numexpr (#7 - #2) * (#7 - #2) > 1 \relax %
         \setbox\gre@box@temp@clef=\hbox{\gre@typesingleclef{#1}{#2}{#3}{#5}}%
         \setbox\gre@box@temp@cleftwo=\hbox{\gre@typesingleclef{#6}{#7}{#3}{#8}}%
         \ifdim\wd\gre@box@temp@clef>\wd\gre@box@temp@cleftwo%
@@ -171,6 +166,11 @@
         \else %
           \hbox to 0pt{\copy\gre@box@temp@clef}\copy\gre@box@temp@cleftwo%
         \fi %
+      \else %
+        \gre@typesingleclef{#1}{#2}{#3}{#5}%
+        \gre@skip@temp@two=\gre@space@skip@clefflatspace\relax%
+        \gre@hskip\gre@skip@temp@two %
+        \gre@typesingleclef{#6}{#7}{#3}{#8}%
       \fi %
     \fi %
   }%


### PR DESCRIPTION
- Made coverage script quieter when cleaning a clean directory.
- Found and marked more assertions.
- Corrected determination of gvgvv, gvvgv, gsgss, and gssgs.
- Improved error checking of score lexer (fixed unexpected ECHO).
- Corrected gabc output of quadratum shapes.
- Removed dead gabc cases.
- Corrected morphing of oriscus added to cavum.
- Fixed double clef rendering on the same line.
- Fixed missing translation center gabc output.
- Removed determination of G_TRIGONUS since it is ambiguous/inaccurate.
- Added a check for unclosed braces, ledger lines, and slurs.
For #697.

An additional note about G_TRIGONUS.  We were detecting things like `(GHG)` and `(HGH)` as trigonus, but this is not accurate (i.e., trigon is also typically something like `(HHG)`) and was playing strangely with proper detection in sequences like `(GHGF)`, so I removed it, which only affects the glyph type and doesn't affect the final (TeX) output.

With gregorio-project/gregorio-test#121, this brings coverage to 97.4% functions and 92.2% lines.  I've discovered that the lines generated from flex and bison rules are not tested for coverage, so I no longer intend to include the `*-y.c` and `*-l.c` files in coverage testing.

There is still a good deal of work to do:
- Possibly remove the "multi-staff" polyphony vestiges in the C code (see my comments in #697).
- Create a test harness for running non-gabc tests against the executable
- More test coverage; much of what remains has to do with obscure sequences of notes
- Improved coverage in the code related to long/short queues.  I'd like to roll in the changes for #803 before concentrating too much on this.

Please double-check my assertions, review these changes, and merge them (along with the corresponding gregorio-test pull request) if satisfactory.