### PR TITLE
Reworked parser to ignore spaces after the semicolon ending a header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The Scribus external tool script now uses latexmk in order to handle the multi-pass features of Gregorio (see [#1236](https://github.com/gregorio-project/gregorio/issues/1236)).
 - Translation text in a syllable with a trailing (forced) hyphen is no longer truncated to its first character (see [#1254](https://github.com/gregorio-project/gregorio/issues/1254)).
 - A trailing (forced) hyphen in a syllable no longer generates a forced hyphen in the previous syllable (see [#1255](https://github.com/gregorio-project/gregorio/issues/1255)).
+- A trailing space on a header line is now ignored (see [#1269](https://github.com/gregorio-project/gregorio/issues/1269)).
 
 ## Changed
 - Notes are now left-aligned as if all clefs had the same width as the largest clef in the score. You can get previous behavior back with `\grebolshiftcleftype{current}`, or temporary force alignment until the end of a score with `\grelocalbolshiftcleftype`. See Documentation of these functions and [#1189](https://github.com/gregorio-project/gregorio/issues/1189).

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -153,15 +153,20 @@ semicolon. */
         BEGIN(attribute);
         return COLON;
     }
-<attribute>[^;\n\r]*(;[^;\n\r]+)*([\n\r]+[^;]*(;[^;]+)*)? {
+<attribute>;;?[\n\r \t]*[\n\r] {
+         BEGIN(INITIAL);
+         return SEMICOLON;
+    }
+<attribute>[^;]+ {
         gabc_score_determination_lval.text =
                 gregorio_strdup(gabc_score_determination_text);
         return ATTRIBUTE;
     }
-<attribute>;;?[\n\r]+ {
-         BEGIN(INITIAL);
-         return SEMICOLON;
-    }
+<attribute>; {
+        gabc_score_determination_lval.text =
+                gregorio_strdup(gabc_score_determination_text);
+        return ATTRIBUTE;
+}
 <INITIAL>def-m[0-9] {
          gabc_score_determination_lval.character = gabc_score_determination_text[5];
          return DEF_MACRO;

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -642,6 +642,13 @@ static void gabc_y_add_notes(char *notes, YYLTYPE loc) {
         current_element->nabc_lines = nabc_state;
     }
 }
+
+static char *concatenate(char *first, char *const second) {
+    first = (char *)gregorio_realloc(first, strlen(first) + strlen(second) + 1);
+    strcat(first, second);
+    free(second);
+    return first;
+}
 %}
 
 %initial-action {
@@ -702,8 +709,17 @@ definitions:
     | definitions definition
     ;
 
+attribute_value:
+    ATTRIBUTE {
+        $$.text = $1.text;
+    }
+    | attribute_value ATTRIBUTE {
+        $$.text = concatenate($1.text, $2.text);
+    }
+    ;
+
 attribute:
-    COLON ATTRIBUTE SEMICOLON {
+    COLON attribute_value SEMICOLON {
         $$.text = $2.text;
     }
     | COLON SEMICOLON {


### PR DESCRIPTION
Fixes #1269.

All current tests pass, but I added the score from #1269 to test that case.

Please review and merge if satisfactory.