### PR TITLE
Fixed centering when the determined center ends at an elision.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Fixed
 - New bar spacing algorithm now accounts for translations (and other below lyrics stuff).
 - Horizontal episema on initio debilis is now sized correctly (see [#880](https://github.com/gregorio-project/gregorio/issues/880)).
+- Elisions immediately after the vowel are now properly left out of the center (see [#907](https://github.com/gregorio-project/gregorio/issues/907))
 
 ### Changed
 - Adjustments to the heuristic for ledger lines to include adjacent notes (see [#862](https://github.com/gregorio-project/gregorio/issues/862)).

--- a/src/characters.c
+++ b/src/characters.c
@@ -893,16 +893,29 @@ void gregorio_rebuild_characters(gregorio_character **const param_character,
             switch (current_character->cos.s.type) {
             case ST_T_BEGIN:
                 /* the beginning of a style */
+
+                if (center_is_determined == CENTER_DETERMINING_MIDDLE
+                        && index == end - 1) {
+                    /* if we are determining the end of the center and we have
+                     * a, ELISION, VERBATIM or SPECIAL_CHAR style, we end the
+                     * center determination */
+                    switch (style) {
+                    case ST_VERBATIM:
+                    case ST_SPECIAL_CHAR:
+                    case ST_ELISION:
+                        end_center(center_type, current_character, &first_style);
+                        center_is_determined = CENTER_FULLY_DETERMINED;
+                        break;
+
+                    default:
+                        /* something else; don't do anything */
+                        break;
+                    }
+                }
+
                 switch (style) {
                 case ST_VERBATIM:
                 case ST_SPECIAL_CHAR:
-                    /* if we are determining the end of the middle and we have
-                     * a VERBATIM or SPECIAL_CHAR style, we end the center
-                     * determination */
-                    if (center_is_determined == CENTER_DETERMINING_MIDDLE) {
-                        end_center(center_type, current_character, &first_style);
-                        center_is_determined = CENTER_FULLY_DETERMINED;
-                    }
                     /* Here we pass all the characters after a verbatim (or
                      * special char) beginning, until we find a style (begin or
                      * end) */


### PR DESCRIPTION
Fixes #907.

All current tests pass, but that means that this bug was not included in the tests, so I added the appropriate test.

Please review and merge if satisfactory.