### PR TITLE
Addresses #1036

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - A podatus followed by a virga `(eghv)` will now be kept together (no line break between the shapes),  If you would like to allow a line break there, use `(eg/hv)` instead (see UPGRADE.md and [#1045](https://github.com/gregorio-project/gregorio/issues/1045)).
 - Penalties must now be changed using the `\grechangecount` command.  See GregorioRef and [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#1021](https://github.com/gregorio-project/gregorio/issues/1021)).
 - `\greemergencystretch` must now be set by changing `emergencystretch` using `\grechangedim` instead of redefining the macro.
-- `interwordspacetext` and it's related distances are now defined as fixed distances based on the `\fontdimen` values so that a space between two words in a score is exactly the same as a space between two words in text if notes do not interfere.  This also means that they will scale according to the font, not the staff size.  The documenation has been updated to explain how this is done and provide the default definitions.  See [#1036](https://github.com/gregorio-project/gregorio/issues/1036).
+- `interwordspacetext` and it's related distances have been redefined to be smaller and dependent on a font based distance (`ex`).  They are also no longer scale with the staff size by default.  See [#1036](https://github.com/gregorio-project/gregorio/issues/1036) & [gregoriot-test#208](https://github.com/gregorio-project/gregorio-test/pull/208).
 
 ### Removed
 - `\grescorereference`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - A podatus followed by a virga `(eghv)` will now be kept together (no line break between the shapes),  If you would like to allow a line break there, use `(eg/hv)` instead (see UPGRADE.md and [#1045](https://github.com/gregorio-project/gregorio/issues/1045)).
 - Penalties must now be changed using the `\grechangecount` command.  See GregorioRef and [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#1021](https://github.com/gregorio-project/gregorio/issues/1021)).
 - `\greemergencystretch` must now be set by changing `emergencystretch` using `\grechangedim` instead of redefining the macro.
+- `interwordspacetext` and it's related distances are now defined as fixed distances based on the `\fontdimen` values.  This means that they will scale according to the font, not the staff size.  The documenation has been updated to explain how this is done and provide the default definitions.  See [#1036](https://github.com/gregorio-project/gregorio/issues/1036).
 
 ### Removed
 - `\grescorereference`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - A podatus followed by a virga `(eghv)` will now be kept together (no line break between the shapes),  If you would like to allow a line break there, use `(eg/hv)` instead (see UPGRADE.md and [#1045](https://github.com/gregorio-project/gregorio/issues/1045)).
 - Penalties must now be changed using the `\grechangecount` command.  See GregorioRef and [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#1021](https://github.com/gregorio-project/gregorio/issues/1021)).
 - `\greemergencystretch` must now be set by changing `emergencystretch` using `\grechangedim` instead of redefining the macro.
-- `interwordspacetext` and it's related distances are now defined as fixed distances based on the `\fontdimen` values.  This means that they will scale according to the font, not the staff size.  The documenation has been updated to explain how this is done and provide the default definitions.  See [#1036](https://github.com/gregorio-project/gregorio/issues/1036).
+- `interwordspacetext` and it's related distances are now defined as fixed distances based on the `\fontdimen` values so that a space between two words in a score is exactly the same as a space between two words in text if notes do not interfere.  This also means that they will scale according to the font, not the staff size.  The documenation has been updated to explain how this is done and provide the default definitions.  See [#1036](https://github.com/gregorio-project/gregorio/issues/1036).
 
 ### Removed
 - `\grescorereference`

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1291,10 +1291,6 @@ separated with an automatic hyphen.
 Minimum space between notes of syllables from different words.
 \end{gdimension}
 
-\begin{gdimension}{interwordspacetext}
-Minimum space between texts of different words. Please keep the same \texttt{plus} and \texttt{minus} as \texttt{interwordspacenotes}.
-\end{gdimension}
-
 \begin{gdimension}{interwordspacenotes@alteration}
 Same as \texttt{interwordspacenotes} for the case where the second syllable starts with an alteration.
 \end{gdimension}
@@ -1305,10 +1301,6 @@ Same as \texttt{intersyllablespacenotes} for the case where the second syllable 
 
 \begin{gdimension}{interwordspacenotes@euouae}
 Same as \texttt{interwordspacenotes} for \texttt{euouae} blocks.
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@euouae}
-Same as \texttt{interwordspacetext} for \texttt{euouae} blocks.
 \end{gdimension}
 
 \begin{gdimension}{bitrivirspace}
@@ -1587,7 +1579,7 @@ Vertical distance to place a punctum mora for the second note in a porrectus (or
 Distance to place a ``rare'' sign above the top space in a score.
 \end{gdimension}
 
-\subsubsection*{Bar distances}
+\subsubsection{Bar distances}
 
 \begin{gdimension}{bar@finalfinalis}
 This space is added before the final divisio final of a score (old bar spacing algorithm only).
@@ -1669,22 +1661,6 @@ A rubber value applied on both sides of all bars in standalone syllables, in new
 \textbf{Nota Bene:} This distance should always have a base value of 0pt.
 \end{gdimension}
 
-\begin{gdimension}{interwordspacetext@bars}
-Minimum space between texts of different words when one of the syllable contains only a bar (new bar spacing algorithm only).
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@bars@euouae}
-Same as \texttt{interwordspacetext@bars} for \texttt{euouae} blocks (so quite rare).
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@bars@notext}
-Minimum space between texts of adjacent words when they are separated by a bar syllable which has no text associated with it (new bar spacing algorithm only).
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@bars@notext@euouae}
-Same as \texttt{interwordspacetext@bars@notext} for \texttt{euouae} blocks (so quite rare).
-\end{gdimension}
-
 \begin{gdimension}{textbartextspace}
 Space between the text of previous syllable and the text associated with the bar (old bar spacing algorithm only).
 \end{gdimension}
@@ -1716,6 +1692,65 @@ Maximum distance by which the center of a bar and the center of its associated t
 \begin{gdimension}{maxbaroffsettextright@eol}
 Same as \texttt{maxbaroffsettextleft@eol} but when the center of the text goes right of the center of the bar.
 \end{gdimension}
+
+\subsubsection{Distances tied to font size}
+In some cases it is desirable to link a distance with the size of the text font, rather than the score's staff size.  This can be accomplished in the following way:
+
+\begin{enumerate}
+  \item The distance should be defined in terms of the various \texttt{\textbackslash fontdimen} values (there are 7).  These should be prepended by \verb=\the= and can be combined or scaled using \verb=\dimexpr= and \verb=\glueexpr= (which also need to be prepended by \verb=\the= when used).
+  \item To prevent premature expansion, the entire value for the distance should be enclosed in \verb=\unexpanded=.
+  \item The distance should be defined as \texttt{fixed} relative to the staff size.  If the distance is \texttt{scalable} then any link between the distance and the font size will be broken if \verb=\grechangestaffsize= is called.
+\end{enumerate}
+
+Example:\par\medskip
+{\footnotesize
+\begin{latexcode}
+  \grechangedim{interwordspacetext}{\unexpanded{\the\fontdimen6\font}}{fixed}%
+\end{latexcode}
+}
+
+This definition for \texttt{interwordspacetext} will make it equal to the size of the font.
+
+Each of the following distances has a default which is defined in this way.  The actual definition is shown first (without the \verb=\unexpanded=), followed by the numerical default for 12pt Linux Libertine (the font in use in this document).
+
+\begin{gdimension}{interwordspacetext}
+Minimum space between texts of different words. 
+
+\textbf{Nota Bene:} To avoid unpredictable differences in the stretching/shrinking between words, the same \texttt{plus} and \texttt{minus} as \texttt{interwordspacenotes} should be used.  To ensure this here, we make use of \verb=\gluestretch= and \verb=\glueshrink= in order to call those values directly.  When combined with the call of \verb=\unexpanded= which is necessary for linking the base distance to a \texttt{\textbackslash fontdimen}, this ensures that they will always match.
+
+\definition{interwordspacetext}
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@euouae}
+Same as \texttt{interwordspacetext} for \texttt{euouae} blocks.
+
+\definition{interwordspacetext@euouae}
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@bars}
+Minimum space between texts of different words when one of the syllable contains only a bar (new bar spacing algorithm only).
+
+\definition{interwordspacetext@bars}
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@bars@euouae}
+Same as \texttt{interwordspacetext@bars} for \texttt{euouae} blocks (so quite rare).
+
+\definition{interwordspacetext@bars@euouae}
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@bars@notext}
+Minimum space between texts of adjacent words when they are separated by a bar syllable which has no text associated with it (new bar spacing algorithm only).
+
+\definition{interwordspacetext@bars@notext}
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@bars@notext@euouae}
+Same as \texttt{interwordspacetext@bars@notext} for \texttt{euouae} blocks (so quite rare).
+
+\definition{interwordspacetext@bars@notext@euouae}
+\end{gdimension}
+
 
 
 \subsection{Penalties}\label{penalties}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1291,6 +1291,10 @@ separated with an automatic hyphen.
 Minimum space between notes of syllables from different words.
 \end{gdimension}
 
+\begin{gdimension}{interwordspacetext}
+Minimum space between texts of different words. Please keep the same \texttt{plus} and \texttt{minus} as \texttt{interwordspacenotes}.
+\end{gdimension}
+
 \begin{gdimension}{interwordspacenotes@alteration}
 Same as \texttt{interwordspacenotes} for the case where the second syllable starts with an alteration.
 \end{gdimension}
@@ -1301,6 +1305,10 @@ Same as \texttt{intersyllablespacenotes} for the case where the second syllable 
 
 \begin{gdimension}{interwordspacenotes@euouae}
 Same as \texttt{interwordspacenotes} for \texttt{euouae} blocks.
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@euouae}
+Same as \texttt{interwordspacetext} for \texttt{euouae} blocks.
 \end{gdimension}
 
 \begin{gdimension}{bitrivirspace}
@@ -1661,6 +1669,22 @@ A rubber value applied on both sides of all bars in standalone syllables, in new
 \textbf{Nota Bene:} This distance should always have a base value of 0pt.
 \end{gdimension}
 
+\begin{gdimension}{interwordspacetext@bars}
+Minimum space between texts of different words when one of the syllable contains only a bar (new bar spacing algorithm only).
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@bars@euouae}
+Same as \texttt{interwordspacetext@bars} for \texttt{euouae} blocks (so quite rare).
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@bars@notext}
+Minimum space between texts of adjacent words when they are separated by a bar syllable which has no text associated with it (new bar spacing algorithm only).
+\end{gdimension}
+
+\begin{gdimension}{interwordspacetext@bars@notext@euouae}
+Same as \texttt{interwordspacetext@bars@notext} for \texttt{euouae} blocks (so quite rare).
+\end{gdimension}
+
 \begin{gdimension}{textbartextspace}
 Space between the text of previous syllable and the text associated with the bar (old bar spacing algorithm only).
 \end{gdimension}
@@ -1692,65 +1716,6 @@ Maximum distance by which the center of a bar and the center of its associated t
 \begin{gdimension}{maxbaroffsettextright@eol}
 Same as \texttt{maxbaroffsettextleft@eol} but when the center of the text goes right of the center of the bar.
 \end{gdimension}
-
-\subsubsection{Distances tied to font size}
-Each text font defines 7 distances related to how it is spaced (see \url{http://tex.stackexchange.com/questions/88991/what-do-different-fontdimennum-mean} for a description of these).  These distances are accessed in \LaTeX\ via the \texttt{\textbackslash fontdimen<int>\textbackslash font} interface (where \texttt{<int>} is an integer between 1 and 7).  In some cases it is desirable to link a Gregorio\TeX\ distance with the one of these distances, rather than the score's staff size.  This can be accomplished in the following way:
-
-\begin{enumerate}
-  \item When using \texttt{\textbackslash fontdimen} values in defining a Gregorio\TeX\ distance, they should be prepended by \verb=\the= and can be combined or scaled using \verb=\dimexpr= and \verb=\glueexpr= (which also need to be prepended by \verb=\the= when used).
-  \item To prevent premature expansion, the entire value for the distance should be enclosed in \verb=\unexpanded=.
-  \item The distance should be defined as \texttt{fixed} relative to the staff size.  If the distance is \texttt{scalable} then any link between the distance and the font distance will be broken if \verb=\grechangestaffsize= is called.
-\end{enumerate}
-
-Example:\par\medskip
-{\footnotesize
-\begin{latexcode}
-  \grechangedim{interwordspacetext}{\unexpanded{\the\fontdimen2\font}}{fixed}%
-\end{latexcode}
-}
-
-This definition for \texttt{interwordspacetext} will make it equal to the standard space for the font.
-
-Each of the following distances has a default which is defined in this way.  The actual definition is shown first (without the \verb=\unexpanded=), followed by the numerical default for 12pt Linux Libertine (the font in use in this document).
-
-\begin{gdimension}{interwordspacetext}
-Minimum space between texts of different words. 
-
-\textbf{Nota Bene:} To avoid unpredictable differences in the stretching/shrinking between words, the same \texttt{plus} and \texttt{minus} as \texttt{interwordspacenotes} should be used.  To ensure this here, we make use of \verb=\gluestretch= and \verb=\glueshrink= in order to call those values directly.  When combined with the call of \verb=\unexpanded= which is necessary for linking the base distance to a \texttt{\textbackslash fontdimen}, this ensures that they will always match.
-
-\definition{interwordspacetext}
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@euouae}
-Same as \texttt{interwordspacetext} for \texttt{euouae} blocks.
-
-\definition{interwordspacetext@euouae}
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@bars}
-Minimum space between texts of different words when one of the syllable contains only a bar (new bar spacing algorithm only).
-
-\definition{interwordspacetext@bars}
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@bars@euouae}
-Same as \texttt{interwordspacetext@bars} for \texttt{euouae} blocks (so quite rare).
-
-\definition{interwordspacetext@bars@euouae}
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@bars@notext}
-Minimum space between texts of adjacent words when they are separated by a bar syllable which has no text associated with it (new bar spacing algorithm only).
-
-\definition{interwordspacetext@bars@notext}
-\end{gdimension}
-
-\begin{gdimension}{interwordspacetext@bars@notext@euouae}
-Same as \texttt{interwordspacetext@bars@notext} for \texttt{euouae} blocks (so quite rare).
-
-\definition{interwordspacetext@bars@notext@euouae}
-\end{gdimension}
-
 
 
 \subsection{Penalties}\label{penalties}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1694,22 +1694,22 @@ Same as \texttt{maxbaroffsettextleft@eol} but when the center of the text goes r
 \end{gdimension}
 
 \subsubsection{Distances tied to font size}
-In some cases it is desirable to link a distance with the size of the text font, rather than the score's staff size.  This can be accomplished in the following way:
+Each text font defines 7 distances related to how it is spaced (see \url{http://tex.stackexchange.com/questions/88991/what-do-different-fontdimennum-mean} for a description of these).  These distances are accessed in \LaTeX\ via the \texttt{\textbackslash fontdimen<int>\textbackslash font} interface (where \texttt{<int>} is an integer between 1 and 7).  In some cases it is desirable to link a Gregorio\TeX\ distance with the one of these distances, rather than the score's staff size.  This can be accomplished in the following way:
 
 \begin{enumerate}
-  \item The distance should be defined in terms of the various \texttt{\textbackslash fontdimen} values (there are 7).  These should be prepended by \verb=\the= and can be combined or scaled using \verb=\dimexpr= and \verb=\glueexpr= (which also need to be prepended by \verb=\the= when used).
+  \item When using \texttt{\textbackslash fontdimen} values in defining a Gregorio\TeX\ distance, they should be prepended by \verb=\the= and can be combined or scaled using \verb=\dimexpr= and \verb=\glueexpr= (which also need to be prepended by \verb=\the= when used).
   \item To prevent premature expansion, the entire value for the distance should be enclosed in \verb=\unexpanded=.
-  \item The distance should be defined as \texttt{fixed} relative to the staff size.  If the distance is \texttt{scalable} then any link between the distance and the font size will be broken if \verb=\grechangestaffsize= is called.
+  \item The distance should be defined as \texttt{fixed} relative to the staff size.  If the distance is \texttt{scalable} then any link between the distance and the font distance will be broken if \verb=\grechangestaffsize= is called.
 \end{enumerate}
 
 Example:\par\medskip
 {\footnotesize
 \begin{latexcode}
-  \grechangedim{interwordspacetext}{\unexpanded{\the\fontdimen6\font}}{fixed}%
+  \grechangedim{interwordspacetext}{\unexpanded{\the\fontdimen2\font}}{fixed}%
 \end{latexcode}
 }
 
-This definition for \texttt{interwordspacetext} will make it equal to the size of the font.
+This definition for \texttt{interwordspacetext} will make it equal to the standard space for the font.
 
 Each of the following distances has a default which is defined in this way.  The actual definition is shown first (without the \verb=\unexpanded=), followed by the numerical default for 12pt Linux Libertine (the font in use in this document).
 

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -137,27 +137,6 @@
   Default: \expandafter$\expandafter\the\csname gre@space@count@#1\endcsname$
 }
 
-\newcommand\definition[1]{%
-  \gre@rubberpermit{#1}%
-  \ifgre@rubber%
-    \expandafter
-      \let
-    \expandafter
-      \temp
-    \csname gre@space@skip@#1\endcsname%
-  \else%
-    \expandafter
-      \let
-    \expandafter
-      \temp
-    \csname gre@space@dimen@#1\endcsname%
-  \fi%
-  Definition:
-  {\ttfamily%
-  \expandafter\strip@prefix\meaning\temp
-  }%
-}
-
 \newcommand{\writemode}[3]{%
   \gre@style@modeline #1\endgre@style@modeline %
   \gre@style@modemodifier #2\endgre@style@modemodifier %

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -87,7 +87,7 @@
   \ifbreakable%
     \filbreak%
   \else%
-    \breakabletrue%
+    \global\breakabletrue%
   \fi%
   \makebox[\linewidth]{\ttfamily\bfseries #1#2%
   \hspace{\fill}\normalfont\itshape #3}%
@@ -135,6 +135,27 @@
 \NewDocumentEnvironment{gcount}{m}{\macroname{#1}{}{gsp-default.tex}}{%
 
   Default: \expandafter$\expandafter\the\csname gre@space@count@#1\endcsname$
+}
+
+\newcommand\definition[1]{%
+  \gre@rubberpermit{#1}%
+  \ifgre@rubber%
+    \expandafter
+      \let
+    \expandafter
+      \temp
+    \csname gre@space@skip@#1\endcsname%
+  \else%
+    \expandafter
+      \let
+    \expandafter
+      \temp
+    \csname gre@space@dimen@#1\endcsname%
+  \fi%
+  Definition:
+  {\ttfamily%
+  \expandafter\strip@prefix\meaning\temp
+  }%
 }
 
 \newcommand{\writemode}[3]{%

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -131,12 +131,10 @@
 % separated with an automatic hyphen
 \grecreatedim{intersyllablespacestretchhyphen}{0cm plus 0.05cm}{scalable}%
 % minimal space between letters of different words.
-% The use of the various `\fontdimen` values ties this distance (and others which do the same) to the font size of the lyrics.  In order to make this tie dynamic, we use eTeX's `\unexpanded` primitive to prevent premature expansion (we want the `\fontdimen` values to expand at time of use, not right now).  We also declare this distance as "fixed" so that it GregorioTeX won't try to scale it when the staff size changes, as doing so would break the tie to the lyric font size.
-% See http://tex.stackexchange.com/questions/88991/what-do-different-fontdimennum-mean for a description of the available `\fontdimen` values.
-\grecreatedim{interwordspacetext}{\unexpanded{\the\fontdimen2\font plus \the\gluestretch\gre@space@skip@interwordspacenotes minus \the\glueshrink\gre@space@skip@interwordspacenotes}}{fixed}%
+\grecreatedim{interwordspacetext}{1ex plus 0.15cm minus 0.05cm}{fixed}%
 % Versions of interword spaces for euouae blocks
 \grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scalable}%
-\grecreatedim{interwordspacetext@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font) * 8 / 10)\relax plus \the\gluestretch\gre@space@skip@interwordspacenotes@euouae minus \the\glueshrink\gre@space@skip@interwordspacenotes@euouae}}{fixed}%
+\grecreatedim{interwordspacetext@euouae}{08.ex plus 01.cm minus 0.05cm}{fixed}%
 % versions of note spaces when the first note of the second syllable is an alteration
 % those are used in euouae blocks
 \grecreatedim{interwordspacenotes@alteration}{0.1 cm plus 0.07 cm minus 0.01 cm}{scalable}%
@@ -225,14 +223,14 @@
 %
 % minimal space between letters of different syllable texts for text around bars
 % (new bar spacing algorithm only)
-\grecreatedim{interwordspacetext@bars}{\unexpanded{\the\dimexpr((\the\fontdimen2\font)*7/10)\relax}}{fixed}%
+\grecreatedim{interwordspacetext@bars}{0.7ex}{fixed}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\grecreatedim{interwordspacetext@bars@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font)*7/10)\relax}}{fixed}%
-\grecreatedim{interwordspacetext@bars@notext}{\unexpanded{\the\fontdimen2\font}}{fixed}%
+\grecreatedim{interwordspacetext@bars@euouae}{0.7ex}{fixed}%
+\grecreatedim{interwordspacetext@bars@notext}{1ex}{fixed}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\grecreatedim{interwordspacetext@bars@notext@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font)*7/10)\relax}}{fixed}%
+\grecreatedim{interwordspacetext@bars@notext@euouae}{0.7ex}{fixed}%
 % rubber length that will be added around bars in new bar spacing algorithm
 \grecreatedim{bar@rubber}{0 cm plus 0.22787 cm minus 0.02 cm}{scalable}%
 % additional space that will appear around bars that are preceded by a custos and followed by a key.

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -130,12 +130,12 @@
 % stretching added in the case where the text of two syllables of the same word are
 % separated with an automatic hyphen
 \grecreatedim{intersyllablespacestretchhyphen}{0cm plus 0.05cm}{scalable}%
-% minimal space between letters of different words. Makes sense to have
-% the same plus and minus as interwordspacenotes.
-\grecreatedim{interwordspacetext}{0.38 cm plus 0.15 cm minus 0.05 cm}{scalable}%
+% minimal space between letters of different words.
+% The use of the various `\fontdimen` values ties this distance (and others which do the same) to the font size of the lyrics.  In order to make this tie dynamic, we use eTeX's `\unexpanded` primitive to prevent premature expansion (we want the `\fontdimen` values to expand at time of use, not right now).  We also declare this distance as "fixed" so that it GregorioTeX won't try to scale it when the staff size changes, as doing so would break the tie to the lyric font size.
+\grecreatedim{interwordspacetext}{\unexpanded{\the\fontdimen2\font plus \the\gluestretch\gre@space@skip@interwordspacenotes minus \the\glueshrink\gre@space@skip@interwordspacenotes}}{fixed}%
 % Versions of interword spaces for euouae blocks
 \grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scalable}%
-\grecreatedim{interwordspacetext@euouae}{0.27 cm plus 0.1 cm minus 0.05 cm}{scalable}%
+\grecreatedim{interwordspacetext@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font) * 8 / 10)\relax plus \the\gluestretch\gre@space@skip@interwordspacenotes@euouae minus \the\glueshrink\gre@space@skip@interwordspacenotes@euouae\relax}}{fixed}%
 % versions of note spaces when the first note of the second syllable is an alteration
 % those are used in euouae blocks
 \grecreatedim{interwordspacenotes@alteration}{0.1 cm plus 0.07 cm minus 0.01 cm}{scalable}%
@@ -224,14 +224,14 @@
 %
 % minimal space between letters of different syllable texts for text around bars
 % (new bar spacing algorithm only)
-\grecreatedim{interwordspacetext@bars}{0.15 cm}{scalable}%
+\grecreatedim{interwordspacetext@bars}{\unexpanded{\the\dimexpr((\the\fontdimen2\font)*7/10)\relax}}{fixed}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\grecreatedim{interwordspacetext@bars@euouae}{0.15 cm}{scalable}%
-\grecreatedim{interwordspacetext@bars@notext}{0.4 cm}{scalable}%
+\grecreatedim{interwordspacetext@bars@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font)*7/10)\relax}}{fixed}%
+\grecreatedim{interwordspacetext@bars@notext}{\unexpanded{\the\fontdimen2\font}}{fixed}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\grecreatedim{interwordspacetext@bars@notext@euouae}{0.3 cm}{scalable}%
+\grecreatedim{interwordspacetext@bars@notext@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font)*7/10)\relax}}{fixed}%
 % rubber length that will be added around bars in new bar spacing algorithm
 \grecreatedim{bar@rubber}{0 cm plus 0.22787 cm minus 0.02 cm}{scalable}%
 % additional space that will appear around bars that are preceded by a custos and followed by a key.

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -132,6 +132,7 @@
 \grecreatedim{intersyllablespacestretchhyphen}{0cm plus 0.05cm}{scalable}%
 % minimal space between letters of different words.
 % The use of the various `\fontdimen` values ties this distance (and others which do the same) to the font size of the lyrics.  In order to make this tie dynamic, we use eTeX's `\unexpanded` primitive to prevent premature expansion (we want the `\fontdimen` values to expand at time of use, not right now).  We also declare this distance as "fixed" so that it GregorioTeX won't try to scale it when the staff size changes, as doing so would break the tie to the lyric font size.
+% See http://tex.stackexchange.com/questions/88991/what-do-different-fontdimennum-mean for a description of the available `\fontdimen` values.
 \grecreatedim{interwordspacetext}{\unexpanded{\the\fontdimen2\font plus \the\gluestretch\gre@space@skip@interwordspacenotes minus \the\glueshrink\gre@space@skip@interwordspacenotes}}{fixed}%
 % Versions of interword spaces for euouae blocks
 \grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scalable}%

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -134,7 +134,7 @@
 \grecreatedim{interwordspacetext}{1ex plus 0.15cm minus 0.05cm}{fixed}%
 % Versions of interword spaces for euouae blocks
 \grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scalable}%
-\grecreatedim{interwordspacetext@euouae}{08.ex plus 01.cm minus 0.05cm}{fixed}%
+\grecreatedim{interwordspacetext@euouae}{0.8ex plus 01.cm minus 0.05cm}{fixed}%
 % versions of note spaces when the first note of the second syllable is an alteration
 % those are used in euouae blocks
 \grecreatedim{interwordspacenotes@alteration}{0.1 cm plus 0.07 cm minus 0.01 cm}{scalable}%

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -135,7 +135,7 @@
 \grecreatedim{interwordspacetext}{\unexpanded{\the\fontdimen2\font plus \the\gluestretch\gre@space@skip@interwordspacenotes minus \the\glueshrink\gre@space@skip@interwordspacenotes}}{fixed}%
 % Versions of interword spaces for euouae blocks
 \grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scalable}%
-\grecreatedim{interwordspacetext@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font) * 8 / 10)\relax plus \the\gluestretch\gre@space@skip@interwordspacenotes@euouae minus \the\glueshrink\gre@space@skip@interwordspacenotes@euouae\relax}}{fixed}%
+\grecreatedim{interwordspacetext@euouae}{\unexpanded{\the\dimexpr((\the\fontdimen2\font) * 8 / 10)\relax plus \the\gluestretch\gre@space@skip@interwordspacenotes@euouae minus \the\glueshrink\gre@space@skip@interwordspacenotes@euouae}}{fixed}%
 % versions of note spaces when the first note of the second syllable is an alteration
 % those are used in euouae blocks
 \grecreatedim{interwordspacenotes@alteration}{0.1 cm plus 0.07 cm minus 0.01 cm}{scalable}%


### PR DESCRIPTION
`interwordspacetext` distances are changed to be dependent on the font
Instructions are added to GregorioRef for how the above is accomplished so that the user can do the same.

Lots of tests break, but all in the expected manner.  However, I think that these new defaults might be a tad too small.  If others would please review the test changes and tell me if they agree or not, I'd appreciate it.