### PR TITLE
Suppressed a z0 custos separated from a line break (z) by only bars/clefs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 [Unreleased][unreleased]
 ## Changed
 - Notes are now left-aligned as if all clefs had the same width as the largest clef in the score. You can get previous behavior back with `\grebolshiftcleftype{current}`, or temporary force alignment until the end of a score with `\grelocalbolshiftcleftype`. See Documentation of these functions and [#1189](https://github.com/gregorio-project/gregorio/issues/1189).
+- If only bars and clefs are between an explicit custos `(z0)` and a line break `(z)`, the explicit custos will be suppressed (see [1190](https://github.com/gregorio-project/gregorio/issues/1190)).
 
 ### Added
 - More cavum shapes are now available.  To use them, simply add `r` in gabc to any note in a glyph.  See [#844](https://github.com/gregorio-project/gregorio/issues/844).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 [Unreleased][unreleased]
 ## Changed
 - Notes are now left-aligned as if all clefs had the same width as the largest clef in the score. You can get previous behavior back with `\grebolshiftcleftype{current}`, or temporary force alignment until the end of a score with `\grelocalbolshiftcleftype`. See Documentation of these functions and [#1189](https://github.com/gregorio-project/gregorio/issues/1189).
-- If only bars and clefs are between an explicit custos `(z0)` and a line break `(z)`, the explicit custos will be suppressed (see [1190](https://github.com/gregorio-project/gregorio/issues/1190)).
+- A clef change immediately before a line break `(z)` will now typeset the new clef at the beginning of the next line.  An explicit custos `(z0)` immediately before such a clef change (or separated by only a bar) will be suppressed.  See [1190](https://github.com/gregorio-project/gregorio/issues/1190).
 
 ### Added
 - More cavum shapes are now available.  To use them, simply add `r` in gabc to any note in a glyph.  See [#844](https://github.com/gregorio-project/gregorio/issues/844).

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -1116,7 +1116,7 @@ void gabc_det_notes_finish(void)
     }
 [\t\r\n]+ /* ignore ends of line and tabs */;
 z0  {
-        gregorio_add_custo_as_note(&current_note, &notes_lloc);
+        gregorio_add_custos_as_note(&current_note, &notes_lloc);
     }
 z   {
         gregorio_add_end_of_line_as_note(&current_note, false, false, false,

--- a/src/gabc/gabc-score-determination.h
+++ b/src/gabc/gabc-score-determination.h
@@ -53,10 +53,11 @@ YY_DECL;
 
 #define YYLTYPE gregorio_scanner_location
 
-void fix_custos(gregorio_score *score_to_check);
-bool check_score_integrity(gregorio_score *score_to_check);
-bool check_infos_integrity(gregorio_score *score_to_check);
-void determine_oriscus_orientation(const gregorio_score *score);
-void determine_punctum_inclinatum_orientation(const gregorio_score *score);
+void gabc_suppress_extra_custos_at_linebreak(gregorio_score *score);
+void gabc_fix_custos_pitches(gregorio_score *score_to_check);
+bool gabc_check_score_integrity(gregorio_score *score_to_check);
+bool gabc_check_infos_integrity(gregorio_score *score_to_check);
+void gabc_determine_oriscus_orientation(const gregorio_score *score);
+void gabc_determine_punctum_inclinatum_orientation(const gregorio_score *score);
 
 #endif

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -197,7 +197,7 @@ static void end_definitions(void)
 {
     int i;
 
-    gregorio_assert_only(check_infos_integrity(score), end_definitions,
+    gregorio_assert_only(gabc_check_infos_integrity(score), end_definitions,
             "can't determine valid infos on the score");
 
     elements = (gregorio_element **) gregorio_malloc(number_of_voices *
@@ -505,16 +505,17 @@ gregorio_score *gabc_read_score(FILE *f_in, bool point_and_click)
      * initialized) */
     gabc_score_determination_parse();
     if (!score->legacy_oriscus_orientation) {
-        determine_oriscus_orientation(score);
+        gabc_determine_oriscus_orientation(score);
     }
-    determine_punctum_inclinatum_orientation(score);
+    gabc_determine_punctum_inclinatum_orientation(score);
     gregorio_fix_initial_keys(score, gregorio_default_clef);
     rebuild_score_characters();
-    fix_custos(score);
+    gabc_suppress_extra_custos_at_linebreak(score);
+    gabc_fix_custos_pitches(score);
     gabc_det_notes_finish();
     free_variables();
     /* then we check the validity and integrity of the score we have built. */
-    if (!check_score_integrity(score)) {
+    if (!gabc_check_score_integrity(score)) {
         gregorio_message(_("unable to determine a valid score from file"),
                 "gabc_read_score", VERBOSITY_ERROR, 0);
     }

--- a/src/struct.c
+++ b/src/struct.c
@@ -230,7 +230,7 @@ void gregorio_add_end_of_line_as_note(gregorio_note **current_note,
     element->u.other.eol_forces_custos_on = eol_forces_custos_on;
 }
 
-void gregorio_add_custo_as_note(gregorio_note **current_note,
+void gregorio_add_custos_as_note(gregorio_note **current_note,
         const gregorio_scanner_location *const loc)
 {
     gregorio_note *element = create_and_link_note(current_note, loc);
@@ -897,22 +897,22 @@ static __inline void free_one_element(gregorio_element *element)
     free(element);
 }
 
-static void gregorio_free_one_element(gregorio_element **element)
+void gregorio_free_one_element(gregorio_element **element)
 {
     gregorio_element *next = NULL;
+    gregorio_element *to_free;
     gregorio_not_null_ptr(element, gregorio_free_one_element, return);
-    if ((*element)->next) {
-        (*element)->next->previous = NULL;
-        next = (*element)->next;
+    to_free = *element;
+    if (to_free->next) {
+        to_free->next->previous = NULL;
+        next = to_free->next;
     }
-    if ((*element)->previous) {
-        /* this doesn't currently happen, but it's safer to leave this in */
-        /* LCOV_EXCL_START */
-        (*element)->previous->next = NULL;
+    if (to_free->previous) {
+        to_free->previous->next = NULL;
     }
     /* The previous line is probably optimized out */
     /* LCOV_EXCL_STOP */
-    free_one_element(*element);
+    free_one_element(to_free);
     *element = next;
 }
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -58,6 +58,7 @@ unsigned short tex_position_id = 0;
 gregorio_clef_info gregorio_default_clef = {
     /*.line =*/ 3,
     /*.secondary_line =*/ 0,
+    /*.pitch_difference =*/ 0,
     /*.clef =*/ CLEF_C,
     /*.flatted =*/ false,
     /*.secondary_clef =*/ CLEF_C, /* not used since secondary_line is 0 */

--- a/src/struct.h
+++ b/src/struct.h
@@ -32,6 +32,7 @@
 #ifndef STRUCT_H
 #define STRUCT_H
 
+#include <assert.h>
 #include "enum_generator.h"
 #include "bool.h"
 #include "sha1.h"
@@ -386,6 +387,7 @@ typedef struct gregorio_extra_info {
 typedef struct gregorio_clef_info {
     signed char line;
     signed char secondary_line;
+    signed char pitch_difference;
     ENUM_BITFIELD(gregorio_clef) clef:1;
     bool flatted:1;
     ENUM_BITFIELD(gregorio_clef) secondary_clef:1;
@@ -941,6 +943,19 @@ static __inline const gregorio_glyph *gregorio_previous_non_texverb_glyph(
 static __inline char gregorio_clef_to_char(gregorio_clef clef)
 {
     return (clef == CLEF_C)? 'c' : 'f';
+}
+
+static __inline signed char gregorio_adjust_pitch_into_staff(
+        const gregorio_score *score, signed char pitch)
+{
+    while (pitch < LOWEST_PITCH) {
+        pitch += 7;
+    }
+    while (pitch > score->highest_pitch) {
+        pitch -= 7;
+    }
+    assert(pitch >= LOWEST_PITCH && pitch <= score->highest_pitch);
+    return pitch;
 }
 
 #endif

--- a/src/struct.h
+++ b/src/struct.h
@@ -548,9 +548,8 @@ typedef struct gregorio_element {
     /* index to a string containing a possible TeX verbatim; necessary during
      * structure generation. */
     unsigned short texverb;
-    /* type can have the values GRE_ELEMENT, GRE_BAR, GRE_C_KEY_CHANGE,
-     * GRE_F_KEY_CHANGE, GRE_END_OF_LINE, GRE_SPACE, GRE_TEXVERB_ELEMENT
-     * or GRE_NLBA */
+    /* type can have the values GRE_ELEMENT, GRE_BAR, GRE_CLEF, GRE_CUSTOS,
+     * GRE_END_OF_LINE, GRE_SPACE, GRE_TEXVERB_ELEMENT or GRE_NLBA */
     ENUM_BITFIELD(gregorio_type) type:8;
 } gregorio_element;
 
@@ -823,6 +822,7 @@ void gregorio_add_voice_info(gregorio_voice_info **current_voice_info);
 void gregorio_free_voice_infos(gregorio_voice_info *voice_info);
 void gregorio_free_one_note(gregorio_note **note);
 void gregorio_free_one_glyph(gregorio_glyph **glyph);
+void gregorio_free_one_element(gregorio_element **element);
 void gregorio_free_score(gregorio_score *score);
 void gregorio_free_characters(gregorio_character *current_character);
 void gregorio_go_to_first_character(const gregorio_character **character);
@@ -837,7 +837,7 @@ void gregorio_add_unpitched_element_as_glyph(gregorio_glyph **current_glyph,
 void gregorio_add_end_of_line_as_note(gregorio_note **current_note,
         bool eol_ragged, bool eol_forces_custos, bool eol_forces_custos_on,
         const gregorio_scanner_location *loc);
-void gregorio_add_custo_as_note(gregorio_note **current_note,
+void gregorio_add_custos_as_note(gregorio_note **current_note,
         const gregorio_scanner_location *loc);
 void gregorio_add_manual_custos_as_note(gregorio_note **current_note,
         signed char pitch, const gregorio_scanner_location *loc);

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -149,6 +149,7 @@
 %% #4 int: height of the flat of first clef, 3 for no flat
 %% #5, #6, #7 = #1, #2, #3 for second clef
 \def\GreSetLinesClef#1#2#3#4#5#6#7{%
+  \gre@save@clef{#1}{#2}{#4}{#5}{#6}{#7}%
   \gre@localleftbox{%
     \gre@skip@temp@four = \gre@dimen@additionalleftspace\relax%
     \kern\gre@skip@temp@four %


### PR DESCRIPTION
Fixes #1190.

Some tests (that happen to employ this sequence of figures) change, and a test was added to exercise all the variants in the issue post.

Please review and merge if satisfactory.