### PR TITLE
Passed height arguments to \GreNABCNeumes.

### DIFF
--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1095,12 +1095,14 @@ Macro used to prevent a line break from occurring at a given position.
 \macroname{\textbackslash GreScoreId}{}{gregoriotex-main.tex}
 A Lua\TeX\ attribute which designates a unique identifier for each score.
 
-\macroname{\textbackslash GreNABCNeumes}{\#1\#2}{gregoriotex-nabc.tex}
+\macroname{\textbackslash GreNABCNeumes}{\#1\#2\#3\#4}{gregoriotex-nabc.tex}
 Macro to print a nabc character above the lines.
 
 \begin{argtable}
   \#1 & integer & the line on which the character should appear (currently unused)\\
   \#2 & string & The \texttt{nabc} syntax which indicates what neumes are to be printed\\
+  \#3 & integer & The high pitch of the notes covered by the nabc character(s).\\
+  \#4 & integer & The low pitch of the notes covered by the nabc character(s).\\
 \end{argtable}
 
 \macroname{\textbackslash GreNABCChar}{\#1}{gregoriotex-nabc.tex}

--- a/tex/gregoriotex-nabc.tex
+++ b/tex/gregoriotex-nabc.tex
@@ -50,7 +50,7 @@
   \endgre@style@nabc%
 }}
 
-\def\GreNABCNeumes#1#2{%
+\def\GreNABCNeumes#1#2#3#4{%
   \GreSetNabcAboveLines{\GreNABCChar{#2}}%
 }
 


### PR DESCRIPTION
Fixes #1181.

The `#3` and `#4` arguments to `\GreNABCNeumes` are presently ignored.  Tests don't change.  I didn't add a CHANGELOG entry since there is no user-visible effect to this change.

Please review and merge if satisfactory.