### PR TITLE
Fixed problems found in coverage testing.

### DIFF
--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -2414,7 +2414,7 @@ def write_fusion_leading(i, first_glyph, glyph_type, lique, qtype = None, stemsh
         elif first_glyph == 'SalicusOriscus':
             first_glyph = 'OriscusLineBL'
         elif first_glyph == 'VirgaBaseLineBL':
-            first_glyph = 'virgabase'
+            first_glyph = 'rvirgabase'
     length = get_width(first_glyph) + length
     if qtype:
         write_left_queue(i, qtype, stemshape, lique)

--- a/src/characters.c
+++ b/src/characters.c
@@ -1073,8 +1073,8 @@ void gregorio_rebuild_characters(gregorio_character **const param_character,
                 /* LCOV_EXCL_START */
                 gregorio_fail(gregorio_rebuild_characters,
                         "unexpected style type");
-                /* LCOV_EXCL_STOP */
             }
+            /* LCOV_EXCL_STOP */
         }
         current_character = current_character->next_character;
     }

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -611,9 +611,7 @@ static gregorio_note *close_fused_glyph(gregorio_glyph **last_glyph,
 static gregorio_note *next_non_texverb_note(gregorio_note *first_note,
         gregorio_note *last_note)
 {
-    if (first_note == NULL) {
-        return NULL;
-    }
+    gregorio_not_null(first_note, gregorio_note, return NULL);
 
     if (first_note == last_note) {
         /* not reachable unless there's a programming error */

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -179,25 +179,46 @@ static void fix_custos(gregorio_score *score_to_check)
  * ridiculous... but it might be improved in the future. 
  */
 
-static int check_score_integrity(gregorio_score *score_to_check)
+static bool check_score_integrity(gregorio_score *score_to_check)
 {
+    bool good = true;
+
     gregorio_assert(score_to_check, check_score_integrity, "score is NULL",
-            return 0);
-    return 1;
+            return false);
+
+    if (score_to_check->first_syllable
+            && score_to_check->first_syllable->elements
+            && *(score_to_check->first_syllable->elements)) {
+        if ((score_to_check->first_syllable->elements)[0]->type
+                == GRE_END_OF_LINE) {
+            gregorio_message(
+                    "line break is not supported on the first syllable",
+                    "check_score_integrity", VERBOSITY_ERROR, 0);
+            good = false;
+        }
+        if (gregorio_get_clef_change(score_to_check->first_syllable)) {
+            gregorio_message(
+                    "clef change is not supported on the first syllable",
+                    "check_score_integrity", VERBOSITY_ERROR, 0);
+            good = false;
+        }
+    }
+
+    return good;
 }
 
 /*
  * Another function to be improved: this one checks the validity of the voice_infos.
  */
 
-static int check_infos_integrity(gregorio_score *score_to_check)
+static bool check_infos_integrity(gregorio_score *score_to_check)
 {
     if (!score_to_check->name) {
         gregorio_message(_("no name specified, put `name:...;' at the "
                 "beginning of the file, can be dangerous with some output "
                 "formats"), "det_score", VERBOSITY_WARNING, 0);
     }
-    return 1;
+    return true;
 }
 
 /*
@@ -642,8 +663,10 @@ gregorio_score *gabc_read_score(FILE *f_in)
     gabc_det_notes_finish();
     free_variables();
     /* then we check the validity and integrity of the score we have built. */
-    gregorio_assert_only(check_score_integrity(score), gabc_read_score,
-            "unable to determine a valid score from file");
+    if (!check_score_integrity(score)) {
+        gregorio_message(_("unable to determine a valid score from file"),
+                "gabc_read_score", VERBOSITY_ERROR, 0);
+    }
     sha1_finish_ctx(&digester, score->digest);
     return score;
 }

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -564,7 +564,7 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
             return SHAPE_VirgaOpenqueue;
         case Q_ON_LINE_ABOVE_BOTTOM_LINE:
             return SHAPE_VirgaLongqueue;
-        }
+        } /* all cases return, so this line is not hit; LCOV_EXCL_LINE */
     case S_VIRGA_REVERSA:
         switch (note->u.note.liquescentia) {
         case L_AUCTUS_ASCENDENS:
@@ -596,7 +596,7 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
                 return SHAPE_VirgaReversaOpenqueueDescendens;
             case Q_ON_LINE_ABOVE_BOTTOM_LINE:
                 return SHAPE_VirgaReversaLongqueueDescendens;
-            }
+            } /* all cases return, so this line is not hit; LCOV_EXCL_LINE */
         default:
             return fusible_queued_shape(note, glyph, SHAPE_VirgaReversa,
                     SHAPE_VirgaReversaLongqueue, SHAPE_VirgaReversaOpenqueue);
@@ -632,7 +632,7 @@ static const char *gregoriotex_determine_note_glyph_name(gregorio_note *note,
         case Q_ON_BOTTOM_LINE:
         case Q_ON_LINE_ABOVE_BOTTOM_LINE:
             return SHAPE_StrophaAuctaLongtail;
-        }
+        } /* all cases return, so this line is not hit; LCOV_EXCL_LINE */
     case S_PUNCTUM_CAVUM_INCLINATUM:
         *type = AT_PUNCTUM_INCLINATUM;
         return SHAPE_PunctumCavumInclinatum;
@@ -721,7 +721,7 @@ static __inline const char *porrectus_shape(const gregorio_glyph *const glyph,
         case Q_ON_LINE_ABOVE_BOTTOM_LINE:
             return longqueue_shape;
         }
-    }
+    } /* must be optimized out; LCOV_EXCL_LINE */
     return base_shape;
 }
 
@@ -786,8 +786,8 @@ static __inline const char *quadratum_shape(const gregorio_glyph *const glyph,
         /* LCOV_EXCL_START */
         gregorio_fail(quadratum_shape, "unexpected queue length");
         /* fall out of the conditional */
-        /* LCOV_EXCL_STOP */
     }
+    /* LCOV_EXCL_STOP */
     return base_shape;
 }
 
@@ -1096,49 +1096,6 @@ static bool gregoriotex_is_last_of_line(gregorio_syllable *syllable)
 }
 
 /*
- * A small helper for the following function
- */
-
-static __inline bool is_clef(gregorio_type x)
-{
-    return x == GRE_CLEF;
-}
-
-/*
- * This function is used in write_syllable, it detects if the syllable is like
- * (c4), (::c4), (z0c4) or (z0::c4). It returns the gregorio_element of the
- * clef change.
- */
-static gregorio_element *gregoriotex_syllable_is_clef_change(gregorio_syllable
-        *syllable)
-{
-    gregorio_element *element;
-    gregorio_assert(syllable && syllable->elements && syllable->elements[0],
-            gregoriotex_syllable_is_clef_change, "invalid syllable",
-            return NULL);
-    element = syllable->elements[0];
-    /* we just detect the foud cases */
-    if (element->type == GRE_CUSTOS && element->next
-            && (is_clef(element->next->type)) && !element->next->next) {
-        return element->next;
-    }
-    if (element->type == GRE_BAR && element->next
-            && (is_clef(element->next->type)) && !element->next->next) {
-        return element->next;
-    }
-    if ((is_clef(element->type)) && !element->next) {
-        return element;
-    }
-    if (element->type == GRE_CUSTOS && element->next
-            && element->next->type == GRE_BAR && element->next->next
-            && (is_clef(element->next->next->type))
-            && !element->next->next->next) {
-        return element->next->next;
-    }
-    return NULL;
-}
-
-/*
  * ! @brief Prints the beginning of each text style
  */
 static void gtex_write_begin(FILE *f, grestyle_style style)
@@ -1299,8 +1256,12 @@ static void gtex_print_char(FILE *f, const grewchar to_print)
         fprintf(f, "\\GreStar{}");
         break;
     case L'%':
+        /* there's currently no way to get a % into gabc, so this wont be hit,
+         * but we leave it here for safety and possible future use */
+        /* LCOV_EXCL_START */
         fprintf(f, "\\%%{}");
         break;
+        /* LCOV_EXCL_STOP */
     case L'\\':
         fprintf(f, "\\textbackslash{}");
         break;
@@ -3195,9 +3156,8 @@ static void write_syllable_text(FILE *f, const char *const syllable_type,
 static void write_first_syllable_text(FILE *f, const char *const syllable_type,
         const gregorio_character *const text, bool end_of_word)
 {
-    if (syllable_type == NULL) {
-        fprintf(f, "}{\\GreSyllable}{\\GreSetNoFirstSyllableText}");
-    } else if (text == NULL) {
+    gregorio_not_null(syllable_type, write_first_syllable_text, return);
+    if (text == NULL) {
         fprintf(f, "}{%s}{\\GreSetNoFirstSyllableText}", syllable_type);
     } else {
         gregorio_character *text_with_initial = gregorio_clone_characters(text),
@@ -3361,6 +3321,9 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
      */
     if (syllable->elements && *(syllable->elements)) {
         if ((syllable->elements)[0]->type == GRE_END_OF_LINE) {
+            gregorio_assert(syllable != score->first_syllable, write_syllable,
+                    "line break is not supported on the first syllable",
+                    return);
             if ((syllable->elements)[0]->u.misc.unpitched.info.eol_ragged) {
                 fprintf(f, "%%\n%%\n\\GreNewParLine %%\n%%\n%%\n");
             } else {
@@ -3376,8 +3339,12 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
          * effect. So first we detect it:
          */
         if (first_of_disc == 0) {   /* to avoid infinite loops */
-            clef_change_element = gregoriotex_syllable_is_clef_change(syllable);
+            clef_change_element = gregorio_get_clef_change(syllable);
             if (clef_change_element) {
+                gregorio_assert(syllable != score->first_syllable,
+                        write_syllable,
+                        "clef change is not supported on the first syllable",
+                        return);
                 /*
                  * In this case, the first thing to do is to change the line clef
                  */
@@ -3396,22 +3363,27 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
         write_fixed_text_styles(f, syllable->text,
                 syllable->next_syllable? syllable->next_syllable->text : NULL);
         if ((syllable->elements)[0]->type == GRE_BAR) {
-            if (!syllable->next_syllable && !syllable->text
-                    && (syllable->elements)[0]->u.misc.unpitched.info.bar ==
-                    B_DIVISIO_FINALIS) {
-                handle_final_bar(f, "DivisioFinalis", syllable);
-                write_this_syllable_text(f, NULL, syllable->text, end_of_word);
-                return;
+            if (syllable != score->first_syllable) {
+                if (!syllable->next_syllable && !syllable->text
+                        && (syllable->elements)[0]->u.misc.unpitched.info.bar
+                        == B_DIVISIO_FINALIS) {
+                    handle_final_bar(f, "DivisioFinalis", syllable);
+                    write_this_syllable_text(f, NULL, syllable->text,
+                            end_of_word);
+                    return;
+                }
+                if (!syllable->next_syllable && !syllable->text
+                        && (syllable->elements)[0]->u.misc.unpitched.info.bar
+                        == B_DIVISIO_MAIOR) {
+                    handle_final_bar(f, "DivisioMaior", syllable);
+                    write_this_syllable_text(f, NULL, syllable->text,
+                            end_of_word);
+                    return;
+                }
             }
-            if (!syllable->next_syllable && !syllable->text
-                    && (syllable->elements)[0]->u.misc.unpitched.info.bar ==
-                    B_DIVISIO_MAIOR) {
-                handle_final_bar(f, "DivisioMaior", syllable);
-                write_this_syllable_text(f, NULL, syllable->text, end_of_word);
-                return;
-            } else {
-                syllable_type = "\\GreBarSyllable";
-            }
+            /* the special case of first syllable will be treated as a normal
+             * bar syllable */
+            syllable_type = "\\GreBarSyllable";
         } else {
             syllable_type = "\\GreSyllable";
         }
@@ -3479,9 +3451,6 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
             switch (element->type) {
             case GRE_SPACE:
                 switch (element->u.misc.unpitched.info.space) {
-                case SP_ZERO_WIDTH:
-                    fprintf(f, "\\GreEndOfElement{3}{1}%%\n");
-                    break;
                 case SP_LARGER_SPACE:
                     fprintf(f, "\\GreEndOfElement{1}{0}%%\n");
                     break;

--- a/src/struct.c
+++ b/src/struct.c
@@ -1399,6 +1399,48 @@ const char *gregorio_unknown(int value) {
     return buf;
 }
 
+/*
+ * A small helper for the following function
+ */
+
+static __inline bool is_clef(gregorio_type x)
+{
+    return x == GRE_CLEF;
+}
+
+/*
+ * This function is used in write_syllable, it detects if the syllable is like
+ * (c4), (::c4), (z0c4) or (z0::c4). It returns the gregorio_element of the
+ * clef change.
+ */
+gregorio_element *gregorio_get_clef_change(gregorio_syllable *syllable)
+{
+    gregorio_element *element;
+    gregorio_assert(syllable && syllable->elements && syllable->elements[0],
+            gregoriotex_syllable_is_clef_change, "invalid syllable",
+            return NULL);
+    element = syllable->elements[0];
+    /* we just detect the foud cases */
+    if (element->type == GRE_CUSTOS && element->next
+            && (is_clef(element->next->type)) && !element->next->next) {
+        return element->next;
+    }
+    if (element->type == GRE_BAR && element->next
+            && (is_clef(element->next->type)) && !element->next->next) {
+        return element->next;
+    }
+    if ((is_clef(element->type)) && !element->next) {
+        return element;
+    }
+    if (element->type == GRE_CUSTOS && element->next
+            && element->next->type == GRE_BAR && element->next->next
+            && (is_clef(element->next->next->type))
+            && !element->next->next->next) {
+        return element->next->next;
+    }
+    return NULL;
+}
+
 ENUM_TO_STRING(gregorio_type, GREGORIO_TYPE)
 ENUM_TO_STRING(gregorio_shape, GREGORIO_SHAPE)
 ENUM_TO_STRING(gregorio_bar, GREGORIO_BAR)

--- a/src/struct.h
+++ b/src/struct.h
@@ -853,6 +853,7 @@ gregorio_character *gregorio_clone_characters(const gregorio_character *source);
 signed char gregorio_determine_next_pitch(gregorio_syllable *syllable,
         gregorio_element *element, gregorio_glyph *glyph);
 const char *gregorio_unknown(int value);
+gregorio_element *gregorio_get_clef_change(gregorio_syllable *syllable);
 
 static __inline void gregorio_go_to_first_character_c(gregorio_character **character)
 {


### PR DESCRIPTION
- Corrected base glyph used for virga reversa fusion.
- Corrected assertions and added corresponding up-front score checking.
For #697.

Not much of an improvement here, but it fixes an important bug I'd like to get into beta2 (the base glyph bug).  With the corresponding tests (gregorio-project/gregorio-test#135), this gets us to 98.5% line coverage.

Please review and merge if satisfactory.