### PR TITLE
Corrected comment coloring in the header section.

### DIFF
--- a/contrib/gabc.vim
+++ b/contrib/gabc.vim
@@ -37,7 +37,7 @@ syn match gabcSpace "Z[-+]\?" contained
 syn match gabcSpace "/\[[^\]]*\]" contained extend
 syn match gabcCommand "@\@<!\[[^\]]*\]" contained extend
 
-syn region gabcComment start="%" end="$" contained keepend extend
+syn region gabcComment start="%" end="$" keepend extend
 syn region gabcAlt matchgroup=gabcTextMarkup start="<alt>" end="</alt>"
             \ contained
 syn region gabcSpecial matchgroup=gabcTextMarkup start="<sp>" end="</sp>"
@@ -45,13 +45,13 @@ syn region gabcSpecial matchgroup=gabcTextMarkup start="<sp>" end="</sp>"
 syn region gabcVerbatim matchgroup=gabcTextMarkup start="<v>" end="</v>"
             \ contained
 syn region gabcNabc matchgroup=gabcNabcCut start="|" end="[|)]" keepend
-syn cluster gabcFusable contains=gabcBasicNote,gabcAlteration,gabcBar,gabcSpace,
+syn cluster gabcFusible contains=gabcBasicNote,gabcAlteration,gabcBar,gabcSpace,
             \gabcComment,gabcCommand,gabcNoteError,gabcFuse,
             \gabcTextOrNoteMarkup,gabcClef,gabcNabc
 syn region gabcFuseGroup matchGroup=gabcFuseGroup start="@\[" end="\]"
-            \ contains=@gabcFusable,gabcFuseEnd contained keepend
+            \ contains=@gabcFusible,gabcFuseEnd contained keepend
 syn region gabcNotes matchgroup=gabcNote start="(" end=")"
-            \ contains=@gabcFusable,gabcFuseGroup contained keepend
+            \ contains=@gabcFusible,gabcFuseGroup contained keepend
 syn region gabcTranslation matchgroup=gabcTextMarkup start="\[" end="\]"
             \ contained extend
 syn region gabcText start="^\(%%\)\@=" end="\%$"


### PR DESCRIPTION
This is a small change to allow the comment coloring to work in the header section.  I also corrected the spelling of `fusible`.

Please review and merge if satisfactory.