### PR TITLE
Feature/backwardsbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+### Changed
+- The treatment of syllables with no notes has been reverted when the old spacing algorithm is used.  Such syllables are now treated as notes syllables under the old algorithm (as was the case in 4.1.0-beta3 and earlier) and as bar syllables under the new algorithm.
 
 
 ## [4.1.0-rc1] - 2016-02-18

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Gregorio provides an [`.editorconfig` file](../.editorconfig), using an [editorc
 
 Python files must output no error when inspected by `pylint`.
 
-TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -nE '^( |\\(|g|e|x)def)[^%]+$' tex/*.tex tex/*.sty` returns only Lua and metapost code or other lines where `%` is not needed.
+TeX code must use LuaTeX (more than TeX + eTeX + Omega + PDFTeX) primitives as much as possible, and, when not possible, use code compiling under PlainTeX. All lines inside macro definitions must end with `%` to avoid spurious spaces. To check that no line has been forgotten, please check that `grep -nE '^(\s|\\(|g|e|x)def)[^%]+$' tex/*.tex tex/*.sty` returns only Lua and metapost code or other lines where `%` is not needed.
 
 ### Tests
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1094,6 +1094,9 @@ Macro which formats the mode in roman or arabic numerals according to the approp
   \#1 & \texttt{1}--\texttt{8} & The mode to be formated\\
 \end{argtable}
 
+\macroname{\textbackslash GreNoNoteSyllable}{}{gregoriotex-syllable.tex}
+Alias for \verb=\GreSyllable= or \verb=\GreBarSyllable= depending on whether the old or new bar spacing algorithm (respectively) is active.  This is used only for syllables which have no notes.
+
 %%% Local Variables:
 %%% mode: latex
 %%% TeX-master: "GregorioRef"

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3443,7 +3443,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
     } else {
         write_fixed_text_styles(f, syllable->text,
                 syllable->next_syllable? syllable->next_syllable->text : NULL);
-        syllable_type = "\\GreBarSyllable";
+        syllable_type = "\\GreNoNoteSyllable";
     }
     write_this_syllable_text(f, syllable_type, syllable->text, end_of_word);
     fprintf(f, "{}{\\Gre%s}", syllable->first_word ? "FirstWord" : "Unstyled");

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1617,17 +1617,22 @@
 }
 
 \def\gre@unkern@bar@aftermora{%
-  % don't apply a negative kern on the first glyph
-  % while boxing, otherwise the box width will be wrong
-  \ifgre@firstglyph %
-    \ifgre@boxing\else %
+  \ifgre@newbarspacing%
+    % don't apply a negative kern on the first glyph
+    % while boxing, otherwise the box width will be wrong
+    \ifgre@firstglyph %
+      \ifgre@boxing\else %
+        \gre@get@unkern@aftermora{2}%
+        \kern\gre@skip@punctummorashift %
+      \fi %
+    \else %
       \gre@get@unkern@aftermora{2}%
       \kern\gre@skip@punctummorashift %
     \fi %
-  \else %
+  \else%
     \gre@get@unkern@aftermora{2}%
     \kern\gre@skip@punctummorashift %
-  \fi %
+  \fi%
   \relax %
 }
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -244,17 +244,25 @@
 %%  min_text_dist = prev_cur_word ? 0 : space_inter_words
   \ifnum#1=1\relax %
     \ifgre@in@euouae %
-      \ifnum#2=1\relax %
-        \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars@euouae\relax%
-      \else %
+      \ifgre@newbarspacing%
+        \ifnum#2=1\relax %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars@euouae\relax%
+        \else %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@euouae\relax%
+        \fi %
+      \else%
         \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@euouae\relax%
-      \fi %
+      \fi%
     \else %
-      \ifnum#2=1\relax %
-        \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars\relax%
-      \else %
+      \ifgre@newbarspacing%
+        \ifnum#2=1\relax %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext@bars\relax%
+        \else %
+          \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext\relax%
+        \fi %
+      \else%
         \gre@skip@minTextDistance=\gre@space@skip@interwordspacetext\relax%
-      \fi %
+      \fi%
     \fi %
   \else %
     \gre@skip@minTextDistance=0pt\relax%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -921,7 +921,7 @@
   % first we check the text width
   % we have to account for the spacing around the text as well as the text itself
   % first we account for the spacing which is needed after the previous syllable text (by using the minTextDistance left over from the previous syllablefinalskip calculation)
-  \gre@debugmsg{barspacing}{text width: \the\wd\gre@box@syllabletext}
+  \gre@debugmsg{barspacing}{text width: \the\wd\gre@box@syllabletext}%
   \gre@debugmsg{barspacing}{previous syllable skip after text: \the\gre@skip@minTextDistance}%
   \gre@skip@text@requirement = \glueexpr\wd\gre@box@syllabletext + \gre@skip@minTextDistance\relax%
   %now we need to account for the spacing which goes after this syllable (if there is text to this syllable)

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1028,11 +1028,11 @@
       \ifdim-\gre@dimen@text@shift > \dimexpr(\gre@skip@text@allocation/2-\gre@skip@text@requirement/2)\relax%
         % it is, so push both bar and text right to prevent a collision
         \gre@debugmsg{barspacing}{text collision detected}%
-        \gre@dimen@bar@shift = \dimexpr(-\gre@dimen@text@shift+\gre@skip@text@allocation/2-\gre@skip@text@requirement/2)\relax %
-        \gre@dimen@text@shift = \dimexpr(\gre@skip@text@allocation/2-\gre@skip@text@requirement/2)\relax %
+        \gre@dimen@bar@shift = \dimexpr(-\gre@dimen@text@shift-(\gre@skip@text@allocation/2-\gre@skip@text@requirement/2))\relax %
+        \gre@dimen@text@shift = \dimexpr(-\gre@skip@text@allocation/2+\gre@skip@text@requirement/2)\relax %
         % is the bar too far to the right?
         % \gre@dimen@temp@one is excess shift
-        \gre@dimen@temp@one = \dimexpr\gre@dimen@bar@shift - \gre@skip@bar@allocation/2 + \gre@skip@bar@requirement/2\relax%
+        \gre@dimen@temp@one = \dimexpr\gre@dimen@bar@shift - (\gre@skip@bar@allocation/2 - \gre@skip@bar@requirement/2)\relax%
         \ifdim\gre@dimen@temp@one>0pt\relax %
           \gre@debugmsg{barspacing}{bar collision detected}%
           % it is, so allocate more space to prevent the collision
@@ -1042,12 +1042,12 @@
           \advance\gre@dimen@text@shift by -0.5\gre@dimen@temp@one\relax%
         \fi %
       \fi%
-    \else\ifdim\gre@dimen@begindifference < -\gre@dimen@temp@three\relax%
+    \else\ifdim-\gre@dimen@begindifference > \gre@dimen@temp@three\relax%
       %the two elements are too far apart and the text is to the left of the bar
       \gre@debugmsg{barspacing}{shifts for text to left of bar}%
       % first we shift text to the right so that it has the correct offset
       \gre@dimen@bar@shift = 0pt\relax %
-      \gre@dimen@text@shift = \dimexpr(-\gre@dimen@begindifference - \gre@dimen@temp@three)\relax %
+      \gre@dimen@text@shift = \dimexpr((-\gre@dimen@begindifference) - \gre@dimen@temp@three)\relax %
       % is the text too far to the right?
       \ifdim\gre@dimen@text@shift > \dimexpr(\gre@skip@text@allocation/2-\gre@skip@text@requirement/2)\relax %
         \gre@debugmsg{barspacing}{text collision detected}%
@@ -1056,7 +1056,7 @@
         \gre@dimen@text@shift = \dimexpr(\gre@skip@text@allocation/2-\gre@skip@text@requirement/2)\relax %
         % is the bar too far to the left?
         % gre@dimen@temp@one is the excess of bar@shift:
-        \gre@dimen@temp@one=\dimexpr(-\gre@skip@bar@allocation/2+\gre@skip@bar@requirement/2-\gre@dimen@bar@shift)\relax %
+        \gre@dimen@temp@one=\dimexpr(-\gre@dimen@bar@shift -(\gre@skip@bar@allocation/2-\gre@skip@bar@requirement/2))\relax %
         \ifdim\gre@dimen@temp@one>0pt\relax %
           \gre@debugmsg{barspacing}{bar collision detected}%
           % it is, so allocate more space to prevent the collision
@@ -1073,6 +1073,8 @@
       \gre@dimen@bar@shift = 0pt\relax%
     \fi\fi%
   \fi%
+  \gre@debugmsg{barspacing}{text shift: \the\gre@dimen@text@shift}%
+  \gre@debugmsg{barspacing}{bar shift: \the\gre@dimen@bar@shift}%
   %at this point we're going to correct the values of enddifference and begindifference so that they are right for calculations which reference them in the next syllable
   \gre@debugmsg{barspacing}{bar width: \the\wd\gre@box@syllablenotes}%
   \gre@debugmsg{barspacing}{text width: \the\wd\gre@box@syllabletext}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1023,13 +1023,13 @@
       \gre@debugmsg{barspacing}{shifts for text right of bar}%
       % first we shift text to the left so that it has the correct offset
       \gre@dimen@bar@shift = 0pt\relax%
-      \gre@dimen@text@shift = \dimexpr(-\gre@dimen@begindifference + \gre@dimen@temp@two)\relax%
+      \gre@dimen@text@shift = \dimexpr(0pt - (\gre@dimen@begindifference - \gre@dimen@temp@two))\relax%
       % is the text too far to the left?
       \ifdim-\gre@dimen@text@shift > \dimexpr(\gre@skip@text@allocation/2-\gre@skip@text@requirement/2)\relax%
         % it is, so push both bar and text right to prevent a collision
         \gre@debugmsg{barspacing}{text collision detected}%
         \gre@dimen@bar@shift = \dimexpr(-\gre@dimen@text@shift-(\gre@skip@text@allocation/2-\gre@skip@text@requirement/2))\relax %
-        \gre@dimen@text@shift = \dimexpr(-\gre@skip@text@allocation/2+\gre@skip@text@requirement/2)\relax %
+        \gre@dimen@text@shift = \dimexpr(0pt - (\gre@skip@text@allocation/2 - \gre@skip@text@requirement/2))\relax %
         % is the bar too far to the right?
         % \gre@dimen@temp@one is excess shift
         \gre@dimen@temp@one = \dimexpr\gre@dimen@bar@shift - (\gre@skip@bar@allocation/2 - \gre@skip@bar@requirement/2)\relax%
@@ -1080,11 +1080,11 @@
   \gre@debugmsg{barspacing}{text width: \the\wd\gre@box@syllabletext}%
   \gre@debugmsg{barspacing}{Correcting begindifference}%
   %same as before but now we need to account for the widths of the elements and the shifts
-  \gre@dimen@begindifference = \dimexpr(-\wd\gre@box@syllablenotes/2% go left the middle of the bar syllable (width is always positive so lead with plus to go left)
+  \gre@dimen@begindifference = \dimexpr(\wd\gre@box@syllablenotes/2% go right to the middle of the bar syllable (width is always positive so lead with plus to go right)
     -\gre@dimen@bar@shift% go from actual middle of bar to nominal middle of bar (bar@shift represents going the other way, so lead with minus)
     +\gre@dimen@begindifference% go from nominal middle of bar line to nominal middle of text (this is what begindifference currently holds, so lead with positive)
     +\gre@dimen@text@shift% go from nominal middle of text to actual middle of text (text@shift represents this move, so lead with positive)
-    -\wd\gre@box@syllabletext/2)\relax% go left from middle to begining of text (width is always positive, so lead with negative to go left
+    -\wd\gre@box@syllabletext/2)\relax% go left from middle to beginning of text (width is always positive, so lead with negative to go left
   \gre@debugmsg{barspacing}{begindifference: \the\gre@dimen@begindifference}%
   \gre@debugmsg{barspacing}{Correcting enddifference}%
   \gre@dimen@enddifference = \dimexpr-\wd\gre@box@syllabletext% go from end of text to beginning of text (width is always positive, so lead with negative to go left)

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1018,8 +1018,6 @@
     \gre@dimen@text@shift = 0pt\relax%
     \gre@dimen@bar@shift = 0pt\relax%
   \else%
-    \gre@debugmsg{barspacing}{left offset limit: \gre@dimen@temp@three}%
-    \gre@debugmsg{barspacing}{right offset limit: \gre@dimen@temp@two}%
     \ifdim\gre@dimen@begindifference > \gre@dimen@temp@two\relax%
       %the two elements are too far apart and the text is to the right of the bar
       \gre@debugmsg{barspacing}{shifts for text right of bar}%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -216,7 +216,12 @@
     \global\setbox\gre@box@temp@width=\hbox{\gre@fontchar@divisiofinalis}%
   \or %
     % case of no note
-    \global\setbox\gre@box@temp@width=\hbox{}%
+    \ifgre@newbarspacing%
+      \global\setbox\gre@box@temp@width=\hbox{}%
+    \else%
+      % under the old algorithm, syllables with no notes triggered a 0 in this function, so we duplicate the first case here
+      \global\setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPPunctum}%
+    \fi%
   \fi%
   \relax%
 }%
@@ -823,12 +828,16 @@
 
 \newif\ifgre@newbarspacing%
 \gre@newbarspacingfalse%
+% the new bar spacing algorithm treats no note syllables as BarSyllables, while the old algorithm treated them as regular syllables.  In order to allow for this variant, we define NoNoteSyllable which aliases to the appropriate function
+\let\GreNoNoteSyllable\GreSyllable%
 
 \def\gresetbarspacing#1{%
   \IfStrEq{#1}{new}%
-    {\gre@newbarspacingtrue}%
+    {\gre@newbarspacingtrue%
+    \let\GreNoNoteSyllable\GreBarSyllable}%
     {\IfStrEq{#1}{old}%
-      {\gre@newbarspacingfalse}%
+      {\gre@newbarspacingfalse%
+      \let\GreNoNoteSyllable\GreSyllable}%
       {\gre@error{Unrecognized option for \protect\gresetbarspacing}}%
     }%
 }%


### PR DESCRIPTION
These changes restore the behavior of the old bar spacing algorithm so that scores which use it are unchanged when upgrading to 4.1.

There are, however, some changes which I'm not sure we should keep because I think I'm overriding a bug fix to restore the old behavior. These are split out into a separate commit (57af33e) in order to make them easier to identify and revert.

Finally, there is one test gabc-output/edge-cases.gabc for which I cannot seem to get an old version to pass. I'd appreaciate it if someone would look that one over and see if they can identify the code changes which are causing it's failure.