### PR TITLE
Switched to using autotools to get the alignment of uint32_t.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,8 @@ AC_PROG_YACC
 AC_CHECK_TOOL([RC], [windres], [no])
 AM_CONDITIONAL([HAVE_RC], [test x$RC != xno])
 
+AC_CHECK_ALIGNOF(uint32_t)
+
 AX_CHECK_COMPILE_FLAG([-std=gnu89], [CFLAGS+=" -std=gnu89"])
 dnl until flex gets their act together, use pedantic instead of pedantic-errors
 AX_CHECK_COMPILE_FLAG([-pedantic], [CFLAGS+=" -pedantic"])

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -37,15 +37,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef HAVE_STDALIGN_H
-#include <stdalign.h>
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Wc11-extensions"
-#endif
-#else
-#define alignof(x) sizeof(x)
-#endif
-
 #ifdef WORDS_BIGENDIAN
 #define SWAP(n) (n)
 #else
@@ -167,7 +158,7 @@ void sha1_process_bytes(const void *buffer, size_t len, struct sha1_ctx *ctx)
     if (len >= 64) {
         /* architecture and data-specific; LCOV_EXCL_START */
 #if !_STRING_ARCH_unaligned
-#define UNALIGNED_P(p) ((uintptr_t) (p) % alignof (uint32_t) != 0)
+#define UNALIGNED_P(p) ((uintptr_t) (p) % ALIGNOF_UINT32_T != 0)
         if (UNALIGNED_P(buffer)) {
             while (len > 64) {
                 sha1_process_block(memcpy(ctx->buffer, buffer, 64), 64, ctx);


### PR DESCRIPTION
Fixes #1185.

Per @rpspringuel, I created this pull request so we can test to see if the fix works on our various development environments (especially our build environments).

This works on my system under both gcc and clang, though I do use older versions of these compilers.  No tests change.