### PR TITLE
Add support for hn and hp pitches to nabc.

### DIFF
--- a/doc/GregorioNabcRef.tex
+++ b/doc/GregorioNabcRef.tex
@@ -200,8 +200,8 @@ variant.
 The \textit{pitch descriptor} allows to specify the vertical position of the
 neume.  There are no staves, so the vertical position is only rough.  For
 pitches the same letters as in \texttt{gabc} are used, \texttt{a} through
-\texttt{m}.  If the \textit{pitch descriptor} is missing, the default is
-\texttt{hf}, otherwise it consists of the letter \texttt{h} followed by
+\texttt{n} and \texttt{p}.  If the \textit{pitch descriptor} is missing, the default
+is \texttt{hf}, otherwise it consists of the letter \texttt{h} followed by
 the pitch letter.  Within the \textit{complex glyph descriptor}, each
 \textit{basic glyph descriptor} has its own pitch, but in the current fonts
 there are no glyphs with different relative pitches, so if you use a

--- a/tex/gregoriotex-nabc.lua
+++ b/tex/gregoriotex-nabc.lua
@@ -137,9 +137,9 @@ local gregallparse_base = function (str, idx, len)
   end
   -- Ambitus not handled yet, neither during parsing, nor when
   -- typesetting.
-  -- Optional height, h[a-m].
+  -- Optional height, h[a-np].
   if idx < len and str:sub(idx, idx) == "h" then
-    local p = string.find("abcdefghijklm", str:sub(idx + 1, idx + 1))
+    local p = string.find("abcdefghijklmnp", str:sub(idx + 1, idx + 1))
     if not p then return 1 end
     height = p - 1
     idx = idx + 2


### PR DESCRIPTION
As gabc now supports n and p pitches, this adds corresponding change to nabc as well.
While nabc has no staves, higher pitches than m are occassionally useful, plus consistency is also good.
Shall I submit this against develop or release-4.2?
