### PR TITLE
Restored missing raise for alteration holes.

### DIFF
--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -605,11 +605,13 @@ Count which stores the current staff size.
 
 Default: 17 (approximately the size found in graduals)
 
-\macroname{\textbackslash gre@fillhole}{\#1}{gregoriotex-signs.tex}
+\macroname{\textbackslash gre@fillhole}{\#1\#2}{gregoriotex-signs.tex}
 Macro to fill the hole in a glyph so that staff lines do not show through a hole in it.
 
 \begin{argtable}
   \#1 & Gregorio\TeX\ char & character to use to fill the hole\\
+  \#1 & \texttt{0} & the hole is being filled for an alteration\\
+  \#1 & \texttt{1} & the hole is being filled for a cavum glyph\\
 \end{argtable}
 
 \macroname{\textbackslash gre@calculate@notesaligncenter}{\#1}{gregoriotex-syllable.tex}

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -2083,12 +2083,14 @@
 % 2 if previous glyph is a cavum (which is the most interesting information)
 \gre@count@lastglyphiscavum=0
 
-% the argument is the character with which we fill the hole, and we suppose that
+% #1 is the character with which we fill the hole, and we suppose that
 % isonaline and glyphraisevalue are correctly set.
-\def\gre@fillhole#1{%
+% #2 is 0 for alteration or 1 for normal cavum
+\def\gre@fillhole#1#2{%
   \ifgre@boxing\else %
     \global\gre@count@lastglyphiscavum=1\relax %
     \setbox\gre@box@temp@sign=\hbox{#1}%
+    \ifcase#2\raise \gre@dimen@glyphraisevalue\fi%
     \hbox to 0pt{%
       {%
       \color{grebackgroundcolor}%
@@ -2127,7 +2129,7 @@
   \kern-\gre@skip@temp@one %
   \gre@calculate@glyphraisevalue{#1}{0}{}%
   \ifgre@hidealtlines %
-    \gre@fillhole{#3}%
+    \gre@fillhole{#3}{0}%
   \fi %
   \raise \gre@dimen@glyphraisevalue%
   \copy\gre@box@temp@width%
@@ -2197,7 +2199,7 @@
 
 \def\GreCavum#1{%
   \ifgre@hidepclines%
-    \gre@fillhole{{\gre@font@music@hole\csname GreHoleCP#1\endcsname}}%
+    \gre@fillhole{{\gre@font@music@hole\csname GreHoleCP#1\endcsname}}{1}%
   \fi %
   {\gre@font@music@hollow\csname GreHollowCP#1\endcsname}%
 }%


### PR DESCRIPTION
Fixes #1192.

I should have recognized this bug in the sign-styles test, but I missed it.  That expectation is updated.  I also added the test from the issue.

Please review and merge if satisfactory.