### PR TITLE
System setup

### DIFF
--- a/contrib/system-setup.bat
+++ b/contrib/system-setup.bat
@@ -169,21 +169,33 @@ for %%G in (%files%) do (
 	)
 )
 
-:: Unversion files
-set files=gregorio-vowels.dat ^
-gregoriotex-ictus.tex ^
-gsp-default.tex ^
-greciliae.ttf ^
+:: Font Files
+set files=greciliae.ttf ^
 greciliae-op.ttf ^
 greextra.ttf ^
 gregorio.ttf ^
 gregorio-op.ttf ^
+granapadano.ttf ^
+granapadano-op.ttf ^
+gregall.ttf
+
+for %%G in (%files%) do (
+	echo ##### %%G >> %output%
+	for /f "delims=" %%H in ('kpsewhich -all %%G') do (
+		set loc=%%H
+		set loc=!loc:/=\!
+		echo !loc! >> %output%
+		otfinfo --font-version !loc! >> %output% 2>&1
+	)
+)
+
+:: Unversioned and Obsolete Files
+set files=gregorio-vowels.dat ^
+gsp-default.tex ^
+gregoriotex-ictus.tex ^
 gresym.ttf ^
 parmesan.ttf ^
 parmesan-op.ttf ^
-granapadano.ttf ^
-granapadano-op.ttf ^
-gregall.ttf ^
 gregsmodern.ttf
 
 for %%G in (%files%) do (

--- a/contrib/system-setup.bat
+++ b/contrib/system-setup.bat
@@ -1,5 +1,5 @@
 @echo off
-SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEEXTENSIONS EnableDelayedExpansion
 
 set output="%TEMP%\system-setup.log"
 
@@ -79,33 +79,99 @@ echo. >> %output%
 echo. >> %output%
 
 echo ###	Gregorio Setup >> %output%
-echo ####	Version >> %output%
-echo. >> %output%
-gregorio -V >> %output% 2>&1
-echo. >> %output%
-echo #### 	Location >> %output%
-echo. >> %output%
-@for %%e in (%PATHEXT%) do @for %%i in (gregorio%%e) do @if NOT "%%~$PATH:i"=="" echo %%~$PATH:i >> %output% 2>&1
-echo. >> %output%
+echo ####	Locations and Versions >> %output%
+for /f "delims=" %%G in ('where /f gregorio*') do (
+  echo %%G >> %output%
+  for /f "delims=" %%H in ('%%G -V') do echo %%H >> %output% 2>&1
+  echo. >> %output%
+)
 echo ####	GregorioTeX Locations >> %output%
 echo. >> %output%
 
-set files=gregorio-vowels.dat ^
-gregoriosyms.sty ^
+:: Files using GREGORIO_VERSION in {}
+set files=gregoriosyms.sty ^
 gregoriotex-chars.tex ^
 gregoriotex-main.tex ^
-gregoriotex-ictus.tex ^
-gregoriotex-nabc.lua ^
 gregoriotex-nabc.tex ^
-gregoriotex-signs.lua ^
 gregoriotex-signs.tex ^
 gregoriotex-spaces.tex ^
 gregoriotex-syllable.tex ^
-gregoriotex-symbols.lua ^
-gregoriotex-symbols.tex ^
-gregoriotex.lua ^
-gregoriotex.sty ^
-gregoriotex.tex ^
+gregoriotex-symbols.tex
+
+for %%G in (%files%) do (
+	echo ##### %%G >> %output%
+	for /f "delims=" %%H in ('kpsewhich -all %%G') do (
+		set loc=%%H
+		set loc=!loc:/=\!
+		echo !loc! >> %output%
+		for /f "delims=" %%I in ('findstr /r "GREGORIO_VERSION" !loc!') do set ver=%%I
+		set ver=!ver:*{=!
+		set ver=!ver:*{=!
+		set trash=}!ver:*}=!
+		call set ver=%%ver:!trash!=%%
+		echo !ver! >> %output% 2>&1
+		set ver=
+	)
+)
+
+:: Files using GREGORIO_VERSION in spaces
+set files=gregoriotex-nabc.lua ^
+gregoriotex-signs.lua ^
+gregoriotex-symbols.lua
+
+for %%G in (%files%) do (
+	echo ##### %%G >> %output%
+	for /f "delims=" %%H in ('kpsewhich -all %%G') do (
+		set loc=%%H
+		set loc=!loc:/=\!
+		echo !loc! >> %output%
+		for /f "delims=" %%I in ('findstr /r "GREGORIO_VERSION" !loc!') do set ver=%%I
+		set ver=!ver:*N =!
+		echo !ver! >> %output% 2>&1
+		set ver=
+	)
+)
+
+:: Files using GREGORIO_VERSION in ''
+set files=gregoriotex.lua
+
+for %%G in (%files%) do (
+	echo ##### %%G >> %output%
+	for /f "delims=" %%H in ('kpsewhich -all %%G') do (
+		set loc=%%H
+		set loc=!loc:/=\!
+		echo !loc! >> %output%
+		for /f "delims=" %%I in ('findstr /r "GREGORIO_VERSION" !loc!') do set ver=%%I
+		set ver=!ver:*'=!
+		set trash='!ver:*'=!
+		call set ver=%%ver:!trash!=%%
+		echo !ver! >> %output% 2>&1
+		set ver=
+	)
+)
+
+:: Files using PARSE_VERSION_DATE_LTX
+set files=gregoriotex.sty ^
+gregoriotex.tex
+
+for %%G in (%files%) do (
+	echo ##### %%G >> %output%
+	for /f "delims=" %%H in ('kpsewhich -all %%G') do (
+		set loc=%%H
+		set loc=!loc:/=\!
+		echo !loc! >> %output%
+		for /f "delims=" %%I in ('findstr /r "PARSE_VERSION_DATE_LTX" !loc!') do set ver=%%I
+		set ver=!ver:*v=!
+		set trash=G!ver:*G=!
+		call set ver=%%ver:!trash!=%%
+		echo !ver! >> %output% 2>&1
+		set ver=
+	)
+)
+
+:: Unversion files
+set files=gregorio-vowels.dat ^
+gregoriotex-ictus.tex ^
 gsp-default.tex ^
 greciliae.ttf ^
 greciliae-op.ttf ^
@@ -122,8 +188,13 @@ gregsmodern.ttf
 
 for %%G in (%files%) do (
 	echo ##### %%G >> %output%
-	kpsewhich -all %%G >> %output% 2>&1
+	for /f "delims=" %%H in ('kpsewhich -all %%G') do (
+		set loc=%%H
+		set loc=!loc:/=\!
+		echo !loc! >> %output%
+	)
 )
+
 echo. >> %output%
 echo ####	kpsewhich --all -engine luatex -progname lualatex gregoriotex.sty >> %output%
 kpsewhich --all -engine luatex -progname lualatex gregoriotex.sty >> %output% 2>&1

--- a/contrib/system-setup.command
+++ b/contrib/system-setup.command
@@ -172,7 +172,7 @@ do
 	locations=`kpsewhich -all $f`
 	for loc in $locations; do
 	  echo $loc >> $OUTPUT 2>&1
-	  otfinfo --info $loc | grep -m 1 -o '[0-9]*\.[0-9]*\.[0-9]*-*[betarc]*[0-9]*' >> $OUTPUT 2>&1
+	  otfinfo --font-version $loc >> $OUTPUT 2>&1
 	done
 done
 

--- a/contrib/system-setup.command
+++ b/contrib/system-setup.command
@@ -107,22 +107,21 @@ echo "" >> $OUTPUT
 echo "" >> $OUTPUT
 
 echo "###	Gregorio Setup" >> $OUTPUT
-echo "####	Version" >> $OUTPUT
+echo "####	Locations and Versions" >> $OUTPUT
 echo "" >> $OUTPUT
-gregorio -V >> $OUTPUT 2>&1
-echo "" >> $OUTPUT
-echo "#### 	Location" >> $OUTPUT
-echo "" >> $OUTPUT
-which -a gregorio >> $OUTPUT 2>&1
-echo "" >> $OUTPUT
+progs=`compgen -cbka -A function 'gregorio'`
+for prog in $progs; do
+  which -a $prog >> $OUTPUT 2>&1
+  $prog -V >> $OUTPUT 2>&1
+  echo "" >> $OUTPUT
+done
 echo "####	GregorioTeX Locations" >> $OUTPUT
 echo "" >> $OUTPUT
 
-files="gregorio-vowels.dat
-gregoriosyms.sty
+# Files using GREGORIO_VERSION
+files="gregoriosyms.sty
 gregoriotex-chars.tex
 gregoriotex-main.tex
-gregoriotex-ictus.tex
 gregoriotex-nabc.lua
 gregoriotex-nabc.tex
 gregoriotex-signs.lua
@@ -131,9 +130,35 @@ gregoriotex-spaces.tex
 gregoriotex-syllable.tex
 gregoriotex-symbols.lua
 gregoriotex-symbols.tex
-gregoriotex.lua
-gregoriotex.sty
-gregoriotex.tex
+gregoriotex.lua"
+
+for f in $files
+do
+	echo "##### $f" >> $OUTPUT
+	locations=`kpsewhich -all $f`
+	for loc in $locations; do
+	  echo $loc >> $OUTPUT 2>&1
+	  grep -m 1 'GREGORIO_VERSION' $loc | grep -o '[0-9]*\.[0-9]*\.[0-9]*-*[betarc]*[0-9]*' >> $OUTPUT 2>&1
+	done
+done
+
+# Files using PARSE_VERSION_DATE_LTX
+files="gregoriotex.sty
+gregoriotex.tex"
+
+for f in $files
+do
+	echo "##### $f" >> $OUTPUT
+	locations=`kpsewhich -all $f`
+	for loc in $locations; do
+	  echo $loc >> $OUTPUT 2>&1
+	  grep -m 1 'PARSE_VERSION_DATE_LTX' $loc | grep -o '[0-9]*\.[0-9]*\.[0-9]*-*[betarc]*[0-9]*' >> $OUTPUT 2>&1
+	done
+done
+
+# Unversioned Files
+files="gregorio-vowels.dat
+gregoriotex-ictus.tex
 gsp-default.tex
 greciliae.ttf
 greciliae-op.ttf
@@ -154,11 +179,13 @@ do
 	kpsewhich -all $f >> $OUTPUT 2>&1
 done
 
+
 echo "" >> $OUTPUT
-echo "####	kpsewhich --all -engine luatex -progname lualatex gregoriotex.sty" >> $OUTPUT
+echo "###	LuaTeX Double Checks" >> $OUTPUT
+echo "#### kpsewhich --all -engine luatex -progname lualatex gregoriotex.sty" >> $OUTPUT
 kpsewhich --all -engine luatex -progname lualatex gregoriotex.sty >> $OUTPUT 2>&1
 echo "" >> $OUTPUT
-echo "####	kpsewhich --all -engine luatex gregoriotex.tex" >> $OUTPUT
+echo "#### kpsewhich --all -engine luatex gregoriotex.tex" >> $OUTPUT
 kpsewhich --all -engine luatex gregoriotex.tex >> $OUTPUT 2>&1
 echo "" >> $OUTPUT
 echo "" >> $OUTPUT

--- a/contrib/system-setup.command
+++ b/contrib/system-setup.command
@@ -156,21 +156,33 @@ do
 	done
 done
 
-# Unversioned Files
-files="gregorio-vowels.dat
-gregoriotex-ictus.tex
-gsp-default.tex
-greciliae.ttf
+# Font Files
+files="greciliae.ttf
 greciliae-op.ttf
 greextra.ttf
 gregorio.ttf
 gregorio-op.ttf
+granapadano.ttf
+granapadano-op.ttf
+gregall.ttf"
+
+for f in $files
+do
+	echo "##### $f" >> $OUTPUT
+	locations=`kpsewhich -all $f`
+	for loc in $locations; do
+	  echo $loc >> $OUTPUT 2>&1
+	  otfinfo --info $loc | grep -m 1 -o '[0-9]*\.[0-9]*\.[0-9]*-*[betarc]*[0-9]*' >> $OUTPUT 2>&1
+	done
+done
+
+# Unversioned and Obsolete Files
+files="gregorio-vowels.dat
+gsp-default.tex
+gregoriotex-ictus.tex
 gresym.ttf
 parmesan.ttf
 parmesan-op.ttf
-granapadano.ttf
-granapadano-op.ttf
-gregall.ttf
 gregsmodern.ttf"
 
 for f in $files

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -31,7 +31,7 @@
 \input luatexbase.sty%
 \input luamplib.sty%
 \input luaotfload.sty%
-\input xstring.sty%
+\input xstring.tex%
 \input color.tex%
 \input graphicx.tex % for \resizebox
 

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -31,9 +31,9 @@
 \input luatexbase.sty%
 \input luamplib.sty%
 \input luaotfload.sty%
-\input graphicx.tex % for \resizebox
 \input xstring.sty%
-\input color.sty%
+\input color.tex%
+\input graphicx.tex % for \resizebox
 
 \def\gre@error#1{\begingroup%
 \def\MessageBreak{^^J}%


### PR DESCRIPTION
This PR does two things:

1. The system-setup scripts are modified to account for multiple versions of gregorio residing on the same system (which happens when you upgrade gregorio in a TeXLive2016 installation).  The scripts not only show the locations of all versions of each file, but should also grab the version numbers out of them (where appropriate) so that you can see which is where.  This finishes #1197
2. PlainTeX package loading order is modified to work around the bug noticed as a result of #1199.  The bug in color/graphicx has been reported, but this means we don't have to wait for the fix for our tests to be working again.

It should be noted that the modified Windows batch file makes use of `where` which means that it is no longer 100% compatible with XP.  [Microsoft claims that XP knows `where`](https://technet.microsoft.com/en-us/library/cc753148(v=ws.11).aspx), but based on [other information I've found](http://stackoverflow.com/questions/304319/is-there-an-equivalent-of-which-on-the-windows-command-line) the 32-bit version of XP doesn't actually know the command ([though it can be added](http://dllexedown.com/bbs/search.php?sfl=wr_subject&stx=where.exe&sop=and&gr_id=&mininum=0&maxnum=10000&onetable=04_xp64_en)).  Given that XP is now 2+ years past end of life, I'm comfortable dropping full support for it at this point.