### PR TITLE
Luatex ja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The `900_gregorio.xml` file for Scribus now matches `main-lualatex.tex` again (see [#1087](https://github.com/gregorio-project/gregorio/issues/1087)).
 - Multiple subsequent lines in gabc no longer cause TeX to fail (see [#1111](https://github.com/gregorio-project/gregorio/issues/1111)).
 - Old bar spacing algorithm will no longer separate the text and bar when the bar is preceeded by a puncutm mora (see [#1078](https://github.com/gregorio-project/gregorio/issues/1078)).
+- Package conflict with luatex-ja has been resolved.  Notes and lyrics should now appear in documents which use the luatex-ja package.  See [#1107](https://github.com/gregorio-project/gregorio/issues/1107).
 
 ### Added
 - Nabc now supports pitches `hn` and `hp` in addition to previously supported `ha` through `hm`.

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -357,7 +357,7 @@
       \gre@additionaltopcustoslinemiddle %
     \fi\fi %
   \fi %
-  \raise \gre@dimen@glyphraisevalue\relax%
+  \raise \gre@dimen@glyphraisevalue%
   \copy\gre@box@temp@width %
   \ifdim\gre@skip@bar@lastskip=0pt\relax %
     % for now we consider we always have a bar after the custos
@@ -400,7 +400,7 @@
         \gre@hskip\gre@space@skip@spacebeforeeolcustos\relax %
         \gre@custosalteration{#1}{#2}%
         \GreNoBreak%
-        \raise \gre@dimen@glyphraisevalue\relax%
+        \raise \gre@dimen@glyphraisevalue%
         \hbox{%
           \gre@pickcustos{#1}{2}\relax %
         }%
@@ -2078,7 +2078,7 @@
     \hbox to 0pt{%
       {%
       \color{grebackgroundcolor}%
-      \raise \gre@dimen@glyphraisevalue\relax%
+      \raise \gre@dimen@glyphraisevalue%
       \copy\gre@box@temp@sign %
       }%
       %\pdfliteral{}% this is a ugly hack for old versions of LuaTeX to work
@@ -2116,7 +2116,7 @@
   \ifgre@hidealtlines %
     \gre@fillhole{#3}%
   \fi %
-  \raise \gre@dimen@glyphraisevalue\relax%
+  \raise \gre@dimen@glyphraisevalue%
   \copy\gre@box@temp@width%
   #6\relax %
   \ifnum#4=0\relax %

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -157,7 +157,7 @@
   #5\relax %
   \kern-\gre@skip@temp@one %
   \gre@calculate@glyphraisevalue{#2}{0}{}%
-  \raise\gre@dimen@glyphraisevalue\relax%
+  \raise\gre@dimen@glyphraisevalue%
   \copy\gre@box@temp@width%
   \ifgre@endofscore\else\ifgre@boxing\else %
     #3%
@@ -842,7 +842,7 @@
     \kern\gre@skip@temp@one %
   \fi%
   #8\relax %
-  \raise\gre@dimen@textlower\relax%
+  \raise\gre@dimen@textlower%
   \copy\gre@box@syllabletext %
   \ifgre@mustdotranslationcenterend%
     % case of end of translation centering, we do it after the typesetting of the text


### PR DESCRIPTION
Fixes #1107.  For some reasons placing a `\relax` at the end of a `\raise` but before the corresponding box causes the box to not be printed when `luatex-ja` is being used.  These `\relax` commands are not strictly necessary as the immediately subsequent `\copy` command is clearly not part of a distance and thus the LuaTeX engine has no problem detecting the end of the argument to `\raise`.  By eliminating them we can avoid this problem.