### PR TITLE
Copyright notices and installation manifests for documentation

### DIFF
--- a/doc/Appendix_Font_Tables.tex
+++ b/doc/Appendix_Font_Tables.tex
@@ -1,5 +1,23 @@
 % !TEX root = GregorioRef.tex
 % !TEX program = LuaLaTeX+se
+%
+% Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+%
+% This file is part of Gregorio.
+%
+% Gregorio is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Gregorio is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+%
 \begin{landscape}
 
 \section{Font Glyph Tables}\label{glyphtable}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1,5 +1,23 @@
 % !TEX root = GregorioRef.tex
 % !TEX program = LuaLaTeX+se
+%
+% Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+%
+% This file is part of Gregorio.
+%
+% Gregorio is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Gregorio is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+%
 \section{User Controls}
 
 These functions are available to the user to customize elements of the

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1,5 +1,23 @@
 % !TEX root = GregorioRef.tex
 % !TEX program = LuaLaTeX+se
+%
+% Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+%
+% This file is part of Gregorio.
+%
+% Gregorio is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Gregorio is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+%
 \section{Gregorio Controls}
 
 These functions are the ones written by gregorio to the gtex file.

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1,5 +1,23 @@
 % !TEX root = GregorioRef.tex
 % !TEX program = LuaLaTeX+se
+%
+% Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+%
+% This file is part of Gregorio.
+%
+% Gregorio is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Gregorio is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+%
 \section{Gregorio\TeX{} Controls}
 
 These functions are the ones used by Gregorio\TeX{} internally as it

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -1,5 +1,23 @@
 % !TEX root = GregorioRef.tex
 % !TEX program = LuaLaTeX+se
+%
+% Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+%
+% This file is part of Gregorio.
+%
+% Gregorio is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Gregorio is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+%
 \section{The GABC File}
 
 gabc is a simple notation based exclusively on ASCII characters that

--- a/doc/GregorioNabcRef.tex
+++ b/doc/GregorioNabcRef.tex
@@ -1,5 +1,22 @@
 % !TEX program = LuaLaTeX+se
-
+%
+% Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+%
+% This file is part of Gregorio.
+%
+% Gregorio is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Gregorio is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+%
 \documentclass[a4paper]{article}
 \usepackage{color}
 \usepackage[margin=1cm]{geometry}

--- a/doc/GregorioRef.lua
+++ b/doc/GregorioRef.lua
@@ -1,3 +1,20 @@
+-- Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+--
+-- This file is part of Gregorio.
+--
+-- Gregorio is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- Gregorio is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+
 local P = lpeg.P
 local R = lpeg.R
 local C = lpeg.C

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -1,4 +1,22 @@
 % !TEX program = LuaLaTeX+se
+%
+% Copyright (C) 2006-2016 The Gregorio Project (see CONTRIBUTORS.md)
+%
+% This file is part of Gregorio.
+%
+% Gregorio is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Gregorio is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
+%
 \documentclass[12pt,a4paper]{article}
 \usepackage[titletoc,toc,title]{appendix}
 \usepackage{fontspec}

--- a/install-gtex.sh
+++ b/install-gtex.sh
@@ -70,9 +70,7 @@ LATEXFILES=(tex/gregorio*.sty)
 TTFFILES=(gregorio.ttf greciliae.ttf granapadano.ttf gregorio-op.ttf
           greciliae-op.ttf granapadano-op.ttf greextra.ttf gregall.ttf
           gresgmodern.ttf)
-DOCFILES=(doc/Appendix*.tex doc/Command*.tex doc/Gabc.tex
-          doc/*Ref.tex doc/*Ref.lua doc/*.gabc
-          doc/Gregorio*Ref.pdf)
+DOCFILES=(doc/*.tex doc/*.lua doc/*.gabc doc/*.pdf doc/README.md)
 EXAMPLEFILES=(examples/FactusEst.gabc examples/PopulusSion.gabc
               examples/main-lualatex.tex examples/debugging.tex)
 FONTSRCFILES=(gregorio-base.sfd granapadano-base.sfd greciliae-base.sfd

--- a/macosx/create_package.sh
+++ b/macosx/create_package.sh
@@ -74,9 +74,10 @@ else
     make doc
     cd ..
     cp doc/*.tex $EXTRASDIR/doc/
-    cp doc/*.pdf $EXTRASDIR/doc/
-    cp doc/*.md $EXTRASDIR/doc/
+    cp doc/*.lua $EXTRASDIR/doc/
     cp doc/*.gabc $EXTRASDIR/doc/
+    cp doc/*.pdf $EXTRASDIR/doc/
+    cp doc/README.md $EXTRASDIR/doc/
     cp -r contrib/ $EXTRASDIR/contrib
     find $EXTRASDIR/contrib -name 'Makefile*' -delete
     cp examples/*.tex $EXTRASDIR/examples/

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -57,8 +57,8 @@ Source: "../CHANGELOG.md"; DestDir: "{app}";
 Source: "../README.md"; DestDir: "{app}";
 Source: "../CONTRIBUTORS.md"; DestDir: "{app}";
 Source: "../UPGRADE.md"; DestDir: "{app}";
-Source: "../doc/Gregorio*Ref.pdf"; DestDir: "{app}";
-Source: "../doc/Gregorio*Ref.pdf"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
+Source: "../doc/*.pdf"; DestDir: "{app}";
+Source: "../doc/*.pdf"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
 Source: "../COPYING.md"; DestDir: "{app}";
 Source: "../contrib/system-setup.bat"; DestDir: "{app}";
 Source: "../contrib/*"; DestDir: "{app}\contrib"; Excludes: "Makefile*,TeXShop\*,*.command";
@@ -74,13 +74,10 @@ Source: "../fonts/*.ttf"; DestDir: "{app}\texmf\fonts\truetype\public\gregoriote
 Source: "../fonts/*.sfd"; DestDir: "{app}\texmf\fonts\source\gregoriotex";
 Source: "../fonts/*.py"; DestDir: "{app}\texmf\fonts\source\gregoriotex";
 Source: "../fonts/README.md"; DestDir: "{app}\texmf\fonts\source\gregoriotex";
-Source: "../README.md"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
-Source: "../doc/Appendix*.tex"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
-Source: "../doc/Command*.tex"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
-Source: "../doc/Gabc.tex"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
-Source: "../doc/*Ref.tex"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
-Source: "../doc/*Ref.lua"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
+Source: "../doc/*.tex"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
+Source: "../doc/*.lua"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
 Source: "../doc/*.gabc"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
+Source: "../doc/README.md"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
 
 [InstallDelete]
 Type: files; Name: "{app}\gregorio.exe"


### PR DESCRIPTION
~~An attempt to fix #1188.~~

~~This works around the font loader issue, allowing the document to be built under TeX Live 2016.~~

~~However, doing it this way causes a segfault under (Gentoo's packaged version of) TeX Live 2015 unless the luatex font cache is cleared between runs of lualatex or if I `\input` the Dominican font table before the "normal" font table.  Since this doesn't happen under 2016, the bug is obviously fixed.~~

~~Is it good enough to abandon building the document under 2015, knowing that we build it anyway for distribution?  If so, then I think this is ready for review/merge.~~

Edit: this pull request now only adds the copyright notices and corrects the installation manifests.