### PR TITLE
Inherited distances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - `\greemergencystretch` must now be set by changing `emergencystretch` using `\grechangedim` instead of redefining the macro.
 - An isolated stropha will now be considered part of the previous neume group and line breaks will be prevented at that point.  In order to force a line break there, use a breaking space such as `/` before the stropha in gabc.  See [#1056](https://github.com/gregorio-project/gregorio/issues/1056).
 - `interwordspacetext` and it's related distances have been redefined to be smaller and dependent on a font based distance (`ex`).  They are also no longer scale with the staff size by default.  See [#1036](https://github.com/gregorio-project/gregorio/issues/1036) & [gregoriot-test#208](https://github.com/gregorio-project/gregorio-test/pull/208).
+- `\grecreatedim` and `\grechangedim` can now be used to link two distances.  To do this the second argument should be the name of the master distance and the third argument should be `inherited`.  See [#962](https://github.com/gregorio-project/gregorio/issues/962).
 
 ### Removed
 - `\grescorereference`

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -234,7 +234,8 @@ Macro to create one of Gregorio\TeX’s distances.  Used to initialize distances
   \#1 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
   \#2 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
   \#3 & \texttt{fixed} & Distance will not scale when staff size is changed.\\
-  & \texttt{scalable} & Distance will scale when staff size is changed.
+  & \texttt{scalable} & Distance will scale when staff size is changed.\\
+  & \texttt{inherited} & Distance will inherit its value from another distance.  When this argument is used, then \#2 should be the name of another Gregorio\TeX\ distance.
 \end{argtable}
 
 \macroname{\textbackslash grechangedim}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-spaces.tex}
@@ -244,7 +245,8 @@ Macro to change one of Gregorio\TeX’s distances.  This function will check to 
   \#1 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
   \#2 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
   \#3 & \texttt{fixed} & Distance will not scale when staff size is changed.\\
-  & \texttt{scalable} & Distance will scale when staff size is changed.
+  & \texttt{scalable} & Distance will scale when staff size is changed.\\
+  & \texttt{inherited} & Distance will inherit its value from another distance.  When this argument is used, then \#2 should be the name of another Gregorio\TeX\ distance.
 \end{argtable}
 
 \macroname{\textbackslash grescaledim}{\{\#1\}\{\#2\}}{gregoriotex-spaces.tex}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1081,7 +1081,10 @@ Macro to generate the point-and-click links.
 \end{argtable}
 
 \macroname{\textbackslash gre@prefix}{}{gregoriotex-spaces.tex}
-Either ``skip’’ or ``dimen’’ according to the distance being set or changed at the given moment.
+Either \texttt{skip} or \texttt{dimen} according to the distance being set or changed at the given moment.
+
+\macroname{\textbackslash gre@prefixII}{}{gregoriotex-spaces.tex}
+Same as \verb=\gre@prefix=.  Used when we were dealing with two distances simultaneously.
 
 \macroname{\textbackslash gre@rubberpermit}{\#1}{gregoriotex-spaces.tex}
 Determines whether the given distance is allowed to take a rubber length.
@@ -1136,7 +1139,7 @@ Alias for \verb=\luatexlocalrightbox= or \verb=\localrightbox=, depending on \La
 Alias for \verb=\resizebox=.
 
 \macroname{\textbackslash gre@dimension}{}{gregoriotex-spaces.tex}
-Workhorse function behind \verb=\grecreatedim= and \verb=\grechangedim=.
+Workhorse function for setting distances in \verb=\grecreatedim= and \verb=\grechangedim=.
 
 \macroname{\textbackslash gre@setstafflines}{\#1}{gregoriotex-main.tex}
 Sets the number of staff lines.

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1183,16 +1183,18 @@
 %% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
 \newif\ifgre@checklength%
 \def\grecreatedim#1#2#3{%
-  \gre@dimension{#1}{#2}%
   \csname newif\expandafter\endcsname\csname ifgre@scale@#1\endcsname%
   \IfStrEqCase{#3}{
     {scalable}%
       {\grescaledim{#1}{true}}%
     {fixed}%
       {\grescaledim{#1}{false}}%
+    {inherited}%
+      {\grescaledim{#1}{false}}%
     }[% all other cases
       \gre@error{Unrecognized option "#3" for \protect\grecreatedim\MessageBreak Possible options are: 'scalable' and 'fixed'}%
     ]%
+  \gre@dimension{#1}{#2}{#3}%
 }%
 
 
@@ -1209,14 +1211,28 @@
   \fi%
   \ifcsname gre@space@\gre@prefix @#1\endcsname%
     \gre@debugmsg{spacing}{It does exist.}%
-    \gre@dimension{#1}{#2}%
     \IfStrEqCase{#3}{%
       {scalable}%
         {\grescaledim{#1}{true}}%
       {fixed}%
         {\grescaledim{#1}{false}}%
+      {inherited}%
+        {%
+          \gre@rubberpermit{#2}%
+          \ifgre@rubber%
+            \def\gre@prefixII{skip}%
+          \else%
+            \def\gre@prefixII{dimen}%
+          \fi%
+          \ifcsname gre@space@\gre@prefixII @#2\endcsname%
+            \grescaledim{#1}{false}%
+          \else%
+            \gre@error{'#1' cannot inherit from '#2'\MessageBreak Please make sure '#2' is a valid GregorioTeX distance}%
+          \fi%
+        }%
       % all other cases
-      }[\gre@error{Unrecognized option "#3" for \protect\grechangedim\MessageBreak Possible options are: 'scalable' and 'fixed'}]%
+      }[\gre@error{Unrecognized option "#3" for \protect\grechangedim\MessageBreak Possible options are: 'scalable', 'fixed', and 'inherited'}]%
+    \gre@dimension{#1}{#2}{#3}%
   \else%
     \IfStrEqCase{#1}{% DEPRECATED
       {spacearoundsmallbars}% DEPRECATED
@@ -1257,33 +1273,59 @@
 }
 
 % The common internals for \grecreatedim and \grechangedim.
-\def\gre@dimension#1#2{%
-  \gre@checklengthfalse%
-  %check if #2 is a rubber length (contains plus and/or minus)
-  \IfSubStr{#2}{plus}{\gre@checklengthtrue}{\relax}%
-  \IfSubStr{#2}{minus}{\gre@checklengthtrue}{\relax}%
-  %if #1 is one of the distances which cannot be rubber.
-  \gre@rubberpermit{#1}%
-  % do we try to assign a rubber to one where it's not permitted?
-  \ifgre@rubber%
-    \def\gre@prefix{skip}%
-  \else%
-    \ifgre@checklength%
-      \gre@error{#1 cannot be a rubber length.}%
+\def\gre@dimension#1#2#3{%
+  \IfStrEq{#3}{inherited}{%
+    \gre@debugmsg{spacing}{setting inherited distance}
+    \gre@rubberpermit{#1}%
+    \ifgre@rubber%
+      \def\gre@prefix{skip}%
     \else%
       \def\gre@prefix{dimen}%
     \fi%
-  \fi%
-  % special check for bar@rubber
-  \IfStrEq*{#1}{bar@rubber}%
-    {%
-      \gre@skip@temp@one = #2\relax%
-      \ifdim\gre@skip@temp@one=0pt\relax\else%
-        \gre@error{bar@rubber cannot have a non-zero base}%
+    \gre@rubberpermit{#2}%
+    \ifgre@rubber%
+      \def\gre@prefixII{skip}%
+    \else%
+      \def\gre@prefixII{dimen}%
+    \fi%
+    \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{\expandafter\unexpanded{\csname gre@space@\gre@prefixII @#2\endcsname}}%
+  }{%
+    \gre@rubberpermit{#2}%
+    \ifgre@rubber%
+      \def\gre@prefixII{skip}%
+    \else%
+      \def\gre@prefixII{dimen}%
+    \fi%
+    \ifcsname gre@space@\gre@prefixII @#2\endcsname%
+      \gre@error{'#1' cannot be '#3' and depend on '#2' at the same time\MessageBreak Either use 'inherited' in the third argument\MessageBreak or give an actual distance in the second}
+    \fi%
+    \gre@checklengthfalse%
+    %check if #2 is a rubber length (contains plus and/or minus)
+    \IfSubStr{#2}{plus}{\gre@checklengthtrue}{\relax}%
+    \IfSubStr{#2}{minus}{\gre@checklengthtrue}{\relax}%
+    %if #1 is one of the distances which cannot be rubber.
+    \gre@rubberpermit{#1}%
+    % do we try to assign a rubber to one where it's not permitted?
+    \ifgre@rubber%
+      \def\gre@prefix{skip}%
+    \else%
+      \ifgre@checklength%
+        \gre@error{#1 cannot be a rubber length.}%
+      \else%
+        \def\gre@prefix{dimen}%
       \fi%
-    }{}%
-  \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{#2}%
-  \relax %
+    \fi%
+    % special check for bar@rubber
+    \IfStrEq*{#1}{bar@rubber}%
+      {%
+        \gre@skip@temp@one = #2\relax%
+        \ifdim\gre@skip@temp@one=0pt\relax\else%
+          \gre@error{bar@rubber cannot have a non-zero base}%
+        \fi%
+      }{}%
+    \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{#2}%
+    \relax %
+  }%
 }
 
 %a macro to use if all you want to do is turn on or off the scaling for a particular distance


### PR DESCRIPTION
Addresses #962
Adds `inherited` option for third argument in `\grecreatedim` and `\grechangedim`, allowing the user to link one distance to another.