### PR TITLE
Short-term fix for non-ragged breaks before euouae.

### DIFF
--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1640,14 +1640,14 @@
 \gre@in@euouaefalse
 
 \def\GreBeginEUOUAE#1{%
+  \ifgre@euouae@implies@nlba %
+    \GreBeginNLBArea{0}{0}%
+  \fi %
   \ifgre@raggedbreakbeforeeuouae %
     \directlua{gregoriotex.save_pos(#1,2)}%
     \ifcase\directlua{gregoriotex.is_ypos_different(#1)}\relax%
       \gre@newlinecommon{1}%
     \fi %
-  \fi %
-  \ifgre@euouae@implies@nlba %
-    \GreBeginNLBArea{0}{0}%
   \fi %
   \gre@in@euouaetrue %
   % as soon as the EUOUAE starts, we stop blocking the EOL custos that might

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -915,7 +915,7 @@ local function is_ypos_different(index)
       tex.sprint([[\number0\relax ]])
     end
   else
-    tex.sprint([[\number0\relax ]])
+    tex.sprint([[\number1\relax ]])
   end
 end
 


### PR DESCRIPTION
Fixes #984.

This is @eroux's fix, but please review it to make sure I applied it correctly before merging.  I ran all the tests, and the only one that breaks is the test from #982.