### PR TITLE
Build script changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,11 +23,22 @@ EXTRA_DIST = README.md CHANGELOG.md CONTRIBUTING.md CONTRIBUTORS.md \
 			 UPGRADE.md COPYING.md .gregorio-version VersionManager.py \
 			 build.sh install.sh install-gtex.sh
 
+export TOP_LEVEL_MAKE = true
+
+gregorio:
+	make -C src all
+
 fonts: make-fonts
 make-fonts:
 	make -C fonts fonts
 
-export TOP_LEVEL_MAKE = true
+clean-fonts:
+	make -C fonts clean-fonts
+
+doc: pdf
+clean-pdf: clean-doc
+clean-doc:
+	make -C doc clean-doc
 
 gregoriotex.tds.zip: dist install-gtex.sh
 	./install-gtex.sh tds

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@
 #      --build=    : build system for mingw32 cross-compilation
 #      --arch=     : crosscompile for ARCH on OS X
 #      --jobs=     : the number of jobs to run simultaneously in the make step
-#      --force=    : force autoreconf or font building
+#      --force=    : force autoreconf
 #      {other)     : anything else is passed to configure verbatim
       
 # try to find bash, in case the standard shell is not capable of
@@ -45,7 +45,6 @@ MACCROSS=FALSE
 MAKEOPTS=
 OTHERARGS=
 FORCE_AUTORECONF=
-FORCE_FONTS=
 
 until [ -z "$1" ]; do
   case "$1" in
@@ -55,7 +54,6 @@ until [ -z "$1" ]; do
     --arch=*    ) MACCROSS=TRUE; ARCH=`echo $1 | sed 's/--arch=\(.*\)/\1/' ` ;;
     -j*|--jobs=*) MAKEOPTS="$MAKEOPTS $1" ;;
     --force=autoreconf) FORCE_AUTORECONF=TRUE ;;
-    --force=fonts) FORCE_FONTS=TRUE ;;
     *           ) OTHERARGS="$OTHERARGS $1" ;;
   esac
   shift
@@ -124,17 +122,8 @@ echo "Configuring build files; options: $CONFIGURE_ARGS"
 echo
 
 echo "Building Gregorio; options:$MAKEOPTS"
-${MAKE} ${MAKEOPTS} || die "build Gregorio"
+${MAKE} ${MAKEOPTS} all doc || die "build Gregorio"
 echo
-
-if [ "$FORCE_FONTS" = "TRUE" -o ! -e fonts/greciliae.ttf ]
-then
-  echo "Building fonts; options:$MAKEOPTS"
-  cd fonts
-  ${MAKE} ${MAKEOPTS} fonts || die "build fonts"
-  cd ..
-  echo
-fi
 
 if [ "$MINGWCROSS" = "TRUE" ]
 then

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,6 @@ AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], [CFLAGS+=" -Wstrict-prototypes"])
 AX_CHECK_COMPILE_FLAG([-Wdeclaration-after-statement], [CFLAGS+=" -Wdeclaration-after-statement"])
 AX_CHECK_COMPILE_FLAG([-Wall], [CFLAGS+=" -Wall"])
 AX_CHECK_COMPILE_FLAG([-Wextra], [CFLAGS+=" -Wextra"])
-CPPFLAGS+=" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 "
 AX_CHECK_LINK_FLAG([-Wl,-z,relro], [LDFLAGS+=" -Wl,-z,relro"])
 AX_CHECK_LINK_FLAG([-Wl,-z,now], [LDFLAGS+=" -Wl,-z,now"])
 AX_CHECK_LINK_FLAG([-fPIE], [LDFLAGS+=" -fPIE"])
@@ -96,7 +95,11 @@ AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug@<:@=sanitize,coverage@:>@]
             AX_CHECK_COMPILE_FLAG([--coverage], [CFLAGS+=" --coverage"])
             AX_CHECK_LINK_FLAG([--coverage], [LDFLAGS+=" --coverage"])
         ])
+    ], [
+        CPPFLAGS+=" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 "
     ])
+], [
+    CPPFLAGS+=" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 "
 ])
 
 AC_CONFIG_HEADERS([src/config_.h])

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -46,15 +46,19 @@ doc: GregorioRef-$(FILENAME_VERSION).pdf GregorioNabcRef-$(FILENAME_VERSION).pdf
 
 pdf-local: doc
 
-distclean-local:
+clean-doc-intermediate:
 	latexmk -quiet -c -f -jobname=GregorioRef-@FILENAME_VERSION@ GregorioRef.tex
 	latexmk -quiet -c -f -jobname=GregorioNabcRef-@FILENAME_VERSION@ GregorioNabcRef.tex
-	rm -rf _minted* *.gtex *.aux *.gaux
+	rm -rf _minted* *.gtex *.aux *.gaux *.glog
+
+clean-doc: clean-doc-intermediate
+	rm -rf GregorioRef*.pdf
+	rm -rf GregorioRef-* GregorioNabcRef-*
+
+distclean-local: clean-doc-intermediate
+
+maintainer-clean-local: clean-doc
 
 EXTRA_DIST = $(SRCFILES) $(NABCSRCFILES) \
 	     GregorioRef-@FILENAME_VERSION@.pdf \
 	     GregorioNabcRef-@FILENAME_VERSION@.pdf
-
-maintainer-clean-local:
-	rm -rf GregorioRef*.pdf
-	rm -rf GregorioRef-* GregorioNabcRef-*

--- a/fonts/Makefile.am
+++ b/fonts/Makefile.am
@@ -42,6 +42,9 @@ RM = rm
 
 fonts: $(TTFFILES)
 
+clean-fonts:
+	$(RM) -f $(TTFFILES)
+
 %: %.ttf
 
 MAINTAINERCLEANFILES = $(TTFFILES)


### PR DESCRIPTION
Modified build.sh to build docs by default.
Added more build targets to the root Makefile.
Added fine-grained install control to install-gtex.sh.
Disabled FORTIFY when building for debug with -O0.

This change requires the corresponding change in gregorio-project/gregorio-test#216.

Please review and merge if satisfactory.