### PR TITLE
Prevented an element cut before an isolated stropha.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - A podatus followed by a virga `(eghv)` will now be kept together (no line break between the shapes),  If you would like to allow a line break there, use `(eg/hv)` instead (see UPGRADE.md and [#1045](https://github.com/gregorio-project/gregorio/issues/1045)).
 - Penalties must now be changed using the `\grechangecount` command.  See GregorioRef and [UPGRADE.md](UPGRADE.md) for details (for the change request, see [#1021](https://github.com/gregorio-project/gregorio/issues/1021)).
 - `\greemergencystretch` must now be set by changing `emergencystretch` using `\grechangedim` instead of redefining the macro.
+- An isolated stropha will now be considered part of the previous neume group and line breaks will be prevented at that point.  In order to force a line break there, use a breaking space such as `/` before the stropha in gabc.  See [#1056](https://github.com/gregorio-project/gregorio/issues/1056).
 
 ### Removed
 - `\grescorereference`

--- a/src/gabc/gabc-elements-determination.c
+++ b/src/gabc/gabc-elements-determination.c
@@ -198,8 +198,15 @@ static gregorio_element *gabc_det_elements_from_glyphs(
             }
             break;
 
+        case G_STROPHA_AUCTA:
+        case G_STROPHA:
+            if (current_glyph->u.notes.liquescentia
+                    & (L_AUCTUS_ASCENDENS | L_AUCTUS_DESCENDENS)) {
+                force_cut = true;
+            }
+            /* fall through */
         case PUNCTA_INCLINATA_DESCENDENS_GLYPH:
-            /* we don't cut before, so we don't do anything */
+            /* we don't cut before, so we don't do anything else */
             if (do_not_cut) {
                 do_not_cut = false;
             }


### PR DESCRIPTION
Fixes #1056.

Please review and merge if satisfactory.