### PR TITLE
Added parentheses to protect the _, N_, and ngt_ macros.

### DIFF
--- a/src/messages.h
+++ b/src/messages.h
@@ -29,12 +29,12 @@
 #if ENABLE_NLS == 1
 #include "gettext.h"
 #define _(str) gettext(str)
-#define N_(str) str
+#define N_(str) (str)
 #define ngt_(str, strtwo, count) ngettext(str, strtwo, count)
 #else
-#define _(str) str
-#define N_(str) str
-#define ngt_(str, strtwo, count) str
+#define _(str) (str)
+#define N_(str) (str)
+#define ngt_(str, strtwo, count) (str)
 #endif
 
 typedef enum gregorio_verbosity {


### PR DESCRIPTION
This is for #908.  It doesn't actually fix the problem described there, but is surely safer than just leaving `str` by itself.  This simple change doesn't break compilation, so I will merge it.