### PR TITLE
Used "GreDivisio..." rather than "GreInDivisio..." when end-of-line follows a bar.

### DIFF
--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3105,7 +3105,7 @@ static void gregoriotex_print_change_line_clef(FILE *f,
     }
 }
 
-static __inline bool is_manual_custos(const gregorio_element *element)
+static __inline bool is_manual_custos(const gregorio_element *const element)
 {
     return element->type == GRE_CUSTOS && element->u.misc.pitched.force_pitch;
 }
@@ -3607,7 +3607,8 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
             case GRE_BAR:
                 write_bar(f, element->u.misc.unpitched.info.bar,
                         element->u.misc.unpitched.special_sign,
-                        element->next && !is_manual_custos(element->next),
+                        element->next && !is_manual_custos(element->next)
+                        && element->next->type != GRE_END_OF_LINE,
                         !element->previous && syllable->text);
                 break;
 


### PR DESCRIPTION
Fixes #935 as part of #944.

This certainly breaks tests, but hopefully in a good way.  I haven't accepted any updated expectations.  I leave it to @eroux to confirm the fix.