### PR TITLE
Fixes #1019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - High notes are now taken into account for vertical placement of above lines test (see [#960](https://github.com/gregorio-project/gregorio/issues/960)).
 - Forced syllable centers can be used in to override alignment issues when lyric centering is set to `syllable` or `firstletter`.  This is a restoration of old behavior (pre-4.0), but can be turned off with `\gresetgabcforcecenters{prohibit}`.  See [968](https://github.com/gregorio-project/gregorio/issues/968).
 - Deminutus figures in nabc work again (see [#1015](https://github.com/gregorio-project/gregorio/issues/1015)).
+- Orphaned syllables should appear less frequently at end of score (see [1019](https://github.com/gregorio-project/gregorio/issues/1019)).
 
 ### Added
 - The macro `\grechangecount` now allows to change some numeric values of the configuration. This version introduces two of them: `additionaltopspacethreshold` and `additionaltopspacealtthreshold`, see GregorioRef for details.
+- The penalty `grefinalpenalty` (0 by default) is added at the end of the score. Be sure you know what you're doing before modifying it.
 
 ## [4.1.0] - 2016-03-01
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,7 @@ High notes are now taken into account in vertical spacings. If you would like to
 
 ### Last line of score behavior
 
-`\grelooseness` is now `-1` by default. This should prevent orphaned syllable at end of score. If you prefer the old behavior, use `\def\grelooseness{-1}` befor including your scores.
+`\grelooseness` is now `-1` by default. This should prevent orphaned syllable at end of score. If you prefer the old behavior, use `\def\grelooseness{\looseness}` befor including your scores.
 
 ## 4.1
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ This file contains instructions to upgrade to a new release of Gregorio.
 
 High notes are now taken into account in vertical spacings. If you would like to come back to the old way, use `\grechangecount{additionaltopspacethreshold}{6}`. High notes also influence vertical placement of alt text. If you would like to come back to the old way, give a high value to `\grechangecount{additionaltopspacealtthreshold}{6}`.
 
+### Last line of score behavior
+
+`\grelooseness` is now `-1` by default. This should prevent orphaned syllable at end of score. If you prefer the old behavior, use `\def\grelooseness{-1}` befor including your scores.
+
 ## 4.1
 
 ### Initial handling

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1145,7 +1145,7 @@ Macro to set the font to be used for the ancient notation.
 
 \subsection{Counts}\label{counts}
 
-Each of the following counts controls some aspect of the configuration of the Gregorio\TeX\ score.  They are changed using \verb=\grechangecount=, documented above.  
+Each of the following counts controls some aspect of the configuration of the Gregorio\TeX\ score.  They are changed using \verb=\grechangecount=, documented above.
 
 \macroname{additionaltopspacethreshold}{}{gsp-default.tex}
 
@@ -1743,6 +1743,11 @@ Default: 10001
 Penalty to force a line break.
 
 Default: $-10001$
+
+\macroname{\textbackslash grefinalpenalty}{}{gsp-default.tex}
+The penalty applied after the final element of a score.
+
+Default: $0$
 
 \macroname{\textbackslash grelooseness}{}{gsp-default.tex}
 The \TeX\ looseness within a score.

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -364,6 +364,7 @@
   \kern\gre@dimen@temp@four %
   \GreNoBreak%
   \GreCustos{#1}%
+  \gre@endofglyphcommon %
 }
 
 % the argument is the height
@@ -2023,7 +2024,6 @@
     \fi %
     \GreLastOfScore %
     \GreDivisioFinalis{0}{}%
-    \setbox\gre@box@temp@width=\hbox{#1}%
     #1%
   }%
   \relax%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -110,6 +110,14 @@
   \relax %
 }%
 
+\def\gre@endofglyphcommon{%
+  \ifgre@endofscore %
+    \gre@penalty{\grefinalpenalty}%
+    \gre@localleftbox{}%
+    \gre@localrightbox{}%
+  \fi %
+}
+
 % passes the glyph height limits:
 % #1: the high height
 % #2: the low height
@@ -160,6 +168,7 @@
   \fi%
   #6\relax %
   \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
+  \gre@endofglyphcommon %
   \relax%
 }%
 
@@ -525,7 +534,7 @@
     \gdef\gre@firstsyllablepart{#1}%
     \gdef\gre@middlesyllablepart{#2}%
     \gdef\gre@endsyllablepart{#3}%
-  \else%	
+  \else%
     \ifcase\gre@lyriccentering% 0 - syllable centering
       \gdef\gre@firstsyllablepart{}%
       \gdef\gre@middlesyllablepart{#1#2#3}%
@@ -1071,10 +1080,16 @@
         \GreNoBreak %
         \kern\gre@skip@nextbegindifference\relax%
       \fi%
-    \else\ifgre@endofscore\else %
-      \gre@debugmsg{barspacing}{calling new line with argument: \gre@newlinearg}%
-      \gre@newlinecommon{\gre@newlinearg}{1}%
-    \fi\fi%
+    \else %
+      \ifgre@endofscore %
+        \luatexlocalleftbox{}%
+        \gre@debugmsg{barspacing}{after bar penalty: \greendafterbarpenalty}%
+        \gre@penalty{\grefinalpenalty}%
+      \else %
+        \gre@debugmsg{barspacing}{calling new line with argument: \gre@newlinearg}%
+        \gre@newlinecommon{\gre@newlinearg}{1}%
+      \fi %
+    \fi%
   \else%
     %
     % Old spacing algorithm

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -1082,7 +1082,7 @@
       \fi%
     \else %
       \ifgre@endofscore %
-        \luatexlocalleftbox{}%
+        \gre@localleftbox{}%
         \gre@debugmsg{barspacing}{after bar penalty: \greendafterbarpenalty}%
         \gre@penalty{\grefinalpenalty}%
       \else %

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -34,6 +34,8 @@
 \xdef\greendafterbarpenalty{-200}%
 % penalty right after a bar with nothing printed
 \xdef\greendafterbaraltpenalty{-200}%
+% penalty at the end of the score
+\xdef\grefinalpenalty{0}%
 % penalty at the end of a breakable neumatic element (typically at a space
 % between elements)
 \xdef\greendofelementpenalty{-50}%
@@ -47,7 +49,7 @@
 
 %% These macro enable the tuning of linepenalty, tolerance, pretolerance
 %% and emergencystretch
-\def\grelooseness{\looseness}%
+\def\grelooseness{-1}%
 \def\gretolerance{9000}%
 % Workaround for bug 842 (http://tracker.luatex.org/view.php?id=842)
 % see http://tug.org/pipermail/luatex/2013-July/004516.html


### PR DESCRIPTION
- set grelooseness to -1 by default
- add grefinalpenalty (0 by default)
- reset localleftbox and localrightbox earlier (should prevent orphaned lines
  which were removed by gregoriotex.lua, but influenced the end of paragraph
  algorithm)