### PR TITLE
Collapsed strings of whitespace that start with a newline to a single space.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 [Unreleased][unreleased]
 ### Fixed
 - The `900_gregorio.xml` file for Scribus now matches `main-lualatex.tex` again (see [#1087](https://github.com/gregorio-project/gregorio/issues/1087)).
+- Multiple subsequent lines in gabc no longer cause TeX to fail (see [#1111](https://github.com/gregorio-project/gregorio/issues/1111)).
 
 ### Added
 - Nabc now supports pitches `hn` and `hp` in addition to previously supported `ha` through `hm`.

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -106,7 +106,7 @@ double semicolon, (b) multi-line values, which end at a double
 semicolon. */
 
 %%
-<INITIAL>^(\xBB|\xEF|\xBF)* {
+<INITIAL>^(\xBB|\xEF|\xBF)+ {
         /* BOM written by a lot of windows softwares when they write UTF-8 */
     }
 <INITIAL>^[\n\r]+ {
@@ -118,7 +118,7 @@ semicolon. */
 <inicomments>(\n|\r)+ {
         BEGIN(INITIAL);
     }
-<inicomments>[^\n\r]* {
+<inicomments>[^\n\r]+ {
         /* ignored */
     }
 <INITIAL>:(\ )? {
@@ -216,7 +216,11 @@ semicolon. */
                 _("unrecognized character: \"%c\" in definition part"),
                 gabc_score_determination_text[0]);
     }
-<score>[^-\{\}\(\[\]<%]+ {
+<score>[\n\r][\n\r \t]* {
+        gabc_score_determination_lval.text = gregorio_strdup(" ");
+        return CHARACTERS;
+    }
+<score>[^-\{\}\(\[\]<%\n\r]+ {
         gabc_score_determination_lval.text =
                 gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
@@ -326,7 +330,11 @@ semicolon. */
         }
         return SP_END;
     }
-<style>[^<\{\}]* {
+<style>[\n\r][\n\r \t]* {
+        gabc_score_determination_lval.text = gregorio_strdup(" ");
+        return CHARACTERS;
+    }
+<style>[^<\{\}\n\r]+ {
         gabc_score_determination_lval.text =
                 gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
@@ -337,7 +345,7 @@ semicolon. */
 <comments>(\n|\r)+ {
         BEGIN(score);
     }
-<comments>[^\n\r]* {
+<comments>[^\n\r]+ {
         /* ignored */
     }
 <style,score><v> {
@@ -352,7 +360,7 @@ semicolon. */
         }
         return VERB_END;
     }
-<verb>[^<]* {
+<verb>[^<]+ {
         gabc_score_determination_lval.text =
                 gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
@@ -372,7 +380,7 @@ semicolon. */
         BEGIN(alt);
         return ALT_BEGIN;
     }
-<alt>[^<]* {
+<alt>[^<]+ {
         gabc_score_determination_lval.text =
                 gregorio_strdup(gabc_score_determination_text);
         return CHARACTERS;
@@ -400,7 +408,7 @@ semicolon. */
         BEGIN(notes);
         return OPENING_BRACKET;
     }
-<notes>[^|\)]* {
+<notes>[^|\)]+ {
         gabc_score_determination_lval.text =
                 gregorio_strdup(gabc_score_determination_text);
         return NOTES;


### PR DESCRIPTION
Fixes #1111.

One test changes very slightly due to the collapsing, and a test was added to exercise the fix.

Please review and merge if satisfactory.