### PR TITLE
Fixing problems in `\gre@changestyle` definition under PlainTeX

### DIFF
--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -270,8 +270,8 @@
 \def\endgre@style@nabc{\endgroup}%
 
 \def\gre@changestyle#1#2[#3]{%
-  \gdef\csname gre@style@#1\endcsname{\begingroup#2}%
-  \gdef\csname endgre@style@#1\endcsname{#3\endgroup}%
+  \expandafter\gdef\csname gre@style@#1\endcsname{\begingroup#2}%
+  \expandafter\gdef\csname endgre@style@#1\endcsname{#3\endgroup}%
 }%
 
 \catcode`\@=\greoldcatcode


### PR DESCRIPTION
Need to lead with `\expandafter` when defining a function name which is specified with `\csname`