### PR TITLE
Added the <clear> gabc tag, which sends \GreClearSyllableText to TeX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - 9 new St. Gall neume glyphs have been added to the `gregall` font.
 - 5 new St. Gall neume glyphs have been added to the `gresgmodern` font.
 - install-gtex.sh now generates uninstall-gtex.sh, which can be used to uninstall the TeX portion of the installation when GregorioTeX was installed from source.
+- A `<clear>` tag may be added to a syllable to indicate that its text should not overlap any previous syllable (see [#1029](https://github.com/gregorio-project/gregorio/issues/1029)).
 
 ### Removed
 - `initial-style` gabc header, supplanted by the `\gresetinitiallines` TeX command.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -186,6 +186,9 @@ Macro for typesetting a circulus.
   \#2 & string  & Type of glyph the circulus is attached to.  See \nameref{EpisemaSpecial} argument for description of options.\\
 \end{argtable}
 
+\macroname{\textbackslash GreClearSyllableText}{\#1\#2}{gregoriotex-syllable.tex}
+Macro indicating that the text in this syllable should not overlap any previous syllable.
+
 \macroname{\textbackslash GreColored}{\#1}{gregoriotex.sty \textup{and} gregoriotex.tex}
 Colors argument (a string) in \verb=gregoriocolor.=  Corresponds to ``<c></c>'' tags in gabc.  Does nothing in Plain \TeX\ because color is not supported there.
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1788,6 +1788,9 @@ Number of lines the initial takes up.  Currently limited to 0, 1, or 2.  Not cur
 \macroname{\textbackslash ifgre@rewritethissyllable}{}{gregoriotex-syllable.tex}
 Boolean indicating that a syllable should be rewritten to improve ligature rendering.
 
+\macroname{\textbackslash ifgre@textcleared}{}{gregoriotex-syllable.tex}
+Boolean indicating that the text of this syllable should not overlap any previous syllable.
+
 \subsection{Boxes}
 
 Boxes are used to store elements of the score before they are printed for the purposes of reusing them and/or measuring them in order to determine their appropriate placement.

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -361,6 +361,9 @@ semicolon. */
 <score>\] {
         return TRANSLATION_END;
     }
+<score><[\n\r \t]*clear[\n\r \t]*\/?[\n\r \t]*> {
+        return CLEAR;
+    }
 <score>\( {
         BEGIN(notes);
         return OPENING_BRACKET;

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -108,6 +108,7 @@ static bool started_first_word;
 static struct sha1_ctx digester;
 static gabc_style_bits styles;
 static bool generate_point_and_click;
+static bool clear_syllable_text;
 
 /* punctum_inclinatum_orientation maintains the running punctum inclinatum
  * orientation in order to decide if the glyph needs to be cut when a punctum
@@ -173,6 +174,7 @@ static void initialize_variables(bool point_and_click)
     styles = 0;
     punctum_inclinatum_orientation = S_PUNCTUM_INCLINATUM_UNDETERMINED;
     generate_point_and_click = point_and_click;
+    clear_syllable_text = false;
 }
 
 /*
@@ -367,7 +369,7 @@ static void close_syllable(YYLTYPE *loc)
     gregorio_add_syllable(&current_syllable, number_of_voices, elements,
             first_text_character, first_translation_character, position,
             abovelinestext, translation_type, no_linebreak_area, euouae, loc,
-            started_first_word);
+            started_first_word, clear_syllable_text);
     if (!score->first_syllable) {
         /* we rebuild the first syllable if we have to */
         score->first_syllable = current_syllable;
@@ -398,6 +400,7 @@ static void close_syllable(YYLTYPE *loc)
         elements[i] = NULL;
     }
     current_element = NULL;
+    clear_syllable_text = false;
 }
 
 /* a function called when we see a [, basically, all characters are added to
@@ -597,6 +600,7 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
 %token NLBA_B NLBA_E
 %token EUOUAE_B EUOUAE_E
 %token NABC_CUT NABC_LINES
+%token CLEAR
 
 %%
 
@@ -852,6 +856,9 @@ character:
     | style_end
     | linebreak_area
     | euouae
+    | CLEAR {
+        clear_syllable_text = true;
+    }
     ;
 
 text_hyphen:

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3412,21 +3412,23 @@ static __inline void write_syllable_point_and_click(FILE *const f,
 }
 
 static void write_syllable_text(FILE *f, const char *const syllable_type,
-        const bool forced_center, const gregorio_character *text,
+        const gregorio_syllable *const syllable,
         const bool ignored __attribute__((unused)))
 {
     if (syllable_type != NULL) {
-        fprintf(f, "%s{%s\\GreSetThisSyllable", syllable_type,
-                forced_center? "\\GreGABCForceCenters" : "");
-        write_text(f, text);
+        fprintf(f, "%s{%s%s\\GreSetThisSyllable", syllable_type,
+                syllable->clear? "\\GreClearSyllableText" : "",
+                syllable->forced_center? "\\GreGABCForceCenters" : "");
+        write_text(f, syllable->text);
         fprintf(f, "}");
     }
 }
 
 static void write_first_syllable_text(FILE *f, const char *const syllable_type,
-        const bool forced_center, const gregorio_character *const text,
+        const gregorio_syllable *const syllable,
         const bool end_of_word)
 {
+    const gregorio_character *const text = syllable->text;
     gregorio_not_null(syllable_type, write_first_syllable_text, return);
     if (text == NULL) {
         fprintf(f, "}{%s}{\\GreSetNoFirstSyllableText}", syllable_type);
@@ -3436,7 +3438,7 @@ static void write_first_syllable_text(FILE *f, const char *const syllable_type,
         const gregorio_character *t;
 
         /* find out if there is a forced center -> has_forced_center */
-        gregorio_center_determination center = forced_center?
+        gregorio_center_determination center = syllable->forced_center?
                 CENTER_FULLY_DETERMINED : CENTER_NOT_DETERMINED;
 
         gregorio_rebuild_first_syllable(&text_with_initial, false);
@@ -3447,8 +3449,9 @@ static void write_first_syllable_text(FILE *f, const char *const syllable_type,
         gregorio_rebuild_characters(&text_without_initial, center, true);
         gregorio_set_first_word(&text_without_initial);
 
-        fprintf(f, "}{%s}{%s\\GreSetFirstSyllableText", syllable_type,
-                forced_center? "\\GreGABCForceCenters" : "");
+        fprintf(f, "}{%s}{%s%s\\GreSetFirstSyllableText", syllable_type,
+                syllable->clear? "\\GreClearSyllableText" : "",
+                syllable->forced_center? "\\GreGABCForceCenters" : "");
 
         fprintf(f, "{");
         gregorio_write_first_letter_alignment_text(WTP_FIRST_SYLLABLE,
@@ -3654,7 +3657,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
         const gregorio_score *const score,
         const gregorio_element *const *const last_of_voice,
         void (*const write_this_syllable_text)
-        (FILE *, const char *, bool, const gregorio_character *, bool))
+        (FILE *, const char *, const gregorio_syllable *, bool))
 {
     const gregorio_element *clef_change_element = NULL, *element;
     const char *syllable_type = NULL;
@@ -3694,8 +3697,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
             } else {
                 fprintf(f, "%%\n%%\n\\GreNewLine %%\n%%\n%%\n");
             }
-            write_this_syllable_text(f, NULL, syllable->forced_center,
-                    syllable->text, end_of_word);
+            write_this_syllable_text(f, NULL, syllable, end_of_word);
             return;
         }
         /*
@@ -3722,8 +3724,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                 write_syllable(f, syllable, 2, status, score, last_of_voice,
                         write_syllable_text);
                 fprintf(f, "}%%\n");
-                write_this_syllable_text(f, NULL, syllable->forced_center,
-                        syllable->text, end_of_word);
+                write_this_syllable_text(f, NULL, syllable, end_of_word);
                 return;
             }
         }
@@ -3735,16 +3736,14 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                         && (syllable->elements)[0]->u.misc.unpitched.info.bar
                         == B_DIVISIO_FINALIS) {
                     handle_final_bar(f, "DivisioFinalis", syllable);
-                    write_this_syllable_text(f, NULL, syllable->forced_center,
-                            syllable->text, end_of_word);
+                    write_this_syllable_text(f, NULL, syllable, end_of_word);
                     return;
                 }
                 if (!syllable->next_syllable && !syllable->text
                         && (syllable->elements)[0]->u.misc.unpitched.info.bar
                         == B_DIVISIO_MAIOR) {
                     handle_final_bar(f, "DivisioMaior", syllable);
-                    write_this_syllable_text(f, NULL, syllable->forced_center,
-                            syllable->text, end_of_word);
+                    write_this_syllable_text(f, NULL, syllable, end_of_word);
                     return;
                 }
             }
@@ -3763,8 +3762,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                 syllable->next_syllable? syllable->next_syllable->text : NULL);
         syllable_type = "\\GreNoNoteSyllable";
     }
-    write_this_syllable_text(f, syllable_type, syllable->forced_center,
-            syllable->text, end_of_word);
+    write_this_syllable_text(f, syllable_type, syllable, end_of_word);
     fprintf(f, "{}{\\Gre%s}", syllable->first_word ? "FirstWord" : "Unstyled");
     if (end_of_word) {
         fprintf(f, "{1}");

--- a/src/struct.c
+++ b/src/struct.c
@@ -1038,7 +1038,7 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
         gregorio_word_position position, char *abovelinestext,
         gregorio_tr_centering translation_type, gregorio_nlba no_linebreak_area,
         gregorio_euouae euouae, const gregorio_scanner_location *const loc,
-        const bool first_word)
+        const bool first_word, const bool clear)
 {
     gregorio_syllable *next;
     gregorio_element **tab;
@@ -1055,6 +1055,7 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
     next->translation_type = translation_type;
     next->abovelinestext = abovelinestext;
     next->first_word = first_word;
+    next->clear = clear;
     if (loc) {
         next->src_line = loc->first_line;
         next->src_column = loc->first_column;

--- a/src/struct.h
+++ b/src/struct.h
@@ -657,6 +657,7 @@ typedef struct gregorio_syllable {
     ENUM_BITFIELD(gregorio_word_position) position:3;
     bool first_word:1;
     bool forced_center:1;
+    bool clear:1;
 } gregorio_syllable;
 
 /* Stores a header in a singly-linked list */
@@ -808,7 +809,7 @@ void gregorio_add_syllable(gregorio_syllable **current_syllable,
         gregorio_word_position position, char *abovelinestext,
         gregorio_tr_centering translation_type, gregorio_nlba no_linebreak_area,
         gregorio_euouae euouae, const gregorio_scanner_location *loc,
-        bool first_word);
+        bool first_word, bool clear);
 void gregorio_add_special_sign(gregorio_note *current_note, gregorio_sign sign);
 void gregorio_change_shape(gregorio_note *note, gregorio_shape shape,
         bool legacy_oriscus_orientation);

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -783,6 +783,12 @@
   \relax %
 }%
 
+\newif\ifgre@textcleared%
+
+\def\GreClearSyllableText{%
+  \gre@textclearedtrue%
+}%
+
 %% general macro : it will typeset the syllable : arguments are :
 % #1 : macro setting the letters of this syllable
 % #2 : reserved (unused)
@@ -798,6 +804,7 @@
 %% with a special option for #7 : if it is a bar, we don't put a space at the end
 %% at the end we wall \greendofword or \gre@endofsyllable with #7, to reduce the space in case of a flat or natural
 \def\GreSyllable#1#2#3#4#5#6#7#8#9{%
+  \gre@textclearedfalse%
   \def\gre@syllable@args{{#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}{#9}}%
   \futurelet\gre@syllable@next\gre@syllable@expand%
 }%
@@ -1133,6 +1140,7 @@
 
 %a macro to typeset a syllable with only a bar inside
 \def\GreBarSyllable#1#2#3#4#5#6#7#8#9{%
+  \gre@textclearedfalse%
   \gre@debugmsg{general}{}%
   \gre@debugmsg{general}{New bar syllable}%
   \gre@debugmsg{general}{}%


### PR DESCRIPTION
Part of the implementation for #1029.