### PR TITLE
Execute defaults as root

### DIFF
--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -34,7 +34,7 @@ fi
 TeXShopDir=`osascript -e 'POSIX path of (path to app "TeXShop")'`
 
 echo "Adding gabc to list of valid extensions in TeXShop"
-defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -array-add '<dict>
+sudo defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -array-add '<dict>
 <key>CFBundleTypeExtensions</key>
 <array>
 <string>gabc</string>

--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -62,22 +62,22 @@ sudo defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -arr
 echo "Adding Gregorio file extensions to appropriate preference lists"
 #enable syntax coloring and the Typeset button for gabc files
 TeXExtensions=$(defaults read TeXShop OtherTeXExtensions 2>/dev/null)
-if [[ ! $TeXExtensions == *"gabc"* ]]; then
+if [[ ! $TeXExtensions == *gabc* ]]; then
   defaults write TeXShop OtherTeXExtensions -array-add "gabc"
 fi
-if [[ ! $TeXExtensions == *"gtex"* ]]; then
+if [[ ! $TeXExtensions == *gtex* ]]; then
   defaults write TeXShop OtherTeXExtensions -array-add "gtex"
 fi
 
 #Add gtex and gaux to the list of aux files deleted with Trash Aux Files
 TrashExtensions=$(defaults read TeXShop OtherTrashExtensions 2>/dev/null)
-if [[ ! $TrashExtensions == *"gtex"* ]]; then
+if [[ ! $TrashExtensions == *gtex* ]]; then
   defaults write TeXShop OtherTrashExtensions -array-add "gtex"
 fi
-if [[ ! $TrashExtensions == *"gaux"* ]]; then
+if [[ ! $TrashExtensions == *gaux* ]]; then
   defaults write TeXShop OtherTrashExtensions -array-add "gaux"
 fi
-if [[ ! $TrashExtensions == *"glog"* ]]; then
+if [[ ! $TrashExtensions == *glog* ]]; then
   defaults write TeXShop OtherTrashExtensions -array-add "glog"
 fi
 

--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -61,7 +61,7 @@ sudo defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -arr
 
 echo "Adding Gregorio file extensions to appropriate preference lists"
 #enable syntax coloring and the Typeset button for gabc files
-TeXExtensions=`defaults read TeXShop OtherTeXExtensions`
+TeXExtensions=$(defaults read TeXShop OtherTeXExtensions 2>/dev/null)
 if [[ ! $TeXExtensions == *"gabc"* ]]; then
   defaults write TeXShop OtherTeXExtensions -array-add "gabc"
 fi
@@ -70,7 +70,7 @@ if [[ ! $TeXExtensions == *"gtex"* ]]; then
 fi
 
 #Add gtex and gaux to the list of aux files deleted with Trash Aux Files
-TrashExtensions=`defaults read TeXShop OtherTrashExtensions`
+TrashExtensions=$(defaults read TeXShop OtherTrashExtensions 2>/dev/null)
 if [[ ! $TrashExtensions == *"gtex"* ]]; then
   defaults write TeXShop OtherTrashExtensions -array-add "gtex"
 fi

--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -61,13 +61,25 @@ sudo defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -arr
 
 echo "Adding Gregorio file extensions to appropriate preference lists"
 #enable syntax coloring and the Typeset button for gabc files
-defaults write TeXShop OtherTeXExtensions -array-add "gabc"
-defaults write TeXShop OtherTeXExtensions -array-add "gtex"
+TeXExtensions=`defaults read TeXShop OtherTeXExtensions`
+if [[ ! $TeXExtensions == *"gabc"* ]]; then
+  defaults write TeXShop OtherTeXExtensions -array-add "gabc"
+fi
+if [[ ! $TeXExtensions == *"gtex"* ]]; then
+  defaults write TeXShop OtherTeXExtensions -array-add "gtex"
+fi
 
 #Add gtex and gaux to the list of aux files deleted with Trash Aux Files
-defaults write TeXShop OtherTrashExtensions -array-add "gtex"
-defaults write TeXShop OtherTrashExtensions -array-add "gaux"
-defaults write TeXShop OtherTrashExtensions -array-add "glog"
+TrashExtensions=`defaults read TeXShop OtherTrashExtensions`
+if [[ ! $TrashExtensions == *"gtex"* ]]; then
+  defaults write TeXShop OtherTrashExtensions -array-add "gtex"
+fi
+if [[ ! $TrashExtensions == *"gaux"* ]]; then
+  defaults write TeXShop OtherTrashExtensions -array-add "gaux"
+fi
+if [[ ! $TrashExtensions == *"glog"* ]]; then
+  defaults write TeXShop OtherTrashExtensions -array-add "glog"
+fi
 
 echo "Configuration complete"
 exit 0


### PR DESCRIPTION
The TeXShop plist to which the gabc extension needs to be added is not owned by the user and thus elevated privileges are needed in order to modify it.