### PR TITLE
Appended FILE_VERSION to the gregorio executable file name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - With thanks to Claudio Beccari (@OldClaudio), adding a commentary no longer generates a bad `\hbox` during TeX processing (see [#1202](https://github.com/gregorio-project/gregorio/issues/1202)).
 
 ### Changed
-- In order to facilitate installation alongside TeX Live, the version number is now appended to the gregorio executable file name.  If you are running the executable directly in your custom scripts, you will need to change them to include the version number.  If you are not using the TeX-Live-packaged version of Gregorio, you will probably need to use the `--shell-escape` option when compiling your `.tex` files.  See UPGRADE.md and [#1197](https://github.com/gregorio-project/gregorio/issues/1197) for more information.
+- In order to facilitate installation alongside TeX Live, the version number is now appended to the gregorio executable file name.  If you are running the executable directly in your custom scripts, you will need to change them to include the version number.  If you are not using the TeX-Live-packaged version of Gregorio, you will probably need to use the `--shell-escape` option when compiling your `.tex` files.  Note that in TeX Live 2016, which includes Gregorio 4.1.1, the executable filename does not include the version number, though that will change starting with TeX Live 2017.  See UPGRADE.md and [#1197](https://github.com/gregorio-project/gregorio/issues/1197) for more information.
 
 
 ## [4.2.0-rc2] - 2016-07-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - When the note after an oriscus is at the same pitch, the oriscus will now point downwards by default (see [#1177](https://github.com/gregorio-project/gregorio/issues/1177)).
 - With thanks to Claudio Beccari (@OldClaudio), adding a commentary no longer generates a bad `\hbox` during TeX processing (see [#1202](https://github.com/gregorio-project/gregorio/issues/1202)).
 
+### Changed
+- In order to facilitate installation alongside TeX Live, the version number is now appended to the gregorio executable file name.  If you are running the executable directly in your custom scripts, you will need to change them to include the version number.  If you are not using the TeX-Live-packaged version of Gregorio, you will probably need to use the `--shell-escape` option when compiling your `.tex` files.  See UPGRADE.md and [#1197](https://github.com/gregorio-project/gregorio/issues/1197) for more information.
 
 
 ## [4.2.0-rc2] - 2016-07-05

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,14 @@ This file contains instructions to upgrade to a new release of Gregorio.
 
 ## 4.2
 
+### Executable file name
+
+In order to facilitate installation alongside TeX Live, the version number is now appended to the gregorio executable file name.  In version 4.2.0, the filename is gregorio-4.2.0.  If you run the executable directly, you will need to modify your procedures and/or scripts to use the new name.  Alternately, creating a symbolic link, if your system supports it, may work for you.
+
+If you auto-compile or force-compile your GABC files and are *not* using the Gregorio packaged with TeX Live, you will probably need to use the `--shell-escape` option when compiling your `.tex` files.  Alternately, you can add the new filename to your system's `shell_escape_commands` TeX option.
+
+Unforunately, there appears to be no easier way to let a user-installed Gregorio coexist with the TeX-Live-packaged Gregorio.
+
 ### Stemmed oriscus flexus orientation
 
 As of version 4.2, the orientation of the stemmed oriscus flexus `(gOe)` is consistent with the unstemmed oriscus flexus `(goe)` in that the oriscus points downwards (since the note which follows is of lower pitch).  If you prefer the oriscus to point upwards, you will need to use the `1` modifier (as in `(gO1e)`), which will force an upward orientation of the oriscus.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,7 @@ In order to facilitate installation alongside TeX Live, the version number is no
 
 If you auto-compile or force-compile your GABC files and are *not* using the Gregorio packaged with TeX Live, you will probably need to use the `--shell-escape` option when compiling your `.tex` files.  Alternately, you can add the new filename to your system's `shell_escape_commands` TeX option.
 
-Unforunately, there appears to be no easier way to let a user-installed Gregorio coexist with the TeX-Live-packaged Gregorio.
+Unforunately, there appears to be no easier way to let a user-installed Gregorio coexist with the TeX-Live-packaged Gregorio.  Please note: in TeX Live 2016, which includes Gregorio 4.1.1, the executable filename does not include the version number, though that will change starting with TeX Live 2017.
 
 ### Stemmed oriscus flexus orientation
 

--- a/VersionManager.py
+++ b/VersionManager.py
@@ -44,6 +44,7 @@ VERSION_FILE = '.gregorio-version'
 GREGORIO_FILES = ["configure.ac",
                   "windows/gregorio-resources.rc",
                   "macosx/Gregorio.pkgproj",
+                  "macosx/douninstall.sh",
                   "windows/gregorio.iss",
                   "doc/GregorioRef.tex",
                   "tex/gregoriotex.sty",
@@ -61,6 +62,7 @@ GREGORIO_FILES = ["configure.ac",
                   "tex/gregoriotex-nabc.lua",
                   "tex/gregoriosyms.sty",
                   "fonts/squarize.py",
+                  "contrib/gregorio-scribus.lua",
                  ]
 
 def get_parser():

--- a/contrib/gregorio-scribus.lua
+++ b/contrib/gregorio-scribus.lua
@@ -22,7 +22,7 @@ This program allows gregorio to be integrated in Scribus.
 
 require"lfs"
 
-local gregoriobin = 'gregorio'
+local gregoriobin = 'gregorio-4_2_0-rc2' -- FILENAME_VERSION
 local lualatexbin = "lualatex"
 
 local function basename(name)

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1095,7 +1095,7 @@ Macro which holds the point-and-click file name.
 \macroname{\textbackslash gre@gregoriotexluaversion}{}{gregoriotex-main.tex}
 Macro to hold the version number of \emph{gregoriotex.lua} so that it can be checked for consistency.
 
-\macroname{\textbackslash gre@gregorioversion}{}{gregoriotex-main.tex}
+\macroname{\textbackslash gre@gregoriotexversion}{}{gregoriotex-main.tex}
 Macro to hold the version number of Gregorio\TeX\ so that it can be checked for consistency.
 
 \macroname{\textbackslash gre@leftfill}{}{gregoriotex-main.tex}

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -21,14 +21,16 @@ SRCFILES = GregorioRef.tex Command_Index_gregorio.tex \
 		   Gabc.tex Appendix_Font_Tables.tex GregorioRef.lua factus.gabc
 NABCSRCFILES = GregorioNabcRef.tex veni.gabc
 
+GREGORIO=gregorio-$(FILENAME_VERSION)
+
 .NOTPARALLEL:
 
 # I know these rules look wrong, but they must not depend on anything that
 # gets generated or make distcheck will fail.
 
 GregorioRef.pdf: $(SRCFILES)
-	$(MAKE) $(AM_MAKEFLAGS) -C ../src gregorio
-	../src/gregorio -o factus.gtex $(<D)/factus.gabc
+	$(MAKE) $(AM_MAKEFLAGS) -C ../src $(GREGORIO)
+	../src/$(GREGORIO) -o factus.gtex $(<D)/factus.gabc
 	TEXINPUTS=$(<D):$(<D)/../tex: LUAINPUTS=$(<D):$(<D)/../tex: \
 		 TTFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -f -recorder -pdf \
 		 -interaction=nonstopmode -halt-on-error \
@@ -36,8 +38,8 @@ GregorioRef.pdf: $(SRCFILES)
 		 -jobname=GregorioRef $< || rm $@
 
 GregorioNabcRef.pdf: $(NABCSRCFILES)
-	$(MAKE) $(AM_MAKEFLAGS) -C ../src gregorio
-	../src/gregorio -o veni.gtex $(<D)/veni.gabc
+	$(MAKE) $(AM_MAKEFLAGS) -C ../src $(GREGORIO)
+	../src/$(GREGORIO) -o veni.gtex $(<D)/veni.gabc
 	TEXINPUTS=$(<D):$(<D)/../tex: LUAINPUTS=$(<D):$(<D)/../tex: \
 		 TTFONTS=$(<D)/../fonts: PATH=../src:${PATH} latexmk -recorder -pdf \
 		 -interaction=nonstopmode -halt-on-error \

--- a/macosx/create_package.sh
+++ b/macosx/create_package.sh
@@ -121,7 +121,7 @@ packagesbuild Uninstall-Gregorio.pkgproj
 # care about the version of gregorio.
 VERSION=`echo $VERSION | sed s:[.]:_:g`
 mv $BUILDDIR/Gregorio.pkg ../Gregorio-$VERSION.pkg
-mv $BUILDDIR/Uninstall-Gregorio.pkg ../
+mv $BUILDDIR/Uninstall-Gregorio-$VERSION.pkg ../
 
 # Now we clean up
 if $clean; then

--- a/macosx/douninstall.sh
+++ b/macosx/douninstall.sh
@@ -20,7 +20,7 @@ GREFONTDIR="$TEXMFLOCAL/fonts/truetype/public/gregoriotex"
 GREFONTSOURCE="$TEXMFLOCAL/fonts/source/gregoriotex"
 GREDOCDIR="$TEXMFLOCAL/doc/luatex/gregoriotex"
 
-rm "$BINDIR/gregorio"
+rm "$BINDIR/gregorio-4_2_0-rc2" # FILENAME_VERSION
 rm "$PKGCONFIGDIR/gregorio.pc"
 rm -rf "$GREINCLUDEDIR"
 rm -rf "$GRETEXDIR"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,20 +16,16 @@
 # along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/gabc  -I$(top_srcdir)/src/dump  -I$(top_srcdir)/src/gregoriotex
-AM_CFLAGS =
+AM_CFLAGS = $(KPSE_CFLAGS)
+LDADD = $(KPSE_LIBS)
 
-gregorio_CFLAGS = $(KPSE_CFLAGS)
-gregorio_LDADD = $(KPSE_LIBS)
-
-bin_PROGRAMS = gregorio
-gregorio_SOURCES = gregorio-utils.c characters.c characters.h \
-					messages.c messages.h struct.c struct.h struct_iter.h \
-					enum_generator.h unicode.c unicode.h sha1.c sha1.h \
-					support.c support.h config.h bool.h plugins.h \
-					utf8strings.h dump/dump.c \
-					gregoriotex/gregoriotex-write.c \
-					gregoriotex/gregoriotex-position.c \
-					gregoriotex/gregoriotex.h
+bin_PROGRAMS = gregorio-$(FILENAME_VERSION)
+gregorio___FILENAME_VERSION__SOURCES = \
+	gregorio-utils.c characters.c characters.h messages.c messages.h struct.c \
+	struct.h struct_iter.h enum_generator.h unicode.c unicode.h sha1.c sha1.h \
+	support.c support.h config.h bool.h plugins.h utf8strings.h dump/dump.c \
+	gregoriotex/gregoriotex-write.c gregoriotex/gregoriotex-position.c \
+	gregoriotex/gregoriotex.h
 
 @MK@ifneq ($(wildcard ../.git),)
 @MK@  _tag_ = $(shell git describe --exact-match HEAD 2>/dev/null)
@@ -47,41 +43,33 @@ gregorio_SOURCES = gregorio-utils.c characters.c characters.h \
 @MK@endif
 
 # gabc files
-gregorio_SOURCES += gabc/gabc-elements-determination.c gabc/gabc-write.c \
-					gabc/gabc-glyphs-determination.c gabc/gabc.h \
-					gabc/gabc-score-determination.h \
-					gabc/gabc-score-determination.c \
-					gabc/gabc-score-determination-y.h \
-					gabc/gabc-score-determination-y.c \
-					gabc/gabc-score-determination-l.h \
-					gabc/gabc-score-determination-l.c \
-					gabc/gabc-notes-determination-l.c \
-					vowel/vowel.h vowel/vowel.c vowel/vowel-rules.h \
-					vowel/vowel-rules-l.h vowel/vowel-rules-l.c \
-					vowel/vowel-rules-y.h vowel/vowel-rules-y.c
+gregorio___FILENAME_VERSION__SOURCES += \
+	gabc/gabc-elements-determination.c gabc/gabc-write.c \
+	gabc/gabc-glyphs-determination.c gabc/gabc.h \
+	gabc/gabc-score-determination.h gabc/gabc-score-determination.c \
+	gabc/gabc-score-determination-y.h gabc/gabc-score-determination-y.c \
+	gabc/gabc-score-determination-l.h gabc/gabc-score-determination-l.c \
+	gabc/gabc-notes-determination-l.c vowel/vowel.h vowel/vowel.c \
+	vowel/vowel-rules.h  vowel/vowel-rules-l.h vowel/vowel-rules-l.c \
+	vowel/vowel-rules-y.h vowel/vowel-rules-y.c
 
 EXTRA_DIST = encode_utf8strings.c utf8strings.h.in utf8strings.h \
-					gabc/gabc-notes-determination.l \
-					gabc/gabc-notes-determination-l.c \
-					gabc/gabc-score-determination.h \
-					gabc/gabc-score-determination.y \
-					gabc/gabc-score-determination-y.h \
-					gabc/gabc-score-determination-y.c \
-					gabc/gabc-score-determination.l \
-					gabc/gabc-score-determination-l.h \
-					gabc/gabc-score-determination-l.c \
-					vowel/vowel-rules.l \
-					vowel/vowel-rules-l.h vowel/vowel-rules-l.c \
-					vowel/vowel-rules.y \
-					vowel/vowel-rules-y.h vowel/vowel-rules-y.c
+			 gabc/gabc-notes-determination.l gabc/gabc-notes-determination-l.c \
+			 gabc/gabc-score-determination.h gabc/gabc-score-determination.y \
+			 gabc/gabc-score-determination-y.h \
+			 gabc/gabc-score-determination-y.c gabc/gabc-score-determination.l \
+			 gabc/gabc-score-determination-l.h \
+			 gabc/gabc-score-determination-l.c vowel/vowel-rules.l \
+			 vowel/vowel-rules-l.h vowel/vowel-rules-l.c vowel/vowel-rules.y \
+			 vowel/vowel-rules-y.h vowel/vowel-rules-y.c
 
 if HAVE_RC
 # Windows resources (see windows/README.md)
 gregorio-resources.o: ../windows/gregorio-resources.rc ../windows/gregorio.ico
 	$(RC) $(RCFLAGS) $< -o $@
 
-gregorio_SOURCES += ../windows/gregorio-resources.rc ../windows/gregorio.ico
-gregorio_LDADD += gregorio-resources.o
+gregorio___FILENAME_VERSION__SOURCES += ../windows/gregorio-resources.rc ../windows/gregorio.ico
+LDADD += gregorio-resources.o
 endif
 
 gabc/gabc-score-determination-y.c: gabc/gabc-score-determination.y
@@ -138,16 +126,13 @@ clean-local:
 	find . -name '*.gcno' -print | xargs rm -f --
 	find . -name '*.gcda' -print | xargs rm -f --
 
-BUILT_SOURCES = utf8strings.h \
-					gabc/gabc-notes-determination-l.c \
-					gabc/gabc-score-determination-l.c \
-					gabc/gabc-score-determination-l.h \
-					gabc/gabc-score-determination-y.c \
-					gabc/gabc-score-determination-y.h \
-					vowel/vowel-rules-l.c \
-					vowel/vowel-rules-l.h \
-					vowel/vowel-rules-y.c \
-					vowel/vowel-rules-y.h
+BUILT_SOURCES = utf8strings.h gabc/gabc-notes-determination-l.c \
+				gabc/gabc-score-determination-l.c \
+				gabc/gabc-score-determination-l.h \
+				gabc/gabc-score-determination-y.c \
+				gabc/gabc-score-determination-y.h vowel/vowel-rules-l.c \
+				vowel/vowel-rules-l.h vowel/vowel-rules-y.c \
+				vowel/vowel-rules-y.h
 
 CLEANFILES = encode_utf8strings${EXEEXT}
 MAINTAINERCLEANFILES = $(BUILT_SOURCES)

--- a/tex/gregoriosyms.sty
+++ b/tex/gregoriosyms.sty
@@ -39,7 +39,7 @@
 
 % The version of gregorio. All gregoriotex*.tex files must have the same.
 % All gtex files must also have the same version.
-\xdef\gre@gregorioversion{4.2.0-rc2}% GREGORIO_VERSION - VersionManager.py
+\xdef\gre@gregoriotexversion{4.2.0-rc2}% GREGORIO_VERSION - VersionManager.py
 
 \providecommand{\gre@declarefileversion}[2]{\relax}
 
@@ -102,11 +102,11 @@
 \long\def\gre@ifnotlatex#1{}
 \input gregoriotex-symbols.tex
 
-\xdef\gre@gregoriotexluaversion{\directlua{tex.write(gregoriotex.get_gregorioversion())}}%
+\xdef\gre@gregoriotexluaversion{\directlua{tex.write(gregoriotex.get_gregoriotexluaversion())}}%
 
 % Test to make sure that gregoriotex.lua is of the same version.
-\IfStrEq*{\gre@gregoriotexluaversion}{\gre@gregorioversion}{}{%else
-    \gre@error{uncoherent file versions: gregoriosyms.sty is in version \number\gre@gregorioversion \space\space while gregoriotex.lua is in version \gre@gregoriotexluaversion}}%
+\IfStrEq*{\gre@gregoriotexluaversion}{\gre@gregoriotexversion}{}{%else
+    \gre@error{uncoherent file versions: gregoriosyms.sty is in version \number\gre@gregoriotexversion \space\space while gregoriotex.lua is in version \gre@gregoriotexluaversion}}%
 
 %%%%%%%%%
 %% Color definitions

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -159,7 +159,7 @@
 
 % The version of gregorio. All gregoriotex*.tex files must have the same.
 % All gtex files must also have the same version.
-\xdef\gre@gregorioversion{4.2.0-rc2}% GREGORIO_VERSION - VersionManager.py
+\xdef\gre@gregoriotexversion{4.2.0-rc2}% GREGORIO_VERSION - VersionManager.py
 
 % first some macros to allow checks for version:
 % Tests that all gregoriotex files are of the same version.
@@ -167,8 +167,8 @@
 % #2 is the version
 
 \def\gre@declarefileversion#1#2{%
-  \IfStrEq*{#2}{\gre@gregorioversion}{}{%else
-    \gre@error{uncoherent file versions: gregoriotex-main.tex is in version \number\gre@gregorioversion \space\space while #1 is in version \number#2}}%
+  \IfStrEq*{#2}{\gre@gregoriotexversion}{}{%else
+    \gre@error{Version Inconsistency!\MessageBreak gregoriotex-main.tex is in version \number\gre@gregoriotexversion \space\space while #1 is in version \number#2}}%
 }%
 
 % Macro called by scores.
@@ -177,9 +177,9 @@
 % #1 is the version of GregorioTeX the score is made for.
 
 \def\GregorioTeXAPIVersion#1{%
-  \StrBefore{\gre@gregorioversion}{.}[\gre@gregoriomajorversion]%
+  \StrBefore{\gre@gregoriotexversion}{.}[\gre@gregoriomajorversion]%
   \IfBeginWith{#1}{\gre@gregoriomajorversion}{\relax}{%else
-    \gre@error{GregorioTeX is in version \gre@gregorioversion \space\space while a score you included requires version #1. Please recompile your scores}}%
+    \gre@error{Version Inconsistency!\MessageBreak GregorioTeX is in version \gre@gregoriotexversion \space\space while a score you included requires version #1. Please recompile your scores}}%
 }%
 
 \RequireLuaModule{gregoriotex}%
@@ -189,11 +189,11 @@
   \directlua{gregoriotex.init(arg, true)}%
 \fi %
 
-\xdef\gre@gregoriotexluaversion{\directlua{tex.write(gregoriotex.get_gregorioversion())}}%
+\xdef\gre@gregoriotexluaversion{\directlua{tex.write(gregoriotex.get_gregoriotexluaversion())}}%
 
 % Test to make sure that gregoriotex.lua is of the same version.
-\IfStrEq*{\gre@gregoriotexluaversion}{\gre@gregorioversion}{}{%else
-    \gre@error{uncoherent file versions: gregoriotex-main.tex is in version \number\gre@gregorioversion \space\space while gregoriotex.lua is in version \gre@gregoriotexluaversion}}%
+\IfStrEq*{\gre@gregoriotexluaversion}{\gre@gregoriotexversion}{}{%else
+    \gre@error{Version Inconsistency!\MessageBreak gregoriotex-main.tex is in version \number\gre@gregoriotexversion \space\space while gregoriotex.lua is in version \gre@gregoriotexluaversion}}%
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -864,7 +864,7 @@ local function direct_gabc(gabc, header, allow_deprecated)
   os.remove(snippet_logname)
 end
 
-local function get_gregorioversion()
+local function get_gregoriotexluaversion()
   return internalversion
 end
 
@@ -1287,7 +1287,7 @@ gregoriotex.include_score              = include_score
 gregoriotex.atScoreEnd                 = atScoreEnd
 gregoriotex.atScoreBeginning           = atScoreBeginning
 gregoriotex.check_font_version         = check_font_version
-gregoriotex.get_gregorioversion        = get_gregorioversion
+gregoriotex.get_gregoriotexluaversion  = get_gregoriotexluaversion
 gregoriotex.map_font                   = map_font
 gregoriotex.init_variant_font          = init_variant_font
 gregoriotex.change_score_glyph         = change_score_glyph

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -37,6 +37,8 @@ local err, warn, info, log = luatexbase.provides_module({
     license            = "GPLv3+",
 })
 
+local gregorio_exe = 'gregorio-4_2_0-rc2' -- FILENAME_VERSION
+
 gregoriotex.module = { err = err, warn = warn, info = info, log = log }
 
 local format = string.format
@@ -709,14 +711,14 @@ local function compile_gabc(gabc_file, gtex_file, glog_file, allow_deprecated)
     extra_args = extra_args..' -D'
   end
 
-  local cmd = string.format("gregorio %s -W -o %s -l %s %s",
-      extra_args, gtex_file, glog_file, gabc_file)
+  local cmd = string.format("%s %s -W -o %s -l %s %s", gregorio_exe, extra_args,
+      gtex_file, glog_file, gabc_file)
   res = os.execute(cmd)
   if res == nil then
     err("\nSomething went wrong when executing\n    '%s'.\n"
         .."shell-escape mode may not be activated. Try\n\n"
         .."%s --shell-escape %s.tex\n\n"
-        .."See the documentation of gregorio or your TeX\n"
+        .."See the documentation of Gregorio or your TeX\n"
         .."distribution to automatize it.",
         cmd, tex.formatname, tex.jobname)
   elseif res ~= 0 then
@@ -735,7 +737,7 @@ local function compile_gabc(gabc_file, gtex_file, glog_file, allow_deprecated)
       glog:close()
     end
     err("\nAn error occured when compiling the score file\n"
-        .."'%s' with gregorio.\nPlease check your score file.", gabc_file)
+        .."'%s' with %s.\nPlease check your score file.", gabc_file, gregorio_exe)
   else
     -- open the gtex file for writing so that LuaTeX records output to it
     -- when the -recorder option is used
@@ -830,14 +832,14 @@ local function direct_gabc(gabc, header, allow_deprecated)
   gabc = gabc:match('^()%s*$') and '' or gabc:match('^%s*(.*%S)')
   f:write('name:direct-gabc;\n'..(header or '')..'\n%%\n'..gabc:gsub('\\par ', '\n'))
   f:close()
-  local cmd = string.format('gregorio -W %s-S -l %s %s', deprecated, snippet_logname,
-      snippet_filename)
+  local cmd = string.format('%s -W %s-S -l %s %s', gregorio_exe, deprecated,
+      snippet_logname, snippet_filename)
   local p = io.popen(cmd, 'r')
   if p == nil then
     err("\nSomething went wrong when executing\n    %s\n"
         .."shell-escape mode may not be activated. Try\n\n"
         .."%s --shell-escape %s.tex\n\n"
-        .."See the documentation of gregorio or your TeX\n"
+        .."See the documentation of Gregorio or your TeX\n"
         .."distribution to automatize it.", cmd, tex.formatname, tex.jobname)
   else
     tex.print(p:read("*a"):explode('\n'))

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -48,7 +48,8 @@ Name: "{app}\texmf\doc\luatex\gregoriotex"
 Name: "{app}\texmf\doc\luatex\gregoriotex\examples"
 
 [Files]
-Source: "../src/gregorio.exe"; DestDir: "{app}\bin";
+; PARSE_VERSION_FILE_NEXTLINE
+Source: "../src/gregorio-4_2_0-rc2.exe"; DestDir: "{app}\bin";
 Source: "gregorio.ico"; DestDir: "{app}";
 Source: "install.lua"; DestDir: "{app}";
 Source: "uninstall.lua"; DestDir: "{app}";

--- a/windows/gregorio.iss
+++ b/windows/gregorio.iss
@@ -84,10 +84,10 @@ Source: "../doc/README.md"; DestDir: "{app}\texmf\doc\luatex\gregoriotex";
 Type: files; Name: "{app}\gregorio.exe"
 
 [Run]
-Filename: "texlua.exe"; Parameters: """{app}\install.lua"" > ""{app}\install.log"""; StatusMsg: "Adding files to texmf tree..."; Description: "Add files to texmf tree"; Flags: postinstall runascurrentuser ; WorkingDir: "{app}";
+Filename: "texlua.exe"; Parameters: """{app}\install.lua"" > ""{app}\install.log"""; StatusMsg: "Adding files to texmf tree..."; Description: "Add files to texmf tree"; Flags: postinstall runascurrentuser ; WorkingDir: "{app}"
 
 [UninstallRun]
-Filename: "texlua.exe"; Parameters: """{app}\uninstall.lua"" > ""{app}\uninstall.log"""; WorkingDir: "{app}"; RunOnceId: "Remove_texmf" ; Flags: runascurrentuser
+Filename: "texlua.exe"; Parameters: """{app}\uninstall.lua"" > ""{userdesktop}\uninstall.log"""; WorkingDir: "{app}"; RunOnceId: "Remove_texmf"; Flags: runascurrentuser
 
 [Tasks]
 Name: modifypath; Description: "Add gregorio to PATH"; GroupDescription: "New Installs and Upgrades from 4.0 and earlier"; Flags: checkedonce

--- a/windows/uninstall.lua
+++ b/windows/uninstall.lua
@@ -54,27 +54,6 @@ end
 local texmflocal = fixpath(kpse.expand_var("$TEXMFLOCAL"))..pathsep
 local texmfdist = fixpath(kpse.expand_var("$TEXMFDIST"))..pathsep
 
-function remove_executable()
-  print("Removing gregorio.exe...")
-  if string.find(string.lower(texmfdist), "texlive") then
-    texmfbin = fixpath(texmfdist.."../bin/win32/")
-    rm_one(texmfbin.."gregorio.exe")
-  elseif string.find(string.lower(texmfdist), "miktex") then
-    --[[ MiKTeX uses slightly different paths for the location of it's bin
-    directory for 32 and 64 bit versions.  Our current install solution is to
-    copy the executable to both of these locations, so we have to delete from
-    both as well.
-    --]]
-    texmfbin_32 = fixpath(texmfdist.."/miktex/bin/")
-    texmfbin_64 = fixpath(texmfdist.."/miktex/bin/x64/")
-    rm_one(texmfbin_32.."gregorio.exe")
-    rm_one(texmfbin_64.."gregorio.exe")
-  else
-    print("I don't recognize your TeX distribution.")
-    print("You may need to remove gregorio.exe manually.")
-  end
-end
-
 function remove_tex_files()
   if string.find(string.lower(texmfdist),"texlive") then
     remove_texmf_install()
@@ -96,8 +75,10 @@ end
 
 local texmf_install_dirs = {
   fixpath(texmflocal.."tex/luatex/gregoriotex"),
+  fixpath(texmflocal.."tex/lualatex/gregoriotex"),
   fixpath(texmflocal.."fonts/truetype/public/gregoriotex"),
   fixpath(texmflocal.."fonts/source/gregoriotex"),
+  fixpath(texmflocal.."doc/luatex/gregoriotex/examples"),
   fixpath(texmflocal.."doc/luatex/gregoriotex"),
 }
 
@@ -132,7 +113,7 @@ local function rmdirrecursive(dir)
       rm_one(dir..pathsep..filename)
     end
   end
-  os.spawn("rmdir"..dir)
+  os.execute("rmdir "..dir)
 end
 
 function remove_texmf_install()
@@ -156,7 +137,6 @@ function remove_texmf_install()
 end
 
 function main_install()
-  remove_executable()
   remove_tex_files()
   print("Uninstall script complete.")
   print("Press return to continue...")


### PR DESCRIPTION
Fixes #1197.

I think I've covered everything *except* the system-setup scripts.  It's possible to modify those to look for any version of the gregorio executable on the PATH, but I'm not entirely sure how to do that from the Windows batch file, and it might not be a good idea to make this particular script too complicated.

The test harness was also updated to handle this.

Please review and merge if satisfactory (inasmuch as it covers).