### PR TITLE
Get new bar spacing algorithm to respect `\gresetlastline` setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
-
+### Fixed
+- New bar spacing algorithm will now respect `\gresetlastline`.
 
 ## [4.1.0-rc2] - 2016-02-25
 ### Fixed

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1991,7 +1991,7 @@
     \GreDivisioFinalis{0}{}%
     #1%
     \ifgre@justifylastline%
-      \GreNewLine%
+      \def\gre@newlinearg{0}%
     \fi%
   }%
   \relax%
@@ -2004,7 +2004,7 @@
     \GreDivisioMaior{0}{}%
     #1%
     \ifgre@justifylastline%
-      \GreNewLine%
+      \def\gre@newlinearg{0}%
     \fi%
   }%
   \relax%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1990,6 +1990,9 @@
     \GreLastOfScore %
     \GreDivisioFinalis{0}{}%
     #1%
+    \ifgre@justifylastline%
+      \GreNewLine%
+    \fi%
   }%
   \relax%
 }%
@@ -2000,6 +2003,9 @@
     \GreLastOfScore %
     \GreDivisioMaior{0}{}%
     #1%
+    \ifgre@justifylastline%
+      \GreNewLine%
+    \fi%
   }%
   \relax%
 }%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1990,9 +1990,6 @@
     \GreLastOfScore %
     \GreDivisioFinalis{0}{}%
     #1%
-    \ifgre@justifylastline%
-      \def\gre@newlinearg{0}%
-    \fi%
   }%
   \relax%
 }%
@@ -2003,9 +2000,6 @@
     \GreLastOfScore %
     \GreDivisioMaior{0}{}%
     #1%
-    \ifgre@justifylastline%
-      \def\gre@newlinearg{0}%
-    \fi%
   }%
   \relax%
 }%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -946,9 +946,16 @@
       \fi %
       \kern\glueexpr(-\gre@dimen@eolshift)\relax%
     \fi%
-    % if no end of line:
-    \gre@debugmsg{barspacing}{newlinearg: \gre@newlinearg}%
-    \ifnum\gre@newlinearg=-1\relax %
+    % gre@count@temp@one is "forced end of line or last of score"
+    \gre@count@temp@one=0\relax %
+    \ifnum\gre@newlinearg=-1\else %
+      \gre@count@temp@one=1\relax %
+    \fi %
+    \ifgre@endofscore %
+      \gre@count@temp@one=1\relax %
+     \fi %
+    % if no end of line or end of score
+    \ifnum\gre@count@temp@one=0\relax %
       % add the penalty
       \gre@debugmsg{barspacing}{after bar penalty: \greendafterbarpenalty}%
       \gre@penalty{\greendafterbarpenalty}%
@@ -972,10 +979,10 @@
         \GreNoBreak %
         \kern\gre@skip@nextbegindifference\relax%
       \fi%
-    \else %
+    \else\ifgre@endofscore\else %
       \gre@debugmsg{barspacing}{calling new line with argument: \gre@newlinearg}%
       \gre@newlinecommon{\gre@newlinearg}%
-    \fi %
+    \fi\fi%
   \else%
     %
     % Old spacing algorithm

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -947,6 +947,7 @@
       \kern\glueexpr(-\gre@dimen@eolshift)\relax%
     \fi%
     % if no end of line:
+    \gre@debugmsg{barspacing}{newlinearg: \gre@newlinearg}%
     \ifnum\gre@newlinearg=-1\relax %
       % add the penalty
       \gre@debugmsg{barspacing}{after bar penalty: \greendafterbarpenalty}%


### PR DESCRIPTION
This solution is a bit of a hack as I simply insert a call to `\GreNewLine` into the code for a final finalis (or maior).  It works and doesn't modify too much code, but if someone has a better idea as to how to fix it, I'm all ears.

I don't have time to check the tests at the moment (and incorporate a new one), but I wanted to get this out for comment sooner rather than later.  I'll take care of the tests later tonight.