### PR TITLE
Fixing old bar spacing algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 [Unreleased][unreleased]
 ### Fixed
 - The `900_gregorio.xml` file for Scribus now matches `main-lualatex.tex` again (see [#1087](https://github.com/gregorio-project/gregorio/issues/1087)).
+- Old bar spacing algorithm will no longer separate the text and bar when the bar is preceeded by a puncutm mora (see [#1078](https://github.com/gregorio-project/gregorio/issues/1078)).
 
 ### Added
 - Nabc now supports pitches `hn` and `hp` in addition to previously supported `ha` through `hm`.

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1730,33 +1730,12 @@
   % mora, we kern of the corresponding space. We do it only in the case
   % of a bar in the middle of other notes.
   \ifgre@lastendswithmora %
-    \ifgre@newbarspacing %
-      \ifnum\gre@count@shiftaftermora=0\else\ifnum\gre@count@shiftaftermora=4\else %
-        % new bar spacing takes care of punctum mora on its own, but only when
-        % bar has its own syllable
-        \ifcase #2\or %
-          \gre@unkern@bar@aftermora %
-        \fi %
-      \fi\fi %
-    \else %
-      \ifcase\gre@count@shiftaftermora\or %
-        % barsinsideonly
-        \ifcase #2\or %
-          \gre@unkern@bar@aftermora %
-        \fi %
-      \or %
-        % barsnotextonly
-        \ifcase #3\relax %
-          \gre@unkern@bar@aftermora %
-        \fi %
-      \or %
-        % barsonly
-        \gre@unkern@bar@aftermora %
-      \or\or %
-        % always
+    \ifnum\gre@count@shiftaftermora=0\else\ifnum\gre@count@shiftaftermora=4\else %
+      % if bar doesn’t has its own syllable, then we need to take care of the kern after a punctum mora here
+      \ifcase #2\or %
         \gre@unkern@bar@aftermora %
       \fi %
-    \fi %
+    \fi\fi %
   \fi %
   \gre@newglyphcommon %
   \gre@calculate@glyphraisevalue{\gre@pitch@bar}{0}{}% bar glyphs are made to be at this height

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -910,43 +910,7 @@
   % we start by finding the distance between the text and notes of the previous and the next syllable (as if this syllable didn't exist, for the moment)
   \gre@debugmsg{barspacing}{calculate available space}%
   % first, recomputing \gre@dimen@previousenddifference into \gre@dimen@adjustedpreviousenddifference
-  % taking into account the punctum mora shift
-  \gre@dimen@adjustedpreviousenddifference=\gre@dimen@previousenddifference %
-  % gre@skip@punctummorashift is 0 or the punctum mora shift
-  \gre@skip@punctummorashift=0pt\relax %
-  \ifgre@lastendswithmora %
-    \ifcase\gre@count@shiftaftermora\or\or %
-      \ifdim\wd\gre@box@syllabletext=0pt\relax %
-        % punctum mora adjustment should occur only for bars with no text
-        \gre@get@unkern@aftermora{2}%
-        \advance\gre@dimen@adjustedpreviousenddifference by \gre@skip@punctummorashift %
-      \fi %
-    \or %
-      % punctum mora adjustment only before bars
-      \gre@get@unkern@aftermora{2}%
-      \advance\gre@dimen@adjustedpreviousenddifference by \gre@skip@punctummorashift %
-    \or\or %
-      % punctum mora adjustment always occurs
-      \gre@get@unkern@aftermora{2}%
-      \advance\gre@dimen@adjustedpreviousenddifference by \gre@skip@punctummorashift %
-    \fi %
-  \fi %
-  % now something a bit tricky: as we changed previousenddifference,
-  % we must kern of the difference we created, but no more than
-  % the end of the text:
-  \ifdim\gre@skip@punctummorashift=0pt\else %
-    \gre@debugmsg{barspacing}{adjustment for punctum mora: \the\gre@skip@punctummorashift}%
-    \gre@debugmsg{barspacing}{adjusted previous enddifference (for punctum mora): \the\gre@dimen@adjustedpreviousenddifference}%
-    \ifdim -\gre@skip@punctummorashift < \gre@dimen@previousenddifference %
-      \gre@debugmsg{barspacing}{kern \the\gre@skip@punctummorashift for punctum mora adjustment}%
-      \kern\gre@skip@punctummorashift %
-    \else %
-      \ifdim\gre@dimen@previousenddifference > 0pt\relax %
-        \gre@debugmsg{barspacing}{kern \the\gre@dimen@previousenddifference for punctum mora adjustment}%
-        \kern-\gre@dimen@previousenddifference %
-      \fi %
-    \fi %
-  \fi %
+  \gre@punctummoraadjustment%
   \ifdim\gre@dimen@adjustedpreviousenddifference > 0pt\relax%
     % the notes ended after the text in the previous syllable
     \gre@skip@text@allocation = \gre@dimen@adjustedpreviousenddifference\relax%
@@ -1128,6 +1092,48 @@
   \gre@debugmsg{barspacing}{Correcting syllablefinalskip}%
   \gre@calculate@syllablefinalskip{#1}{\gre@count@temp@one}%
   \gre@debugmsg{barspacing}{syllablefinalskip: \the\gre@skip@syllablefinalskip}%
+}%
+
+
+%punctum mora adjustment calculations
+\def\gre@punctummoraadjustment{%
+  % taking into account the punctum mora shift
+  \gre@dimen@adjustedpreviousenddifference=\gre@dimen@previousenddifference %
+  % gre@skip@punctummorashift is 0 or the punctum mora shift
+  \gre@skip@punctummorashift=0pt\relax %
+  \ifgre@lastendswithmora %
+    \ifcase\gre@count@shiftaftermora\or\or %
+      \ifdim\wd\gre@box@syllabletext=0pt\relax %
+        % punctum mora adjustment should occur only for bars with no text
+        \gre@get@unkern@aftermora{2}%
+        \advance\gre@dimen@adjustedpreviousenddifference by \gre@skip@punctummorashift %
+      \fi %
+    \or %
+      % punctum mora adjustment only before bars
+      \gre@get@unkern@aftermora{2}%
+      \advance\gre@dimen@adjustedpreviousenddifference by \gre@skip@punctummorashift %
+    \or\or %
+      % punctum mora adjustment always occurs
+      \gre@get@unkern@aftermora{2}%
+      \advance\gre@dimen@adjustedpreviousenddifference by \gre@skip@punctummorashift %
+    \fi %
+  \fi %
+  % now something a bit tricky: as we changed previousenddifference,
+  % we must kern of the difference we created, but no more than
+  % the end of the text:
+  \ifdim\gre@skip@punctummorashift=0pt\else %
+    \gre@debugmsg{barspacing}{adjustment for punctum mora: \the\gre@skip@punctummorashift}%
+    \gre@debugmsg{barspacing}{adjusted previous enddifference (for punctum mora): \the\gre@dimen@adjustedpreviousenddifference}%
+    \ifdim -\gre@skip@punctummorashift < \gre@dimen@previousenddifference %
+      \gre@debugmsg{barspacing}{kern \the\gre@skip@punctummorashift for punctum mora adjustment}%
+      \kern\gre@skip@punctummorashift %
+    \else %
+      \ifdim\gre@dimen@previousenddifference > 0pt\relax %
+        \gre@debugmsg{barspacing}{kern \the\gre@dimen@previousenddifference for punctum mora adjustment}%
+        \kern-\gre@dimen@previousenddifference %
+      \fi %
+    \fi %
+  \fi %
 }%
 
 %%%%%%%%%%%%%%%%%%%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -1152,6 +1152,7 @@
     % Old spacing algorithm
     %
     %This is the old algorithm.  I've kept it in case people still want to use it.
+    \gre@punctummoraadjustment%
     % then we check if there is something to write
     \global\let\gre@newlinecommon\gre@newlinecommonsaved %
     \gre@debugmsg{ifdim}{ wd(gre@box@syllabletext) = 0pt}%
@@ -1170,10 +1171,10 @@
       \else %
         \gre@skip@temp@two=0 pt\relax%
       \fi %
-      \gre@debugmsg{ifdim}{ previousenddifference < 0pt}%
-      \ifdim\gre@dimen@previousenddifference < 0 pt\relax%
+      \gre@debugmsg{ifdim}{ adjustedpreviousenddifference < 0pt}%
+      \ifdim\gre@dimen@adjustedpreviousenddifference < 0 pt\relax%
         \advance\gre@skip@temp@two by %
-          \glueexpr(-\gre@dimen@previousenddifference %
+          \glueexpr(-\gre@dimen@adjustedpreviousenddifference %
           + \gre@space@skip@interwordspacetext)\relax%
       \else %
         \advance\gre@skip@temp@two by \gre@space@skip@interwordspacenotes\relax%
@@ -1187,9 +1188,9 @@
       \advance\gre@skip@temp@three by \dimexpr(\wd\gre@box@syllablenotes / -2)\relax %
       % now we have our skipone
       \gre@skip@temp@two=\gre@skip@temp@three %
-      \gre@debugmsg{ifdim}{ previousenddifference < 0pt}%
-      \ifdim\gre@dimen@previousenddifference < 0 pt\relax%
-        \advance\gre@skip@temp@two by \gre@dimen@previousenddifference\relax%
+      \gre@debugmsg{ifdim}{ adjustedpreviousenddifference < 0pt}%
+      \ifdim\gre@dimen@adjustedpreviousenddifference < 0 pt\relax%
+        \advance\gre@skip@temp@two by \gre@dimen@adjustedpreviousenddifference\relax%
       \fi %
       \GreNoBreak %
       \gre@debugmsg{ifdim}{ temp@skip@two > -wd(gre@box@syllablenotes)}%


### PR DESCRIPTION
This change accounts for the presence of a punctum mora before the bar when punctum mora shifts are enabled for bar lines

Fixes #1078 