### PR TITLE
Fix #845

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ## [Unreleased][unreleased]
 ### Fixed
-- hyphens now cannot go right of the staff lines. A protrusion factor can now be applied for hyphens at end of lines (50% by default), it can be changed through `\gresethyphenprotrusion` (see GregorioRef and [#845](https://github.com/gregorio-project/gregorio/issues/845)).
+- hyphens now shouldn't go right of the staff lines (see [#845](https://github.com/gregorio-project/gregorio/issues/845)).
 - Offset limit calculations now function better in both directions for new bar spacing algorithm.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
-
+### Fixed
+- hyphens now cannot go right of the staff lines. A protrusion factor can now be applied for hyphens at end of lines (50% by default), it can be changed through `\gresethyphenprotrusion` (see GregorioRef and [#845](https://github.com/gregorio-project/gregorio/issues/845)).
 
 ## [4.1.0-rc1] - 2016-02-18
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -66,14 +66,9 @@ The following spaces have been added:
 
 By default, these are sized one half millimeter larger than their "non-text" counterparts.  This may cause minor spacing changes in your existing scores.  Adjust them as necessary to get the look you want.
 
-### Protrusion of hyphens at end of line
+### Hyphens going right of staff lines
 
-The default protrusion factor for hyphens at end of lines is 50, meaning that 50% of the hyphen is ignored by horizontal spacing algorithm at end of line. This should:
-
-- prevent hyphens from going too far right, especially no further than end of line
-- stretch some lines a little bit
-
-If you prefer the old behavior, `\gresethyphenprotrusion{100}` should restore it (or at least differences should be small). The value 100 may be suprising, but many hyphens were not taken into account at all at end of lines previously, while they are now, hence the value.
+Hyphens should now not go right of staff lines. If you prefer the old behavior, `\gresethyphenprotrusion{100}` should restore it.
 
 ### Oriscus orientation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -66,6 +66,15 @@ The following spaces have been added:
 
 By default, these are sized one half millimeter larger than their "non-text" counterparts.  This may cause minor spacing changes in your existing scores.  Adjust them as necessary to get the look you want.
 
+### Protrusion of hyphens at end of line
+
+The default protrusion factor for hyphens at end of lines is 50, meaning that 50% of the hyphen is ignored by horizontal spacing algorithm at end of line. This should:
+
+- prevent hyphens from going too far right, especially no further than end of line
+- stretch some lines a little bit
+
+If you prefer the old behavior, `\gresethyphenprotrusion{100}` should restore it (or at least differences should be small). The value 100 may be suprising, but many hyphens were not taken into account at all at end of lines previously, while they are now, hence the value.
+
 ### Oriscus orientation
 
 The oriscus orientation (whether it points up or down) is now dependent on the note the follows, even if the note is not directly connected to the oriscus (as it would be in a salicus or a pressus).  Appending a `1` to an unconnected oriscus in gabc will force the oriscus to point upwards and `0` will force the oriscus to point downwards.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -962,6 +962,14 @@ Marco to determine how much space the hyphen at the end of a line occupies for t
   & \texttt{zero} & The hyphen is considered to take up no space
 \end{argtable}
 
+\macroname{\textbackslash gresethyphenprotrusion}{\{\#1\}}{gregoriotex-spaces.tex}
+Sets the protrusion factor of hyphens at end of lines. The default value is 50, a good compromise in the tested scores.
+
+\begin{argtable}
+  \#1 & \texttt{number} & The protrusion factor, over 100
+\end{argtable}
+
+Note that a proper interface for setting protrusion factor of punctuation signs might appear in the next version, deprecating this one.
 
 \subsubsection{Clef Visibility}
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -982,7 +982,7 @@ Marco to determine how much space the hyphen at the end of a line occupies for t
 Sets the protrusion factor of hyphens at end of lines. The default value is 50, a good compromise in the tested scores.
 
 \begin{argtable}
-  \#1 & \texttt{number} & The protrusion factor, over 100
+  \#1 & \texttt{number} & The protrusion factor, percent
 \end{argtable}
 
 Note that a proper interface for setting protrusion factor of punctuation signs might appear in the next version, deprecating this one. Also, this protrusion factor does not apply to all hyphens (only those inserted by the Lua pass), so use it with caution.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -985,7 +985,7 @@ Sets the protrusion factor of hyphens at end of lines. The default value is 50, 
   \#1 & \texttt{number} & The protrusion factor, over 100
 \end{argtable}
 
-Note that a proper interface for setting protrusion factor of punctuation signs might appear in the next version, deprecating this one.
+Note that a proper interface for setting protrusion factor of punctuation signs might appear in the next version, deprecating this one. Also, this protrusion factor does not apply to all hyphens (only those inserted by the Lua pass), so use it with caution.
 
 \subsubsection{Clef Visibility}
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1513,7 +1513,7 @@ Boolean which indicates that the clef should be visible.
 Boolean which indicates that a hyphen after an empty first syllable should be forced.
 
 \macroname{\textbackslash ifgre@showhyphenafterthissyllable}{}{gregoriotex-syllable.tex}
-Boolean set and used by \verb=\GreSyllable= to decide if a hyphen should be shown after the syllable, and used by \verb=\gre@calculate@eolshift= for protrusion calculation.
+Boolean set and used by \verb=\GreSyllable= to decide if a hyphen should be shown after the syllable.
 
 \macroname{\textbackslash ifgre@possibleluahyphenafterthissyllable}{}{gregoriotex-syllable.tex}
 Boolean set by \verb=\GreSyllable= indicating if the lua pass may add an hyphen after the syllable, used by \verb=\gre@calculate@eolshift= for protrusion calculation.

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1513,7 +1513,10 @@ Boolean which indicates that the clef should be visible.
 Boolean which indicates that a hyphen after an empty first syllable should be forced.
 
 \macroname{\textbackslash ifgre@showhyphenafterthissyllable}{}{gregoriotex-syllable.tex}
-Boolean used by \verb=\GreSyllable= to decide if a hyphen should be shown after the syllable.
+Boolean set and used by \verb=\GreSyllable= to decide if a hyphen should be shown after the syllable, and used by \verb=\gre@calculate@eolshift= for protrusion calculation.
+
+\macroname{\textbackslash ifgre@possibleluahyphenafterthissyllable}{}{gregoriotex-syllable.tex}
+Boolean set by \verb=\GreSyllable= indicating if the lua pass may add an hyphen after the syllable, used by \verb=\gre@calculate@eolshift= for protrusion calculation.
 
 \macroname{\textbackslash ifgre@thirdlineadjustmentnecessary}{}{gregoriotex-syllable.tex}
 Boolean which indicates that a third-line adjustment to staff line width is necessary.
@@ -1594,6 +1597,12 @@ Box holding the text associated with a syllable.
 \macroname{\textbackslash gre@box@hep}{}{gregoriotex-chars.tex}
 Box holding the horizontal episema.
 
+
+\subsection{Protrusion factors}
+Protrusion factors are counts representing a protrusion factor over 100.
+
+\macroname{\textbackslash gre@count@protrusion@hyphen@eol}{}{gregoriotex-spaces.tex}
+Protrusion factor applied to hyphens at end of lines.
 
 
 \subsection{Distances}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1518,7 +1518,7 @@ Boolean which indicates that a hyphen after an empty first syllable should be fo
 Boolean set and used by \verb=\GreSyllable= to decide if a hyphen should be shown after the syllable.
 
 \macroname{\textbackslash ifgre@possibleluahyphenafterthissyllable}{}{gregoriotex-syllable.tex}
-Boolean set by \verb=\GreSyllable= indicating if the lua pass may add an hyphen after the syllable, used by \verb=\gre@calculate@eolshift= for protrusion calculation.
+Boolean set by \verb=\GreSyllable= indicating if the Lua pass may add an hyphen after the syllable, used by \verb=\gre@calculate@eolshift= for protrusion calculation.
 
 \macroname{\textbackslash ifgre@thirdlineadjustmentnecessary}{}{gregoriotex-syllable.tex}
 Boolean which indicates that a third-line adjustment to staff line width is necessary.

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -387,7 +387,7 @@
 \newcount\gre@count@protrusion@hyphen@eol %
 
 % protrusion for hyphens inerted by Lua
-\gre@count@protrusion@hyphen@eol = 50
+\gre@count@protrusion@hyphen@eol = 50\relax
 
 \def\gresethyphenprotrusion#1{%
   \gre@count@protrusion@hyphen@eol = #1\relax %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -385,8 +385,10 @@
 % dimen keeping the shift computed with next function
 \newdimen\gre@dimen@eolshift
 \newcount\gre@count@protrusion@hyphen@eol %
+
+% protrusion for hyphens inerted by Lua
 \gre@count@protrusion@hyphen@eol = 50
-%
+
 \def\gresethyphenprotrusion#1{%
   \gre@count@protrusion@hyphen@eol = #1\relax %
   \relax %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -398,32 +398,25 @@
 %%
 %% @arg#1 The \gre@dimen@enddifference of the corresponding syllable
 \def\gre@calculate@eolshift#1{%
-  \global\gre@skip@temp@three=0pt\relax%
-  \global\gre@skip@temp@two=0pt\relax%
+  \gre@skip@temp@two=0pt\relax%
   % we only need a shift if the lyrics are longer than the notes
   \ifdim#1 <0pt\relax%
     % we only need to shift if there is a custos being printed
     \ifgre@blockeolcustos%
-      \global\gre@dimen@eolshift=0pt\relax%
+      \gre@dimen@eolshift=0pt\relax%
     \else%
       % The basic value for the eol shift is -enddifference
-      \global\gre@skip@temp@two=-#1\relax%
+      \gre@skip@temp@two=-#1\relax%
       % if there is a possible hyphen (added afterwards in lua), we keep some room for it
       \ifgre@possibleluahyphenafterthissyllable %
         \setbox\gre@box@temp@width=\hbox{\GreHyph}%
-        \global\advance\gre@skip@temp@two by -\dimexpr(\wd\gre@box@temp@width * ((100 - \gre@count@protrusion@hyphen@eol) / 100))\relax%
-      \fi %
-      % if there is an automatic hyphen, we apply the protrusion factor
-      \ifgre@showhyphenafterthissyllable %
-        \setbox\gre@box@temp@width=\hbox{\GreHyph}%
-        \global\advance\gre@skip@temp@two by \dimexpr(\wd\gre@box@temp@width * (\gre@count@protrusion@hyphen@eol / 100))\relax%
+        \advance\gre@skip@temp@two by -\dimexpr(\wd\gre@box@temp@width * ((100 - \gre@count@protrusion@hyphen@eol) / 100))\relax%
       \fi %
       % The maximum value is wd(custos) + spacebeforeeolcustos
       % Were the eolshift larger than this the lyrics would stick out
       % into the margin
       \setbox\gre@box@temp@width=\hbox{\gre@pickcustos{\gre@pitch@g}}%
-      \global\advance\gre@skip@temp@three by %
-        \glueexpr(\wd\gre@box@temp@width+\gre@space@skip@spacebeforeeolcustos)\relax%
+      \gre@skip@temp@three = \glueexpr(\wd\gre@box@temp@width+\gre@space@skip@spacebeforeeolcustos)\relax%
       % pick the smaller of the two values calculated above
       \ifdim\gre@skip@temp@two>\gre@skip@temp@three%
         \gre@debugmsg{eolshift}{imposing limit}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -384,6 +384,13 @@
 
 % dimen keeping the shift computed with next function
 \newdimen\gre@dimen@eolshift
+\newcount\gre@count@protrusion@hyphen@eol %
+\gre@count@protrusion@hyphen@eol = 50
+%
+\def\gresethyphenprotrusion#1{%
+  \gre@count@protrusion@hyphen@eol = #1\relax %
+  \relax %
+}
 
 %% @desc Macro used in \GreSyllable. Sets \gre@dimen@eolshift to the right kern
 %%       that should appear before an end of line.  When active this prevents
@@ -401,6 +408,16 @@
     \else%
       % The basic value for the eol shift is -enddifference
       \global\gre@skip@temp@two=-#1\relax%
+      % if there is a possible hyphen (added afterwards in lua), we keep some room for it
+      \ifgre@possibleluahyphenafterthissyllable %
+        \setbox\gre@box@temp@width=\hbox{\GreHyph}%
+        \global\advance\gre@skip@temp@two by -\dimexpr(\wd\gre@box@temp@width * ((100 - \gre@count@protrusion@hyphen@eol) / 100))\relax%
+      \fi %
+      % if there is an automatic hyphen, we apply the protrusion factor
+      \ifgre@showhyphenafterthissyllable %
+        \setbox\gre@box@temp@width=\hbox{\GreHyph}%
+        \global\advance\gre@skip@temp@two by \dimexpr(\wd\gre@box@temp@width * (\gre@count@protrusion@hyphen@eol / 100))\relax%
+      \fi %
       % The maximum value is wd(custos) + spacebeforeeolcustos
       % Were the eolshift larger than this the lyrics would stick out
       % into the margin

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -558,6 +558,11 @@
 \def\GreForceHyphen{\global\gre@showhyphenafterthissyllabletrue\gre@debugmsg{hyphen}{Forcing hyphen in gabc}}
 \def\GreEmptyFirstSyllableHyphen{\ifgre@forceemptyfirstsyllablehyphen\GreForceHyphen\fi}%
 
+% if an hyphen maybe be added by lua for this syllable. When syllable is not end of word and
+% no hyphen is added by TeX.
+\newif\ifgre@possibleluahyphenafterthissyllable
+\gre@possibleluahyphenafterthissyllablefalse
+
 %% general macro : it will typeset the syllable : arguments are :
 % #1 : macro setting the letters of this syllable
 % #2 : reserved (unused)
@@ -576,6 +581,7 @@
   \gre@debugmsg{general}{}%
   \gre@debugmsg{general}{New syllable: \expandafter\unexpanded{#1}}%
   \gre@debugmsg{general}{}%
+  \global\gre@possibleluahyphenafterthissyllablefalse %
   \gre@showhyphenafterthissyllablefalse%
   \ifcase#4\ifgre@forcehyphen%
     \gre@debugmsg{hyphen}{Forcing hyphen}%
@@ -684,6 +690,7 @@
       \gre@attr@dash=1\relax % in this particular case where it is not the end of a word and we haven't put a dash, we set potentital dash to 1
       % we rebuild this box, in order it to have the attribute
       \setbox\gre@box@syllabletext=\hbox{\gre@fixedtextformat{\gre@pointandclick{\gre@firstsyllablepart\gre@middlesyllablepart\gre@endsyllablepart}{#6}}}%
+      \global\gre@possibleluahyphenafterthissyllabletrue %
     \fi %
   \fi%
   % then we reuse temp, we assign to it the \gre@dimen@begindifference, but only if it is positive, else it is 0
@@ -836,6 +843,8 @@
 %a macro to typeset a syllable with only a bar inside
 \def\GreBarSyllable#1#2#3#4#5#6#7#8#9{%
   \gre@debugmsg{general}{New bar syllable}%
+  \gre@possibleluahyphenafterthissyllablefalse %
+  \gre@showhyphenafterthissyllablefalse %
   % the algorithm of this function is *extremely* complex, and has been much painful to write... good luck to understand.
   % the main goal is, when there is no text under the bar, to put the bar in the middle of the space between the last note of the previous syllable and the first note of the next syllable. But there are limits : a bar can't go very far above text. For example if there is "nuncncncncn" with a punctum on the u, the bar can't go above the fourth n, the most far position is the position where the end of the bar is above the end of the word. The same limitation applies for the syllable after the bar.
   % there are two different cases that have almost nothing in common : the case where there is something written under the bar, and the case where there is nothing.
@@ -873,7 +882,7 @@
     \GreNoBreak %
     % all that extra stuff (translations and the like)
     #8%
-    \GreNoBreak % 
+    \GreNoBreak %
     %print the text, the raise is in case of a translation
     \raise\gre@dimen@textlower \copy\gre@box@syllabletext%
     %and the code which handles translation centering


### PR DESCRIPTION
Introduce a protrusion factor for hyphens automatically inserted by Lua (so it's a small first step towards #931). The value of 50 should prevent the hyphens from going too far on the right, and shouldn't change the output too much. I'm not entirely sure there's a completely logical explanation to this value, that's just what I found after some experiments. I tried to apply the same protrusion factor to hyphens automatically inserted by TeX, but it changed the tests a lot, in a very surprising way, so it seems unsafe to do it at this stage of the release cycle.