### PR TITLE
Fixed problems found during coverage testing:

### DIFF
--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -2986,9 +2986,7 @@ static void gregoriotex_print_change_line_clef(FILE *f,
 
 static __inline bool is_manual_custos(const gregorio_element *element)
 {
-    return element->type == GRE_ELEMENT
-            && element->u.first_glyph
-            && element->u.first_glyph->type == GRE_MANUAL_CUSTOS;
+    return element->type == GRE_CUSTOS && element->u.misc.pitched.force_pitch;
 }
 
 static __inline bool next_is_bar(const gregorio_syllable *syllable,
@@ -3031,8 +3029,11 @@ static __inline bool next_is_bar(const gregorio_syllable *syllable,
         element = syllable->elements[0];
     }
 
-    assert(false); /* should never reach here; LCOV_EXCL_LINE */
-    return false; /* avoid gcc 5.1 warning */
+    /* not reachable unless there's a programming error */
+    /* LCOV_EXCL_START */
+    gregorio_fail(next_is_bar, "unexpected end of syllables/elements");
+    return false;
+    /* LCOV_EXCL_STOP */
 }
 
 static void finish_syllable(FILE *f, gregorio_syllable *syllable) {
@@ -3101,7 +3102,7 @@ static void write_first_syllable_text(FILE *f, const char *const syllable_type,
         const gregorio_character *const text, bool end_of_word)
 {
     if (syllable_type == NULL) {
-        fprintf(f, "}{\\GreSyllable{\\GreSetNoFirstSyllableText}");
+        fprintf(f, "}{\\GreSyllable}{\\GreSetNoFirstSyllableText}");
     } else if (text == NULL) {
         fprintf(f, "}{%s}{\\GreSetNoFirstSyllableText}", syllable_type);
     } else {
@@ -3744,6 +3745,9 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
         write_syllable(f, current_syllable, 0, &status, score,
                 write_first_syllable_text);
         current_syllable = current_syllable->next_syllable;
+    } else {
+        /* edge case: a score with no syllables */
+        fprintf(f, "}{}{\\GreSetNoFirstSyllableText}%%\n");
     }
     while (current_syllable) {
         write_syllable(f, current_syllable, 0, &status, score,

--- a/src/messages.h
+++ b/src/messages.h
@@ -53,7 +53,6 @@ void gregorio_messagef(const char *function_name,
         int line_number, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 4, 5)));
 void gregorio_set_verbosity_mode(gregorio_verbosity verbosity);
-void gregorio_set_file_name(const char *new_name);
 void gregorio_set_error_out(FILE *f);
 int gregorio_get_return_value(void);
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -317,7 +317,8 @@ ENUM(gregorio_glyph_type, GREGORIO_GLYPH_TYPE);
     E(ST_FIRST_WORD) \
     E(ST_FIRST_SYLLABLE) \
     E(ST_FIRST_SYLLABLE_INITIAL) \
-    L(ST_SYLLABLE_INITIAL)
+    E(ST_SYLLABLE_INITIAL) \
+    L(ST_SENTINEL) /* a temporary style to signify the end of a syllable */
 ENUM(grestyle_style, GRESTYLE_STYLE);
 
 /*


### PR DESCRIPTION
- Corrected problems in command line argument handling.
- Corrected problems rendering empty scores.
- Restored rendering of manual custos immediately after a bar.
- Fixed problems rendering styles around a forced center.
- Removed dead code.
For #697.

The tests I constructed in this phase highlighted two issues related to center determination (the `rebuild_characters` function).  The first is a problem with styles that surround a forced center.  This is fixed in the pull request.  The second is a problem when the initial is centered.  I did not have time to fix that for this pull request, but I will work on that next.

I rewrote the `rebuild_characters` function to hopefully de-spaghettify it a bit and help with these two fixes, so that needs a bit of careful review.

With the corresponding tests in gregorio-project/gregorio-test#124. this brings us to 96.8% line coverage and 100% function coverage.  However, #803 will bring in some new code and I still need to do valgrind and sanitize testing as well.

Please review and merge if satisfactory.