### PR TITLE
Feature/backwardsbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+### Changed
+- The treatment of syllables with no notes has been reverted when the old spacing algorithm is used.  Such syllables are now treated as notes syllables under the old algorithm (as was the case in 4.1.0-beta3 and earlier) and as bar syllables under the new algorithm.
 
 
 ## [4.1.0-rc1] - 2016-02-18

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1094,6 +1094,9 @@ Macro which formats the mode in roman or arabic numerals according to the approp
   \#1 & \texttt{1}--\texttt{8} & The mode to be formated\\
 \end{argtable}
 
+\macroname{\textbackslash GreNoNoteSyllable}{}{gregoriotex-syllable.tex}
+Alias for \verb=\GreSyllable= or \verb=\GreBarSyllable= depending on whether the old or new bar spacing algorithm (respectively) is active.  This is used only for syllables which have no notes.
+
 %%% Local Variables:
 %%% mode: latex
 %%% TeX-master: "GregorioRef"

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3443,7 +3443,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
     } else {
         write_fixed_text_styles(f, syllable->text,
                 syllable->next_syllable? syllable->next_syllable->text : NULL);
-        syllable_type = "\\GreBarSyllable";
+        syllable_type = "\\GreNoNoteSyllable";
     }
     write_this_syllable_text(f, syllable_type, syllable->text, end_of_word);
     fprintf(f, "{}{\\Gre%s}", syllable->first_word ? "FirstWord" : "Unstyled");

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1617,17 +1617,22 @@
 }
 
 \def\gre@unkern@bar@aftermora{%
-  % don't apply a negative kern on the first glyph
-  % while boxing, otherwise the box width will be wrong
-  \ifgre@firstglyph %
-    \ifgre@boxing\else %
+  \ifgre@newbarspacing%
+    % don't apply a negative kern on the first glyph
+    % while boxing, otherwise the box width will be wrong
+    \ifgre@firstglyph %
+      \ifgre@boxing\else %
+        \gre@get@unkern@aftermora{2}%
+        \kern\gre@skip@punctummorashift %
+      \fi %
+    \else %
       \gre@get@unkern@aftermora{2}%
       \kern\gre@skip@punctummorashift %
     \fi %
-  \else %
+  \else%
     \gre@get@unkern@aftermora{2}%
     \kern\gre@skip@punctummorashift %
-  \fi %
+  \fi%
   \relax %
 }
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -244,17 +244,25 @@
 %%  min_text_dist = prev_cur_word ? 0 : space_inter_words
   \ifnum#1=1\relax %
     \ifgre@in@euouae %
-      \ifnum#2=1\relax %
-        \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars@euouae\relax%
-      \else %
+      \ifgre@newbarspacing%
+        \ifnum#2=1\relax %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars@euouae\relax%
+        \else %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@euouae\relax%
+        \fi %
+      \else%
         \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@euouae\relax%
-      \fi %
+      \fi%
     \else %
-      \ifnum#2=1\relax %
-        \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars\relax%
-      \else %
+      \ifgre@newbarspacing%
+        \ifnum#2=1\relax %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars\relax%
+        \else %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext\relax%
+        \fi %
+      \else%
         \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext\relax%
-      \fi %
+      \fi%
     \fi %
   \else %
     \gre@skip@minTextDistance=0pt\relax%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -216,7 +216,12 @@
     \global\setbox\gre@box@temp@width=\hbox{\gre@fontchar@divisiofinalis}%
   \or %
     % case of no note
-    \global\setbox\gre@box@temp@width=\hbox{}%
+    \ifgre@newbarspacing%
+      \global\setbox\gre@box@temp@width=\hbox{}%
+    \else%
+      % under the old algorithm, syllables with no notes triggered a 0 in this function, so we duplicate the first case here
+      \global\setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPPunctum}%
+    \fi%
   \fi%
   \relax%
 }%
@@ -823,12 +828,16 @@
 
 \newif\ifgre@newbarspacing%
 \gre@newbarspacingfalse%
+% the new bar spacing algorithm treats no note syllables as BarSyllables, while the old algorithm treated them as regular syllables.  In order to allow for this variant, we define NoNoteSyllable which aliases to the appropriate function
+\let\GreNoNoteSyllable\GreSyllable%
 
 \def\gresetbarspacing#1{%
   \IfStrEq{#1}{new}%
-    {\gre@newbarspacingtrue}%
+    {\gre@newbarspacingtrue%
+    \let\GreNoNoteSyllable\GreBarSyllable}%
     {\IfStrEq{#1}{old}%
-      {\gre@newbarspacingfalse}%
+      {\gre@newbarspacingfalse%
+      \let\GreNoNoteSyllable\GreSyllable}%
       {\gre@error{Unrecognized option for \protect\gresetbarspacing}}%
     }%
 }%


### PR DESCRIPTION
These changes restore the behavior of the old bar spacing algorithm so that scores which use it are unchanged when upgrading to 4.1.

There are, however, some changes which I'm not sure we should keep because I think I'm overriding a bug fix to restore the old behavior.  These are split out into a separate commit (57af33e) in order to make them easier to identify and revert.

Finally, there is one test `gabc-output/edge-cases.gabc` for which I cannot seem to get an old version to pass.  I'd appreaciate it if someone would look that one over and see if they can identify the code changes which are causing it's failure.