### PR TITLE
implement greprintsigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
-
+### Added
+- It is now possible to turn off rythmic signs (separately or all together) with `\greprintsigns`, see GregorioRef for details (and [#936](https://github.com/gregorio-project/gregorio/issues/936) for request).
 
 ## [4.1.0-rc1] - 2016-02-18
 ### Fixed

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -936,6 +936,22 @@ Macro to activate the new bar spacing algorithm.  The new algorithm attempts to 
   & \texttt{old} & Activates the old behavior (Default)\\
 \end{argtable}
 
+\subsubsection{Sign printing}
+
+\macroname{\textbackslash greprintsigns}{\{\#1\}\{\#2\}}{gregoriotex-signs.tex}
+Macro to prevent rythmic signs from printing:
+
+\begin{argtable}
+  \#1 & \texttt{vepisemus} & sets the printing of vertical episema\\
+  & \texttt{hepisemus} & sets the printing of horizontal episema\\
+  & \texttt{mora} & sets the printing of punctum mora and auctum duplex\\
+  & \texttt{all} & set the printing of all of these\\
+  \#2 & \texttt{enable} & enable the printing\\
+  & \texttt{disable} & disable the priting\\
+\end{argtable}
+
+Note that punctum mora and auctum duplex have an influence on spacings, so removing them will have an impact on that matter.
+
 \subsubsection{Hyphenation}
 
 \macroname{\textbackslash gresethyphen}{\{\#1\}}{gregoriotex-main.tex}

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -35,6 +35,43 @@
 
 \gresetglyphstyle{default}%
 
+% Possibility to disable some signs:
+\newif\ifgre@disablevepisemus
+\gre@disablevepisemusfalse
+\newif\ifgre@disablehepisemus
+\gre@disablehepisemusfalse
+\newif\ifgre@disablemora
+\gre@disablemorafalse
+
+\def\greprintsigns#1#2{%
+  \IfStrEq{#2}{enable}%
+    {%
+      \IfStrEq{#1}{vepisemus}{\global\gre@disablevepisemusfalse}{%
+        \IfStrEq{#1}{hepisemus}{\global\gre@disablehepisemusfalse}{%
+          \IfStrEq{#1}{mora}{\global\gre@disablemorafalse}{%
+            \IfStrEq{#1}{all}{\global\gre@disablemorafalse\global\gre@disablevepisemusfalse\global\gre@disablehepisemusfalse}{%
+              {\gre@error{Unrecognized first argument for \protect\greprintsigns}}%
+            }%
+          }%
+        }%
+      }%
+    }%
+    {\IfStrEq{#2}{disable}%
+      {%
+        \IfStrEq{#1}{vepisemus}{\global\gre@disablevepisemustrue}{%
+          \IfStrEq{#1}{hepisemus}{\global\gre@disablehepisemustrue}{%
+            \IfStrEq{#1}{mora}{\global\gre@disablemoratrue}{%
+              \IfStrEq{#1}{all}{\global\gre@disablemoratrue\global\gre@disablevepisemustrue\global\gre@disablehepisemustrue}{%
+                {\gre@error{Unrecognized first argument for \protect\greprintsigns}}%
+              }%
+            }%
+          }%
+        }%
+      }%
+      {\gre@error{Unrecognized second argument for \protect\greprintsigns}}%
+    }%
+}%
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% macros for discretionaries
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -890,7 +927,7 @@
 %   - 3 same as 2 but with ambitus of one (g.f)
 % #3 is 1 in case of a punctommora in the note before the last note of a podatus, porrectus or torculus resupinus, 0 otherwise.
 % #4 is 1 if we are at a punctum inclinatum, 0 otherwise
-\def\GrePunctumMora#1#2#3#4{%
+\def\gre@punctum@mora#1#2#3#4{%
   \GreNoBreak %
   \ifcase#2\relax %
     \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
@@ -963,6 +1000,13 @@
   \GreNoBreak %
   \relax%
 }%
+
+\def\GrePunctumMora#1#2#3#4{%
+  \ifgre@disablemora\else %
+    \gre@punctum@mora{#1}{#2}{#3}{#4}%
+  \fi %
+  \relax %
+}
 
 % a function to typeset an augmentum duplex, easy enough to be understood...
 \def\GreAugmentumDuplex#1#2#3{%
@@ -1121,7 +1165,9 @@
 }%
 
 \def\GreVEpisema#1#2{%
-  \gre@vepisemaorrare{#1}{#2}{\GreCPVEpisema}{1}{}%
+  \ifgre@disablevepisemus\else %
+    \gre@vepisemaorrare{#1}{#2}{\GreCPVEpisema}{1}{}%
+  \fi %
   \relax %
 }%
 
@@ -1382,7 +1428,7 @@
 %%   4 : low in space below note
 %%   5 : high in space below note
 \def\GreHEpisema#1#2#3#4#5#6#7#8#9{%
-  \ifgre@boxing\else %
+  \ifgre@boxing\else\ifgre@disablehepisemus\else %
     \gre@prephepisemaledgerlineheuristics%
     #7%
     \ifgre@hepisemabridge%
@@ -1391,7 +1437,7 @@
       \gre@hepisorline{#1}{#2}{#3}{#4}{#5}{#8}{#9}%
     \fi %
     \gre@resetledgerlineheuristics%
-  \fi %
+  \fi\fi %
   \relax %
 }%
 


### PR DESCRIPTION
fixes #936. A problem remains if some rare cases where horizontal episema are printed but not vertical episema. It's ok for 4.1, as 90% of the use cases are to just remove all signs. We'll fix the bug in 5.0.