### PR TITLE
Updated spaces from the Italian Antiphonale Project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Ledger lines are now extended through notes on either side of a ledger line that crosses a stem, as long as the notes are within the same "element."  If the algorithm doesn't produce the result you want, you can use `[oll:0]` to suppress an over-the-staff ledger line on a note, `[ull:0]` to suppress an under-the-staff ledger line on a note, `[oll:1]` to force an over-the-line ledger line on a note, or [ull:1] to force an under-the-staff ledger line on a note.  Please note that other forms of `[oll:...]` and `[ull:...]` can interfere with these new settings. See [UPGRADE.md](UPGRADE.md) and [#1215](https://github.com/gregorio-project/gregorio/issues/1215) for details.
 - The left stem of Dominican plicae on lines has been shortened (see [#1238](https://github.com/gregorio-project/gregorio/issues/1238)).
 - Clefs on the top or bottom line adjust the spacing as if there were a note above the top line or below the bottom line, respectively (see [#1007](https://github.com/gregorio-project/gregorio/issues/1007)).
+- Default spaces have been adjusted (see [#1182](https://github.com/gregorio-project/gregorio/issues/1182)).
 
 ### Added
 - More cavum shapes are now available.  To use them, simply add `r` in gabc to any note in a glyph.  See [#844](https://github.com/gregorio-project/gregorio/issues/844).

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -125,7 +125,7 @@
 % space before in-line custos
 \grecreatedim{spacebeforeinlinecustos}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
 % space before end-of-line custos
-\grecreatedim{spacebeforeeolcustos}{0.3 cm plus 0 cm minus 0 cm}{scalable}%
+\grecreatedim{spacebeforeeolcustos}{0.23 cm plus 0 cm minus 0 cm}{scalable}%
 % space before punctum mora and augmentum duplex
 \grecreatedim{spacebeforesigns}{0.050 cm plus 0.004 cm minus 0.004 cm}{scalable}%
 % when a syllable is shifted left because of a preceding punctum mora, moraadjustmentbar is
@@ -133,25 +133,25 @@
 % This version is the general case.
 \grecreatedim{moraadjustment}{0.050 cm}{scalable}%
 % This version is for when punctum mora is before a bar.
-\grecreatedim{moraadjustmentbar}{0 cm}{scalable}%
+\grecreatedim{moraadjustmentbar}{0.050 cm}{scalable}%
 % space after punctum mora and augmentum duplex
 \grecreatedim{spaceaftersigns}{0.08203 cm plus 0.0082 cm minus 0.0082 cm}{scalable}%
 % space after a clef at the beginning of a line
-\grecreatedim{spaceafterlineclef}{0.27345 cm plus 0.14584 cm minus 0.01367 cm}{scalable}%
+\grecreatedim{spaceafterlineclef}{0.23 cm plus 0 cm minus 0.01367 cm}{scalable}%
 % space after a clef at the beginning of a line, when the clef and first note are vertically distant
-\grecreatedim{shortspaceafterlineclef}{0.2 cm plus 0.2 cm minus 0.01367 cm}{scalable}%
+\grecreatedim{shortspaceafterlineclef}{0.18 cm plus 0 cm minus 0.01367 cm}{scalable}%
 % minimal space between notes of different words
-\grecreatedim{interwordspacenotes}{0.27 cm plus 0.15 cm minus 0.05 cm}{scalable}%
+\grecreatedim{interwordspacenotes}{0.29 cm plus 0.05 cm minus 0.05 cm}{scalable}%
 % minimal space between notes of the same syllable.
 \grecreatedim{intersyllablespacenotes}{0.24 cm}{scalable}%
 % stretching added in the case where the text of two syllables of the same word are
 % separated with an automatic hyphen
 \grecreatedim{intersyllablespacestretchhyphen}{0cm plus 0.05cm}{scalable}%
 % minimal space between letters of different words.
-\grecreatedim{interwordspacetext}{1ex plus 0.15cm minus 0.05cm}{fixed}%
+\grecreatedim{interwordspacetext}{0.17 cm plus 0.05 cm minus 0.05 cm}{scalable}%
 % Versions of interword spaces for euouae blocks
-\grecreatedim{interwordspacenotes@euouae}{0.19 cm plus 0.1 cm minus 0.05 cm}{scalable}%
-\grecreatedim{interwordspacetext@euouae}{0.8ex plus 01.cm minus 0.05cm}{fixed}%
+\grecreatedim{interwordspacenotes@euouae}{0.23 cm plus 0.1 cm minus 0.05 cm}{scalable}%
+\grecreatedim{interwordspacetext@euouae}{0.21 cm plus 0.1 cm minus 0.05 cm}{scalable}%
 % versions of note spaces when the first note of the second syllable is an alteration
 % those are used in euouae blocks
 \grecreatedim{interwordspacenotes@alteration}{0.1 cm plus 0.07 cm minus 0.01 cm}{scalable}%
@@ -213,9 +213,9 @@
 %
 \grecreatedim{bar@virgula}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 % short versions are when the notes are very low (virgula and minima only)
-\grecreatedim{bar@virgula@short}{0.16 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\grecreatedim{bar@virgula@short}{0.13 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
 \grecreatedim{bar@minima}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\grecreatedim{bar@minima@short}{0.16 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\grecreatedim{bar@minima@short}{0.12 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
 \grecreatedim{bar@minor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 % dominican bars
 \grecreatedim{bar@dominican}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
@@ -240,9 +240,9 @@
 %
 % bars having their own syllable, with no text associated (new bar spacing algorithm only)
 %
-\grecreatedim{bar@virgula@standalone@notext}{0.2323 cm}{scalable}%
+\grecreatedim{bar@virgula@standalone@notext}{0.2 cm}{scalable}%
 \grecreatedim{bar@virgula@standalone@notext@short}{0.19 cm}{scalable}%
-\grecreatedim{bar@minima@standalone@notext}{0.2323 cm}{scalable}%
+\grecreatedim{bar@minima@standalone@notext}{0.2 cm}{scalable}%
 \grecreatedim{bar@minima@standalone@notext@short}{0.19 cm}{scalable}%
 \grecreatedim{bar@minor@standalone@notext}{0.2323 cm}{scalable}%
 \grecreatedim{bar@dominican@standalone@notext}{0.2323 cm}{scalable}%
@@ -252,16 +252,16 @@
 %
 % minimal space between letters of different syllable texts for text around bars
 % (new bar spacing algorithm only)
-\grecreatedim{interwordspacetext@bars}{0.7ex}{fixed}%
+\grecreatedim{interwordspacetext@bars}{0.18 cm}{scalable}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\grecreatedim{interwordspacetext@bars@euouae}{0.7ex}{fixed}%
-\grecreatedim{interwordspacetext@bars@notext}{1ex}{fixed}%
+\grecreatedim{interwordspacetext@bars@euouae}{0.18 cm}{scalable}%
+\grecreatedim{interwordspacetext@bars@notext}{0.19 cm}{scalable}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\grecreatedim{interwordspacetext@bars@notext@euouae}{0.7ex}{fixed}%
+\grecreatedim{interwordspacetext@bars@notext@euouae}{0.18 cm}{scalable}%
 % rubber length that will be added around bars in new bar spacing algorithm
-\grecreatedim{bar@rubber}{0 cm plus 0.22787 cm minus 0.02 cm}{scalable}%
+\grecreatedim{bar@rubber}{0 cm plus 0.025 cm minus 0.025 cm}{scalable}%
 % in the case of an alteration after a bar, the alteration will "protrude" left of this value
 % think of it as some kind of moraadjustmentbar
 \grecreatedim{alterationadjustmentbar}{0.07 cm}{scalable}%
@@ -272,9 +272,9 @@
 % minimal space between a note and a bar (old algorithm only)
 \grecreatedim{notebarspace}{0.31903 cm plus 0.27345 cm minus 0.02824 cm}{scalable}%
 % Maximum offset between a bar and its associated text when the text goes left of the bar (new bar spacing algorithm only)
-\grecreatedim{maxbaroffsettextleft}{0.6 cm}{scalable}%
+\grecreatedim{maxbaroffsettextleft}{0.3 cm}{scalable}%
 % Same as maxbaroffsettextleft when text goes right of the bar
-\grecreatedim{maxbaroffsettextright}{0 cm}{scalable}%
+\grecreatedim{maxbaroffsettextright}{0.15 cm}{scalable}%
 % Maximum offset between a no-bar (i.e. something like `text()` in gabc) and its associated text when the text goes left of the no-bar (new bar spacing algorithm only)
 \grecreatedim{maxbaroffsettextleft@nobar}{12 cm}{scalable}%
 % Same as maxbaroffsettextleft@nobar when text goes right of the no-bar
@@ -292,9 +292,9 @@
 % an extensible space for the beginning of lines
 \grecreatedim{afterclefnospace}{0 cm plus 0.27345 cm minus 0 cm}{scalable}%
 % space between the initial and the beginning of the score
-\grecreatedim{afterinitialshift}{0.2457 cm}{scalable}%
+\grecreatedim{afterinitialshift}{0.2 cm}{scalable}%
 % space before the initial
-\grecreatedim{beforeinitialshift}{0.2457 cm}{scalable}%
+\grecreatedim{beforeinitialshift}{0.2 cm}{scalable}%
 % when bolshifts are enabled, minimum space between beginning of line and first syllable text
 \grecreatedim{minimalspaceatlinebeginning}{0.05 cm}{scalable}%
 % space to force the initial width to.  Ignored when 0.
@@ -304,13 +304,13 @@
 % distance to move the initial up by
 \grecreatedim{initialraise}{0 cm}{scalable}%
 % Space between lines in the annotation
-\grecreatedim{annotationseparation}{0.05cm}{scalable}%
+\grecreatedim{annotationseparation}{0.05 cm}{scalable}%
 % Amount to raise (positive) or lower (negative) the annotations from the default position
-\grecreatedim{annotationraise}{0cm}{scalable}%
+\grecreatedim{annotationraise}{-0.2 cm}{scalable}%
 % Space between lines in the commentary
-\grecreatedim{commentaryseparation}{0.05cm}{scalable}%
+\grecreatedim{commentaryseparation}{0.05 cm}{scalable}%
 % Amount to raise (positive) or lower (negative) the commentary from the default position (base line of bottom commentary aligned with top line of staff)
-\grecreatedim{commentaryraise}{0.2cm}{scalable}%
+\grecreatedim{commentaryraise}{0.2 cm}{scalable}%
 % space at the beginning of the lines if there is no clef
 \grecreatedim{noclefspace}{0.1 cm}{scalable}%
 % space around a clef change
@@ -335,7 +335,7 @@
 % the space for the translation
 \grecreatedim{translationheight}{0.5 cm}{scalable}%
 %the space above the lines
-\grecreatedim{spaceabovelines}{0.45576 cm plus 0.36461 cm minus 0.09114 cm}{scalable}%
+\grecreatedim{spaceabovelines}{0.45576 cm plus 0.45576 cm minus 0.20114 cm}{scalable}%
 % this counter is the threshold above which we start accounting notes above
 % lines for additional space above lines. For instance with a threshold of
 % 2, notes with a pitch of k and l will not interfere with the space above
@@ -398,5 +398,5 @@
 %%%%%%%%%%
 \grecreatedim{parskip}{0pt plus 1pt}{scalable}%
 \grecreatedim{lineskip}{1pt}{scalable}%
-\grecreatedim{baselineskip}{14.5pt}{scalable}%
+\grecreatedim{baselineskip}{11.5pt}{scalable}%
 \grecreatedim{lineskiplimit}{0pt}{scalable}%


### PR DESCRIPTION
Fixes #1182.

@eroux Please double check that I pulled in all the changes.  I didn't set change the eolhyphen or custosalteration settings, and I left the emergency stretch set as `\the\emergencystretch`.  You'll also see that I changed various `interwordspacetext` values from the old ex-dimensioned values (which seemed weird given ex is a relative vertical height) to the cm-dimensioned values for similar spaces from the Italian Antiphonale Project.

I added a `CHANGELOG.md` entry, but no `UPGRADE.md` because I can't see a way that a user can easily "opt out" of these changes.

See the corresponding test pull request for notes on the tests.

Please review and merge if satisfactory.