### PR TITLE
Set glyph id and heights for custos glyphs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 [Unreleased][unreleased]
+### Fixed
+- Custos glyphs heights are now counted when adjusting line heights (see [#961](https://github.com/gregorio-project/gregorio/issues/961)).
+
+
 ### Added
 - It is now possible to invert the oriscus orientation on pes quassus and oriscus flexus shapes.  Use `o0` or `o1` to force the oriscus into the orientation you desire.  It is also possible to fuse the oriscus from either direction in either orientation.  See [#898](https://github.com/gregorio-project/gregorio/issues/898) and [#972](https://github.com/gregorio-project/gregorio/issues/972).
 - Formerly missing torculus figures starting with an oriscus are now rendered using neume fusion (see [#1013](https://github.com/gregorio-project/gregorio/issues/1013)).

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1055,6 +1055,9 @@ The pitch of a rare sign (semicirculus, \etc).
 \macroname{\textbackslash gre@pitch@dummy}{}{gregoriotex-main.tex}
 A meaningless (don't-care) pitch.
 
+\macroname{\textbackslash gre@pitch@nominal}{}{gregoriotex-main.tex}
+A pitch guaranteed to be in the staff.
+
 \macroname{\textbackslash gre@pointandclick}{\#1\#2}{gregoriotex-main.tex}
 Macro to generate the point-and-click links.
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -197,6 +197,7 @@
 \let\gre@pitch@overbraceglyph\gre@pitch@g %
 \let\gre@pitch@bar\gre@pitch@g %
 \let\gre@pitch@dummy\gre@pitch@g %
+\let\gre@pitch@nominal\gre@pitch@e %
 
 % factor is the factor with which you open you font (the number after the at). It will decide almost everything (spaces, etc.), so it is particularly important.
 % it is set to the default value : 17 (the value that makes it look like a standard graduale)

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -314,7 +314,6 @@
 
 % custos just typesets a custos, useful for before the key changes for example
 % #1 is the height
-% #2 is indicating if the custo ends the line
 \def\GreCustos#1{%
   \ifdim\gre@skip@bar@lastskip=0pt\else % we're after a bar:
     \kern-\gre@skip@bar@lastskip %
@@ -323,7 +322,7 @@
   \kern\gre@skip@temp@four%
   \gre@calculate@glyphraisevalue{#1}{0}{}%
   %here we need some tricks to draw the line before the custos (for the color)
-  \setbox\gre@box@temp@width=\hbox{\gre@pickcustos{#1}}%
+  \setbox\gre@box@temp@width=\hbox{\gre@pickcustos{#1}{1}}%
   \gre@dimen@temp@three=\wd\gre@box@temp@width %
   \ifgre@showlines %
     \ifnum#1<\gre@pitch@belowstaff\relax %
@@ -346,6 +345,7 @@
     \kern\gre@skip@bar@lastskip %
     \GreNoBreak %
   \fi %
+  \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \relax %
 }%
 
@@ -373,12 +373,12 @@
       \setbox\gre@box@temp@width=\hbox{%
         % we type a hskip and the we type the custos
         \gre@hskip\gre@space@skip@spacebeforeeolcustos\relax %
-        \gre@pickcustos{#1}\relax %
+        \gre@pickcustos{#1}{2}\relax %
       }%
       \gre@dimen@temp@three=\wd\gre@box@temp@width %
       % we make \wd\gre@box@temp@sign contain the width of a custos
       \setbox\gre@box@temp@sign=\hbox{%
-        \gre@pickcustos{#1}\relax %
+        \gre@pickcustos{#1}{0}\relax %
       }%
       \gre@localrightbox{%
         \ifgre@showlines %
@@ -480,7 +480,18 @@
   \relax %
 }%
 
-\def\gre@pickcustos#1{%
+% #2 is 0 for measurement only, 1 in the normal case, 2 for the right box
+\def\gre@pickcustos#1#2{%
+  % set attributes to adjust the line height for the pitch of the custos
+  \ifcase#2% 0
+  \or % 1
+    \global\advance\gre@attr@glyph@id by 1\relax %
+    \GreGlyphHeights{#1}{#1}%
+  \or % 2
+    \ifgre@eolshiftsenabled %
+      \GreGlyphHeights{#1}{#1}%
+    \fi %
+  \fi %
   \ifcase#1%
   \or\or%
   \or\gre@fontchar@custostopmiddle %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -428,7 +428,7 @@
       % The maximum value is wd(custos) + spacebeforeeolcustos
       % Were the eolshift larger than this the lyrics would stick out
       % into the margin
-      \setbox\gre@box@temp@width=\hbox{\gre@pickcustos{\gre@pitch@g}}%
+      \setbox\gre@box@temp@width=\hbox{\gre@pickcustos{\gre@pitch@g}{0}}%
       \gre@skip@temp@three = \glueexpr(\wd\gre@box@temp@width+\gre@space@skip@spacebeforeeolcustos)\relax%
       \gre@debugmsg{eolshift}{custos + space before custos = \the\gre@skip@temp@three}%
       % pick the smaller of the two values calculated above


### PR DESCRIPTION
Fixes #961.

The updated test results look correct to me, but please confirm.  I'm not sure I handled the end-of-line custos correctly, so double-check that, please.

Please review and merge if satisfactory.