### PR TITLE
Code coverage update

### DIFF
--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -98,8 +98,8 @@ static char gregorio_add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
     /* here we separate notes that would be logically in the same glyph
      * but that are too far to be so */
     if (last_pitch) {
-        if (current_pitch - last_pitch > MAX_INTERVAL
-                || current_pitch - last_pitch < -MAX_INTERVAL) {
+        if (current_pitch - last_pitch > MAX_AMBITUS
+                || current_pitch - last_pitch < -MAX_AMBITUS) {
             current_glyph_type = G_UNDETERMINED;
         }
     }
@@ -430,8 +430,8 @@ static char gregorio_add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
      * it was not the same glyph, there we must say that the previous
      * glyph has ended. */
     if (last_pitch) {
-        if (current_pitch - last_pitch > MAX_INTERVAL
-                || current_pitch - last_pitch < -MAX_INTERVAL) {
+        if (current_pitch - last_pitch > MAX_AMBITUS
+                || current_pitch - last_pitch < -MAX_AMBITUS) {
             if (*end_of_glyph == DET_END_OF_CURRENT
                     || *end_of_glyph == DET_END_OF_BOTH) {
                 /* There is no current way for the code to end up here, but
@@ -531,22 +531,6 @@ static gregorio_note *close_normal_glyph(gregorio_glyph **last_glyph,
                             copy_note_location(current_note, &loc));
                     gregorio_add_note(&added_notes, current_note->u.note.pitch,
                             S_STROPHA, current_note->signs,
-                            current_note->u.note.liquescentia, current_note,
-                            copy_note_location(current_note, &loc));
-                    break;
-                case S_TRISTROPHA_AUCTA:
-                    gregorio_add_note(&added_notes, current_note->u.note.pitch,
-                            S_STROPHA, _NO_SIGN, L_NO_LIQUESCENTIA,
-                            current_note,
-                            copy_note_location(current_note, &loc));
-                    /* fall through */
-                case S_DISTROPHA_AUCTA:
-                    gregorio_add_note(&added_notes, current_note->u.note.pitch,
-                            S_STROPHA, _NO_SIGN, L_NO_LIQUESCENTIA,
-                            current_note,
-                            copy_note_location(current_note, &loc));
-                    gregorio_add_note(&added_notes, current_note->u.note.pitch,
-                            S_STROPHA_AUCTA, current_note->signs,
                             current_note->u.note.liquescentia, current_note,
                             copy_note_location(current_note, &loc));
                     break;
@@ -1131,10 +1115,6 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                             current_note->u.note.shape =
                                     S_PUNCTUM_CAVUM_INCLINATUM_AUCTUS;
                             break;
-
-                        default:
-                            /* do nothing */
-                            break;
                         }
 
                         if (current_note->next
@@ -1204,10 +1184,6 @@ gregorio_glyph *gabc_det_glyphs_from_notes(gregorio_note *current_note,
                         case L_AUCTUS_ASCENDENS:
                             current_note->u.note.shape =
                                     S_PUNCTUM_CAVUM_INCLINATUM_AUCTUS;
-                            break;
-
-                        default:
-                            /* do nothing */
                             break;
                         }
 

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -555,12 +555,13 @@ static gregorio_note *close_normal_glyph(gregorio_glyph **last_glyph,
                 current_note->next->previous = added_notes;
                 added_notes->next = next_note;
             }
+            if (current_note == new_current_note) {
+                new_current_note = added_notes;
+            }
             gregorio_go_to_first_note(&added_notes);
             if (current_note->previous) {
                 current_note->previous->next = added_notes;
                 added_notes->previous = current_note->previous;
-            } else {
-                new_current_note = added_notes;
             }
             /* Detaching current_note is not strictly necessary here because we
              * are effectively plucking out added_notes into its own glyph;

--- a/src/gabc/gabc-write.c
+++ b/src/gabc/gabc-write.c
@@ -547,9 +547,7 @@ static void gabc_write_gregorio_note(FILE *f, gregorio_note *note,
         fprintf(f, "%cs", pitch_letter(note->u.note.pitch));
         break;
     default:
-        /* includes S_BIVIRGA, S_TRIVIRGA, S_DISTROPHA, S_TRISTROPHA,
-         * S_DISTROPHA_AUCTA, and S_TRISTROPHA_AUCTA -- which are patched out
-         * during parsing */
+        /* includes S_BIVIRGA, S_TRIVIRGA, S_DISTROPHA, and S_TRISTROPHA */
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
         unsupported("gabc_write_gregorio_note", __LINE__, "shape",

--- a/src/gabc/gabc.h
+++ b/src/gabc/gabc.h
@@ -49,9 +49,6 @@ typedef enum gabc_determination {
     DET_END_OF_BOTH
 } gabc_determination;
 
-/* defines the maximal interval between two notes of the same glyph */
-#define MAX_INTERVAL 5
-
 static __inline void gabc_update_location(gregorio_scanner_location *const loc,
         const char *const bytes, const size_t length)
 {

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -317,6 +317,7 @@ int main(int argc, char **argv)
     gregorio_verbosity verb_mode = 0;
     bool point_and_click = false;
     char *point_and_click_filename = NULL;
+    bool debug = false;
     int option_index = 0;
     static struct option long_options[] = {
         {"output-file", 1, 0, 'o'},
@@ -344,7 +345,7 @@ int main(int argc, char **argv)
     setlocale(LC_CTYPE, "C");
 
     while (1) {
-        c = getopt_long(argc, argv, "o:SF:l:f:shOLVvWp",
+        c = getopt_long(argc, argv, "o:SF:l:f:shOLVvWpd",
                         long_options, &option_index);
         if (c == -1)
             break;
@@ -437,7 +438,15 @@ int main(int argc, char **argv)
             exit(0);
             break;
         case 'V':
-            printf("Gregorio version %s.\n%s\n", GREGORIO_VERSION, copyright);
+            printf("Gregorio version %s"
+#ifdef USE_KPSE
+                    " (%s)"
+#endif
+                    ".\n%s\n", GREGORIO_VERSION,
+#ifdef USE_KPSE
+                        kpathsea_version_string,
+#endif
+                        copyright);
             exit(0);
             break;
         case 'v':
@@ -468,6 +477,14 @@ int main(int argc, char **argv)
                 break;
             }
             point_and_click = true;
+            break;
+        case 'd':
+            if (debug) {
+                fprintf(stderr,
+                        "warning: debug option passed two times\n");
+                break;
+            }
+            debug = true;
             break;
         case '?':
             break;
@@ -503,6 +520,8 @@ int main(int argc, char **argv)
         }
         fprintf(stderr, "\n");
     }
+
+    gregorio_set_debug_messages(debug);
 
     if (!input_format) {
         input_format = DEFAULT_INPUT_FORMAT;

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -112,8 +112,8 @@ static char *define_path(char *current_directory, char *string)
             fprintf(stderr, "the directory %s for %s does not exist\n",
                     temp_name, base_name);
             gregorio_exit(1);
+            /* LCOV_EXCL_STOP */
         }
-        /* LCOV_EXCL_STOP */
     } else {
         /* no path was supplied */
         base_name = string;
@@ -257,8 +257,8 @@ static char *encode_point_and_click_filename(char *input_file_name)
         /* LCOV_EXCL_START */
         fprintf(stderr, "error: unable to resolve %s\n", input_file_name);
         gregorio_exit(1);
+        /* LCOV_EXCL_STOP */
     }
-    /* LCOV_EXCL_STOP */
 
     /* 2 extra characters for a possible leading slash and final NUL */
     r = result = gregorio_malloc(strlen(filename) * 4 + 2);
@@ -396,7 +396,7 @@ int main(int argc, char **argv)
                 fprintf(stderr, "error: unknown output format: %s\n", optarg);
                 gregorio_exit(1);
             }
-            break; /* all cases either break or exit; LCOV_EXCL_LINE */
+            break;
         case 'l':
             if (error_file_name) {
                 fprintf(stderr,
@@ -420,7 +420,7 @@ int main(int argc, char **argv)
                 fprintf(stderr, "error: unknown input format: %s\n", optarg);
                 gregorio_exit(1);
             }
-            break; /* all cases either break or exit; LCOV_EXCL_LINE */
+            break;
         case 's':
             /* input_file_name will be null here because of the way
              * we use getopt_long */
@@ -546,7 +546,7 @@ int main(int argc, char **argv)
                 fprintf(stderr, "error: unsupported format");
                 gregorio_exit(1);
                 /* LCOV_EXCL_STOP */
-            } /* all cases either break or exit; LCOV_EXCL_LINE */
+            }
         }
     }
     if (output_basename) {
@@ -630,8 +630,8 @@ int main(int argc, char **argv)
         fclose(output_file);
         fprintf(stderr, "error in file parsing\n");
         gregorio_exit(1);
+        /* LCOV_EXCL_STOP */
     }
-    /* LCOV_EXCL_STOP */
 
     switch (output_format) {
     case GABC:

--- a/src/messages.c
+++ b/src/messages.c
@@ -22,11 +22,10 @@
 
 #include "config.h"
 #include <stdio.h>
-#include <stdlib.h>             /* for exit() */
-#include <stdarg.h>             /* for exit() */
 #include <assert.h>
 #include "bool.h"
 #include "messages.h"
+#include "support.h"
 
 static FILE *error_out;
 static gregorio_verbosity verbosity_mode = 0;
@@ -139,7 +138,7 @@ void gregorio_messagef(const char *function_name,
     case VERBOSITY_FATAL:
         /* all fatal errors should not be reasonably testable */
         /* LCOV_EXCL_START */
-        exit(1);
+        gregorio_exit(1);
         break;
         /* LCOV_EXCL_STOP */
     default:

--- a/src/messages.c
+++ b/src/messages.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #include <stdio.h>
 #include <assert.h>
+#include <stdarg.h>
 #include "bool.h"
 #include "messages.h"
 #include "support.h"

--- a/src/messages.c
+++ b/src/messages.c
@@ -48,12 +48,10 @@ void gregorio_set_verbosity_mode(const gregorio_verbosity verbosity)
     verbosity_mode = verbosity;
 }
 
-#if 0 /* unused */
-static void gregorio_set_debug_messages(bool debug)
+void gregorio_set_debug_messages(bool debug)
 {
     debug_messages = debug;
 }
-#endif
 
 static const char *verbosity_to_str(const gregorio_verbosity verbosity)
 {
@@ -114,12 +112,11 @@ void gregorio_messagef(const char *function_name,
     }
     verbosity_str = verbosity_to_str(verbosity);
     if (line_number) {
+        /* if line number is specified, function_name must be specified */
+        assert(function_name);
         if (function_name) {
             fprintf(error_out, "%d: in function `%s': %s", line_number,
                     function_name, verbosity_str);
-        } else {
-            /* no function_name specified */
-            fprintf(error_out, "%d: %s", line_number, verbosity_str);
         }
     } else {
         if (function_name) {

--- a/src/messages.h
+++ b/src/messages.h
@@ -53,6 +53,7 @@ void gregorio_messagef(const char *function_name,
         int line_number, const char *format, ...)
         __attribute__ ((__format__ (__printf__, 4, 5)));
 void gregorio_set_verbosity_mode(gregorio_verbosity verbosity);
+void gregorio_set_debug_messages(bool debug);
 void gregorio_set_error_out(FILE *f);
 int gregorio_get_return_value(void);
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -113,9 +113,7 @@ ENUM(gregorio_clef, GREGORIO_CLEF);
     E(S_STROPHA) \
     E(S_STROPHA_AUCTA) \
     E(S_DISTROPHA) \
-    E(S_DISTROPHA_AUCTA) \
     E(S_TRISTROPHA) \
-    E(S_TRISTROPHA_AUCTA) \
     E(S_PUNCTUM_CAVUM) \
     E(S_LINEA_PUNCTUM) \
     E(S_LINEA_PUNCTUM_CAVUM) \
@@ -756,6 +754,9 @@ static __inline bool is_fused(char liquescentia)
 #define LOWEST_PITCH 3
 #define DUMMY_PITCH (LOWEST_PITCH + 6)
 #define LOW_LEDGER_LINE_PITCH (LOWEST_PITCH + 1)
+
+/* defines the maximal interval between two notes of the same glyph */
+#define MAX_AMBITUS 5
 
 gregorio_score *gregorio_new_score(void);
 void gregorio_add_note(gregorio_note **current_note, signed char pitch,

--- a/src/support.c
+++ b/src/support.c
@@ -157,8 +157,8 @@ static bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
             gregorio_message(_("invalid buffer size"), "gregorio_getline",
                     VERBOSITY_FATAL, 0);
             gregorio_exit(1);
+            /* LCOV_EXCL_STOP */
         }
-        /* LCOV_EXCL_STOP */
     }
     (*buf)[0] = '\0';
     oldsize = 1;
@@ -176,8 +176,8 @@ static bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
                 gregorio_message(_("Error reading from the file"),
                         "gregorio_getline", VERBOSITY_FATAL, 0);
                 gregorio_exit(1);
+                /* LCOV_EXCL_STOP */
             }
-            /* LCOV_EXCL_STOP */
             return (*buf)[0] != '\0';
         }
 
@@ -187,8 +187,8 @@ static bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
             gregorio_message(_("Line too long"), "gregorio_getline",
                     VERBOSITY_FATAL, 0);
             gregorio_exit(1);
+            /* LCOV_EXCL_STOP */
         }
-        /* LCOV_EXCL_STOP */
 
         oldsize = *bufsize;
         *bufsize <<= 1;

--- a/src/support.c
+++ b/src/support.c
@@ -80,6 +80,7 @@ char *gregorio_strdup(const char *s)
     return (char *)assert_successful_allocation(strdup(s), "gregorio_strdup");
 }
 
+#ifndef USE_KPSE
 bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
 {
     size_t oldsize;
@@ -131,3 +132,4 @@ bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
         *buf = gregorio_realloc(*buf, *bufsize);
     }
 }
+#endif

--- a/src/support.c
+++ b/src/support.c
@@ -3,7 +3,7 @@
  * This file contains miscellaneous support functions.
  *
  * Copyright (C) 2015 The Gregorio Project (see CONTRIBUTORS.md)
- * 
+ *
  * This file is part of Gregorio.
  *
  * Gregorio is free software: you can redistribute it and/or modify
@@ -25,6 +25,8 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
+#include <errno.h>
 #include "support.h"
 #include "messages.h"
 
@@ -54,9 +56,9 @@ static __inline void *assert_successful_allocation(void *ptr, char *funcname) {
         /* LCOV_EXCL_START */
         gregorio_message(_("error in memory allocation"),
                 funcname, VERBOSITY_FATAL, 0);
-        exit(1);
-        /* LCOV_EXCL_STOP */
+        gregorio_exit(1);
     }
+    /* LCOV_EXCL_STOP */
     return ptr;
 }
 
@@ -80,8 +82,69 @@ char *gregorio_strdup(const char *s)
     return (char *)assert_successful_allocation(strdup(s), "gregorio_strdup");
 }
 
+#ifdef USE_KPSE
+static kpathsea kpse = NULL;
+#define USED_FOR_KPSE
+#else
+#define USED_FOR_KPSE __attribute__((unused))
+#endif
+
+void gregorio_support_init(const char *const program USED_FOR_KPSE,
+        const char *const argv0 USED_FOR_KPSE)
+{
+    gregorio_set_error_out(stderr);
+    gregorio_set_verbosity_mode(VERBOSITY_ERROR);
+#ifdef USE_KPSE
+    kpse = kpathsea_new();
+    kpathsea_set_program_name(kpse, argv0, program);
+#endif
+}
+
+void gregorio_print_version(const char *copyright)
+{
+#ifdef USE_KPSE
+    printf("Gregorio version %s (%s).\n%s\n", GREGORIO_VERSION,
+            kpathsea_version_string, copyright);
+#else
+    printf("Gregorio version %s.\n%s\n", GREGORIO_VERSION,
+            copyright);
+#endif
+}
+
+#ifdef USE_KPSE
+bool gregorio_read_ok(const char *const filename,
+        const gregorio_verbosity verbosity)
+{
+    if (kpathsea_in_name_ok_silent(kpse, filename)) {
+        return true;
+    }
+    gregorio_messagef("gregorio_in_name_ok", verbosity, __LINE__,
+            _("kpse prohibits read from file %s"), filename);
+    return false;
+}
+
+bool gregorio_write_ok(const char *const filename,
+        const gregorio_verbosity verbosity)
+{
+    if (kpathsea_out_name_ok_silent(kpse, filename)) {
+        return true;
+    }
+    gregorio_messagef("gregorio_out_name_ok", verbosity, __LINE__,
+            _("kpse prohibits write to file %s"), filename);
+    return false;
+}
+#endif
+
 #ifndef USE_KPSE
-bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
+static __inline void rtrim(char *buf)
+{
+    char *p;
+    for (p = buf + strlen(buf) - 1; p >= buf && isspace(*p); --p) {
+        *p = '\0';
+    }
+}
+
+static bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
 {
     size_t oldsize;
     if (*buf == NULL) {
@@ -93,9 +156,9 @@ bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
             /* LCOV_EXCL_START */
             gregorio_message(_("invalid buffer size"), "gregorio_getline",
                     VERBOSITY_FATAL, 0);
-            exit(1);
-            /* LCOV_EXCL_STOP */
+            gregorio_exit(1);
         }
+        /* LCOV_EXCL_STOP */
     }
     (*buf)[0] = '\0';
     oldsize = 1;
@@ -112,9 +175,9 @@ bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
                 /* LCOV_EXCL_START */
                 gregorio_message(_("Error reading from the file"),
                         "gregorio_getline", VERBOSITY_FATAL, 0);
-                exit(1);
-                /* LCOV_EXCL_STOP */
+                gregorio_exit(1);
             }
+            /* LCOV_EXCL_STOP */
             return (*buf)[0] != '\0';
         }
 
@@ -123,9 +186,9 @@ bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
             /* LCOV_EXCL_START */
             gregorio_message(_("Line too long"), "gregorio_getline",
                     VERBOSITY_FATAL, 0);
-            exit(1);
-            /* LCOV_EXCL_STOP */
+            gregorio_exit(1);
         }
+        /* LCOV_EXCL_STOP */
 
         oldsize = *bufsize;
         *bufsize <<= 1;
@@ -133,3 +196,74 @@ bool gregorio_readline(char **buf, size_t *bufsize, FILE *file)
     }
 }
 #endif
+
+
+char **gregorio_kpse_find(const char *filename)
+{
+    char **filenames;
+#ifdef USE_KPSE
+    filenames = kpathsea_find_file_generic(kpse, filename, kpse_tex_format,
+            true, true);
+    if (!filenames) {
+        /* It's not reasonable to break kpse in such a way that this would
+         * fail. */
+        /* LCOV_EXCL_START */
+        gregorio_messagef("gregorio_kpse_find", VERBOSITY_WARNING, 0,
+                _("kpathsea_find_file_generic returned NULL: %s"), filename);
+        return NULL;
+        /* LCOV_EXCL_STOP */
+    }
+#else
+    FILE *file;
+    size_t bufsize = 0;
+    char *buf = NULL;
+    size_t capacity = 16, size = 0;
+#define KPSE_COMMAND "kpsewhich -must-exist -all "
+    size_t command_size = sizeof(KPSE_COMMAND) + strlen(filename);
+    char *command = gregorio_malloc(command_size);
+
+    strcpy(command, KPSE_COMMAND);
+    strcpy(command + sizeof(KPSE_COMMAND) - 1, filename);
+    file = popen(command, "r");
+    free(command);
+    command = NULL; /* just to be sure */
+    if (!file) {
+        /* it's not reasonable to cause popen to fail */
+        /* LCOV_EXCL_START */
+        gregorio_messagef("gregorio_kpse_find", VERBOSITY_WARNING, 0,
+                _("unable to run kpsewhich %s: %s"), filename,
+                strerror(errno));
+        return NULL;
+        /* LCOV_EXCL_STOP */
+    }
+    filenames = gregorio_malloc(capacity * sizeof(char *));
+    while (gregorio_readline(&buf, &bufsize, file)) {
+        rtrim(buf);
+        if (strlen(buf) > 0) {
+            filenames[size++] = gregorio_strdup(buf);
+            if (size >= capacity) {
+                capacity <<= 1;
+                filenames = gregorio_realloc(filenames,
+                                capacity * sizeof(char *));
+            }
+        } else {
+            gregorio_messagef("read_patterns", VERBOSITY_WARNING, 0,
+                    _("kpsewhich returned bad value for %s"), filename);
+        }
+    }
+    free(buf);
+    filenames[size] = NULL;
+    pclose(file);
+#endif
+    return filenames;
+}
+
+void gregorio_exit(int status)
+{
+#ifdef USE_KPSE
+    if (kpse) {
+        kpathsea_finish(kpse);
+    }
+#endif
+    exit(status);
+} /* the prior line exits; LCOV_EXCL_LINE */

--- a/src/support.h
+++ b/src/support.h
@@ -37,15 +37,15 @@
     ((size_t)((((INT_MAX < GREGORIO_SZ_MAX)? INT_MAX : GREGORIO_SZ_MAX) >> 1) + 1))
 
 void gregorio_snprintf(char *s, size_t size, const char *format, ...)
-        __attribute__ ((__format__ (__printf__, 3, 4)));
-void *gregorio_malloc(size_t size);
-void *gregorio_calloc(size_t nmemb, size_t size);
-void *gregorio_realloc(void *ptr, size_t size);
-char *gregorio_strdup(const char *s);
+        __attribute__((__format__ (__printf__, 3, 4)));
+void *gregorio_malloc(size_t size) __attribute__((malloc));
+void *gregorio_calloc(size_t nmemb, size_t size) __attribute__((malloc));
+void *gregorio_realloc(void *ptr, size_t size) __attribute__((warn_unused_result));
+char *gregorio_strdup(const char *s) __attribute__((malloc));
 void gregorio_support_init(const char *program, const char *argv0);
 void gregorio_print_version(const char *copyright);
 char **gregorio_kpse_find(const char *filename);
-void gregorio_exit(int status);
+void gregorio_exit(int status) __attribute__((noreturn));
 
 #ifdef USE_KPSE
 bool gregorio_read_ok(const char *filename, gregorio_verbosity verbosity);

--- a/src/support.h
+++ b/src/support.h
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include "bool.h"
+#include "config.h"
 
 #define GREGORIO_SZ_MAX (~((size_t)0))
 #define MAX_BUF_GROWTH \
@@ -37,6 +38,8 @@ void *gregorio_malloc(size_t size);
 void *gregorio_calloc(size_t nmemb, size_t size);
 void *gregorio_realloc(void *ptr, size_t size);
 char *gregorio_strdup(const char *s);
+#ifndef USE_KPSE
 bool gregorio_readline(char **bufptr, size_t *bufsize, FILE *file);
+#endif
 
 #endif

--- a/src/support.h
+++ b/src/support.h
@@ -25,8 +25,12 @@
 
 #include <stdlib.h>
 #include <limits.h>
+#ifdef USE_KPSE
+#include <kpathsea/kpathsea.h>
+#endif
 #include "bool.h"
 #include "config.h"
+#include "messages.h"
 
 #define GREGORIO_SZ_MAX (~((size_t)0))
 #define MAX_BUF_GROWTH \
@@ -38,8 +42,29 @@ void *gregorio_malloc(size_t size);
 void *gregorio_calloc(size_t nmemb, size_t size);
 void *gregorio_realloc(void *ptr, size_t size);
 char *gregorio_strdup(const char *s);
-#ifndef USE_KPSE
-bool gregorio_readline(char **bufptr, size_t *bufsize, FILE *file);
+void gregorio_support_init(const char *program, const char *argv0);
+void gregorio_print_version(const char *copyright);
+char **gregorio_kpse_find(const char *filename);
+void gregorio_exit(int status);
+
+#ifdef USE_KPSE
+bool gregorio_read_ok(const char *filename, gregorio_verbosity verbosity);
+bool gregorio_write_ok(const char *filename, gregorio_verbosity verbosity);
+
+#define gregorio_check_file_access(DIR, FILENAME, LEVEL, ON_NOT_ALLOWED) \
+    if (!gregorio_ ## DIR ## _ok(FILENAME, VERBOSITY_ ## LEVEL)) { \
+        ON_NOT_ALLOWED; \
+    }
+#define gregorio_kpse_find_or_else(VAR, FILENAME, ON_FAIL) \
+    VAR = gregorio_kpse_find(FILENAME); \
+    if (!VAR) { \
+        ON_FAIL; \
+    }
+#else
+#define gregorio_check_file_access(DIRECTION, FILENAME, LEVEL, ON_NOT_ALLOWED)
+#define gregorio_kpse_find_or_else(VAR, FILENAME, ON_FAIL) \
+    VAR = gregorio_kpse_find(FILENAME); \
+    gregorio_not_null(VAR, gregorio_kpse_find, ON_FAIL)
 #endif
 
 #endif

--- a/src/vowel/vowel.c
+++ b/src/vowel/vowel.c
@@ -26,9 +26,6 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
-#ifdef USE_KPSE
-    #include <kpathsea/kpathsea.h>
-#endif
 #include "bool.h"
 #include "vowel.h"
 #include "unicode.h"
@@ -240,13 +237,7 @@ void gregorio_vowel_tables_init(void)
 void gregorio_vowel_tables_load(const char *const filename,
         char **const language, rulefile_parse_status *status)
 {
-#ifdef USE_KPSE
-    if (!kpse_in_name_ok(filename)) {
-        gregorio_messagef("gregorio_vowel_tables_load", VERBOSITY_WARNING, 0,
-                _("kpse disallows read from %s"), filename);
-        return;
-    }
-#endif
+    gregorio_check_file_access(read, filename, WARNING, return);
     gregorio_vowel_rulefile_in = fopen(filename, "r");
     if (gregorio_vowel_rulefile_in) {
         gregorio_vowel_rulefile_parse(filename, language, status);


### PR DESCRIPTION
- Removed warnings that are no longer relevant.
- Unified MAX_AMBITUS and MAX_INTERVAL values.
- Added debug command line option.
- Added display of kpathsea version when compiled with kpathsea.
- Excluded gregorio_readline (unused) when compiled with kpathsea.
- Added and corrected assertions.
- Removed dead code.
- Fixed buffer-use-after-free (bug in repercussion pointers) and buffer-overrun (with bad unicode).
- Switched from the kpse compatibility API to the newer kpathsea API.
- Added a kpathsea check for writing the error file.
- Updated the copyright (and moved the string to the top of the file).
For #697.

A few notes:

I have run the system through sanitize and valgrind as well, which revealed a couple of bugs and a problem with kpathsea.

With the accompanying tests (gregorio-project/gregorio-test#139), this gets us to 100% coverage*, both with kpathsea and without kpathsea.  The * indicates that this is with the exclusion of
1. certain lines (marked with LCOV tokens), because they are not reasonably testable or are assertions that should not be hit
2. bison- and flex- generated files because the key parts for testing (the code in the actions) are skipped by the coverage tools.

I switched to the newer kpathsea API because valgrind detected a memory leak coming from a call to `kpathsea_name_ok`, so I did some research and found the `kpathsea_finish` function which purportedly cleaned up, but would require a switch to the new API.  A few grueling hours later, I completed the switch, and valgrind found that the leak had worsened.  I tracked this down to the fact that the kpathsea library (6.2.1-20150521) included in Gentoo has `KPATHSEA_CAN_FREE` set to `0`, which is likely the cause of the original leak with the old API.  This means that running sanitize or valgrind against the executable with kpathsea linked in on my computer shows every test having memory leaks.  Perhaps if one you has a kpathsea than can free, you can try the valgrind/sanitize tests against a `--with-kpathsea` build.

I decided to leave the new code in since it uses the newer API and because, in so doing, I updated the copyright and added the kpathsea check for the error file which was missing earlier.  The kpathsea switch is in a different commit, so I can exclude that easily if you feel that I should.

I have not done a new static analysis (with scan-build), because it's getting pretty late.  I'll see if I can do that tomorrow (well, today actually), but it's Chinese New Year (and the last weekend before Lent), so I'll be at a party for much of the day.

Please review and merge if satisfactory, or let me know if there's anything I should change.