### PR TITLE
Added a tunable space for puncta inclinata at the unison.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Changed
 - The stemmed oriscus flexus `(gOe)` is now consistent with the unstemmed oriscus flexus `(goe)` in that the oriscus points downward at the note that follows.  If you prefer to have the oriscus point upward, use `(gO1e)` for force upward orientation.
 - Space before a custos appearing in the middle of a line is now set by `spacebeforeinlinecustos`.
+- The space between two puncta inclinata at the unison may be tuned by changing `punctuminclinatumunisonshift` (see [#1042](https://github.com/gregorio-project/gregorio/issues/1042)).
 
 ### Removed
 - `\grescorereference`

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1290,7 +1290,11 @@ Space between notes of a bistropha or tristrophae.
 \end{gdimension}
 
 \begin{gdimension}{punctuminclinatumshift}
-Space between two punctum inclinatum.
+Space between two descending puncta inclinata.
+\end{gdimension}
+
+\begin{gdimension}{punctuminclinatumunisonshift}
+Space between two unison puncta inclinata.
 \end{gdimension}
 
 \begin{gdimension}{beforepunctainclinatashift}
@@ -1298,7 +1302,8 @@ Space before puncta inclinata.
 \end{gdimension}
 
 \begin{gdimension}{punctuminclinatumanddebilisshift}
-Space between a punctum inclinatum and a punctum inclinatum deminutus.
+Space between a punctum inclinatum and a punctum inclinatum deminutus,
+descending.
 \end{gdimension}
 
 \begin{gdimension}{punctuminclinatumdebilisshift}
@@ -1306,11 +1311,11 @@ Space between two punctum inclinatum deminutus.
 \end{gdimension}
 
 \begin{gdimension}{punctuminclinatumbigshift}
-Space between puncta inclinata, larger ambitus (range=3rd).
+Space between descending puncta inclinata, larger ambitus (range=3rd).
 \end{gdimension}
 
 \begin{gdimension}{punctuminclinatummaxshift}
-Space between puncta inclinata, larger ambitus (range=4th or 5th).
+Space between descending puncta inclinata, larger ambitus (range=4th or 5th).
 \end{gdimension}
 
 \begin{gdimension}{ascendingpunctuminclinatumshift}

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3094,9 +3094,18 @@ static void write_element(FILE *f, gregorio_syllable *syllable,
                         }
                     } else if (is_puncta_inclinata(
                                 glyph->next->u.notes.glyph_type)
-                            || glyph->next->u.notes.glyph_type ==
-                            G_PUNCTA_INCLINATA) {
-                        fprintf(f, "\\GreEndOfGlyph{9}%%\n");
+                            || glyph->next->u.notes.glyph_type
+                            == G_PUNCTA_INCLINATA) {
+                        if ((is_puncta_inclinata(glyph->u.notes.glyph_type)
+                                    || glyph->u.notes.glyph_type
+                                    == G_PUNCTA_INCLINATA)
+                                && glyph->next->u.notes.first_note->u.note.pitch
+                                == gregorio_glyph_last_note(glyph)->u.note.pitch) {
+                            /* special case for unison puncta inclinata */
+                            fprintf(f, "\\GreEndOfGlyph{23}%%\n");
+                        } else {
+                            fprintf(f, "\\GreEndOfGlyph{9}%%\n");
+                        }
                     } else if (glyph->u.notes.glyph_type != G_ALTERATION
                             || !glyph->next) {
                         fprintf(f, "\\GreEndOfGlyph{0}%%\n");

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1433,6 +1433,10 @@
     \gre@skip@temp@four = \gre@space@skip@ascendinginclinatumtonobarmaxshift\relax%
   \or% case 22
     \gre@skip@temp@four = \gre@space@skip@halfspace\relax%
+  \or% case 23
+    \gre@skip@temp@four = \gre@space@skip@punctuminclinatumunisonshift\relax%
+  \else%
+    \gre@error{Unrecognized spaceskip #1}%
   \fi%
 }%
 

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -152,6 +152,8 @@
 %
 % space between two punctum inclinatum
 \grecreatedim{punctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+% space between two unison punctum inclinatum
+\grecreatedim{punctuminclinatumunisonshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 % space before puncta inclinata
 \grecreatedim{beforepunctainclinatashift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 % space between a punctum inclinatum and a punctum inclinatum deminutus


### PR DESCRIPTION
Fixes #1042.

I set the `punctuminclinatumunisonshift` to the same as `beforepunctainclinatashift`, which is what is currently used in this case.  No current tests break, and though punctum cavum inclinatum at the unison is already tested, I added a test specifically for the non-cavum case.

Please review and merge if satisfactory.