### PR TITLE
Allowed \grechangenextscorelinedim and \grechangenextscorelinecount to take a list of line numbers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - The spacing added for low notes in the staff is now adjustable by setting dimension `noteadditionalspacelinestext`, with the number of notes settable as count `noteadditionalspacelinestextthreshold`.  See GregorioRef and [#1125](https://github.com/gregorio-project/gregorio/issues/1125) for details.
 - Some counts can now be adjusted for a particular line in a score.  Use `\grechangenextscorelinecount` prior to including the score to set the desired values.  The various spacing thresholds may be changed with this command.  See GregorioRef for details.
 
+### Changed
+- `\grechangenextscorelinedim` can now take a comma-separated list of line numbers as its first argument (see [#1280](https://github.com/gregorio-project/gregorio/issues/1280)).
+
 ### Deprecated
 - '\gresethyphenprotrusion{percentage}`, supplanted by `\gresetprotrusionfactor{eolhyphen}{factor}`.  Note that the value the new command takes is a factor rather than a percentage.
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -271,12 +271,18 @@ Macro to change one of Gregorio\TeX’s distances.  This function will check to 
 Changes one of Gregorio\TeX’s distances for a given line in the next included score.  This works with \texttt{spaceabovelines}, \texttt{spacebeneathtext}, and \texttt{spacelinestext}.
 
 \begin{argtable}
-  \#1 & integer & The number of the line in the next score to be adjusted.\\
-  \#2 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
-  \#3 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
+  \#1 & list of integers & A comma-separated list of line numbers in the next
+                           score to be adjusted.\\
+  \#2 & string & The name of the distance to be changed.  See
+                 \nameref{distances} below.\\
+  \#3 & string & The distance in string format.  \textbf{Note:} You cannot use
+                 a length register for this argument.  You \emph{must} use a
+                 string because of the way that Gregorio\TeX\ handles spaces.\\
   \#4 & \texttt{fixed} & Distance will not scale when staff size is changed.\\
   & \texttt{scalable} & Distance will scale when staff size is changed.\\
-  & \texttt{inherited} & Distance will inherit its value from another distance.  When this argument is used, then \#3 should be the name of another Gregorio\TeX\ distance.
+  & \texttt{inherited} & Distance will inherit its value from another
+                         distance.  When this argument is used, then \#3 should
+                         be the name of another Gregorio\TeX\ distance.
 \end{argtable}
 
 \macroname{\textbackslash grescaledim}{\{\#1\}\{\#2\}}{gregoriotex-spaces.tex}
@@ -302,8 +308,10 @@ Macro to change one of Gregorio\TeX’s counts or penalities (numeric values).
 Changes one of Gregorio\TeX’s counts or penalties for a given line in the next included score.
 
 \begin{argtable}
-  \#1 & integer & The number of the line in the next score to be adjusted.\\
-  \#2 & string & The name of the count to be changed.  See \nameref{counts} and \nameref{penalties} below.\\
+  \#1 & list of integers & A comma-separated list of line numbers in the next
+                           score to be adjusted.\\
+  \#2 & string & The name of the count to be changed.  See \nameref{counts} and
+                 \nameref{penalties} below.\\
   \#3 & integer & The new value.\\
 \end{argtable}
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1212,7 +1212,7 @@
   \gre@calculate@additionalspaces{#2}{#3}{#4}{#5}%
   #8%
   \directlua{
-    gregoriotex.atScoreBeginning([[#1]], #2, #3, #4, #5,
+    gregoriotex.at_score_beginning([[#1]], #2, #3, #4, #5,
         \gre@pitch@adjust@top, \gre@pitch@adjust@bottom,
         "\luatexluaescapestring{\gre@gregoriofontname}")
     gregoriotex.adjust_line_height(1)
@@ -1269,7 +1269,7 @@
   \gre@skip@temp@four=0pt\relax%
   \setbox\gre@box@annotation=\box\voidb@x%
   \setbox\gre@box@commentary=\box\voidb@x%
-  \directlua{gregoriotex.atScoreEnd()}%
+  \directlua{gregoriotex.at_score_end()}%
   \unsetluatexattribute{\gre@attr@glyph@id}%
   \unsetluatexattribute{\gre@attr@glyph@top}%
   \unsetluatexattribute{\gre@attr@glyph@bottom}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1641,7 +1641,8 @@
 % #2-#4 : same as #1-#3 of \grechangedim
 \def\grechangenextscorelinedim#1#2#3#4{%
   \directlua{%
-    gregoriotex.change_next_score_line_dim(#1,%
+    gregoriotex.change_next_score_line_dim(%
+      "\luatexluaescapestring{#1}",%
       "\luatexluaescapestring{#2}",%
       "\luatexluaescapestring{#3}",%
       "\luatexluaescapestring{#4}"%
@@ -1669,7 +1670,8 @@
 % #2-#3 : same as #1-#2 of \grechangecount
 \def\grechangenextscorelinecount#1#2#3{%
   \directlua{%
-    gregoriotex.change_next_score_line_count(#1,%
+    gregoriotex.change_next_score_line_count(%
+      "\luatexluaescapestring{#1}",%
       "\luatexluaescapestring{#2}",%
       "\luatexluaescapestring{#3}"%
     )%

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -646,7 +646,7 @@ local function get_score_font_unicode_pairs(name)
   return pairs(unicodes)
 end
 
-local function atScoreBeginning(score_id, top_height, bottom_height,
+local function at_score_beginning(score_id, top_height, bottom_height,
     has_translation, has_above_lines_text, top_height_adj, bottom_height_adj,
     score_font_name)
   local inclusion = score_inclusion[score_id] or 1
@@ -654,7 +654,6 @@ local function atScoreBeginning(score_id, top_height, bottom_height,
   score_id = score_id..'.'..inclusion
   cur_score_id = score_id
   if (top_height > top_height_adj or bottom_height < bottom_height_adj
-      or per_line_counts['noteadditionalspacelinestext'] ~= nil
       or has_translation ~= 0 or has_above_lines_text ~= 0)
       and tex.count['gre@variableheightexpansion'] == 1 then
     score_heights = line_heights[score_id] or {}
@@ -687,7 +686,7 @@ local function atScoreBeginning(score_id, top_height, bottom_height,
   luatexbase.add_to_callback("hyphenate", disable_hyphenation, "gregoriotex.disable_hyphenation", 1)
 end
 
-local function atScoreEnd()
+local function at_score_end()
   luatexbase.remove_from_callback('post_linebreak_filter', 'gregoriotex.post_linebreak')
   luatexbase.remove_from_callback("hyphenate", "gregoriotex.disable_hyphenation")
   per_line_dims = {}
@@ -1137,22 +1136,30 @@ local function save_count(name, value)
   saved_counts[name] = value
 end
 
-local function change_next_score_line_dim(linenum, name, value, modifier)
-  local line_dims = per_line_dims[linenum]
-  if line_dims == nil then
-    line_dims = {}
-    per_line_dims[linenum] = line_dims
+local function change_next_score_line_dim(line_expr, name, value, modifier)
+  local linenum_str
+  for linenum_str in string.gmatch(line_expr, "%s*([^,]+)%s*") do
+    local linenum = tonumber(linenum_str)
+    local line_dims = per_line_dims[linenum]
+    if line_dims == nil then
+      line_dims = {}
+      per_line_dims[linenum] = line_dims
+    end
+    line_dims[name] = { value, modifier }
   end
-  line_dims[name] = { value, modifier }
 end
 
-local function change_next_score_line_count(linenum, name, value)
-  local line_counts = per_line_counts[linenum]
-  if line_counts == nil then
-    line_counts = {}
-    per_line_counts[linenum] = line_counts
+local function change_next_score_line_count(line_expr, name, value)
+  local linenum_str
+  for linenum_str in string.gmatch(line_expr, "([^,]+)") do
+    local linenum = tonumber(linenum_str)
+    local line_counts = per_line_counts[linenum]
+    if line_counts == nil then
+      line_counts = {}
+      per_line_counts[linenum] = line_counts
+    end
+    line_counts[name] = value
   end
-  line_counts[name] = value
 end
 
 local function prep_save_position(index, fn)
@@ -1355,8 +1362,8 @@ end
 gregoriotex.number_to_letter             = number_to_letter
 gregoriotex.init                         = init
 gregoriotex.include_score                = include_score
-gregoriotex.atScoreEnd                   = atScoreEnd
-gregoriotex.atScoreBeginning             = atScoreBeginning
+gregoriotex.at_score_end                 = at_score_end
+gregoriotex.at_score_beginning           = at_score_beginning
 gregoriotex.check_font_version           = check_font_version
 gregoriotex.get_gregoriotexluaversion    = get_gregoriotexluaversion
 gregoriotex.map_font                     = map_font


### PR DESCRIPTION
Fixes #1280.

Current tests pass, as expected. I added a new test to exercise this feature.

Please review and merge if satisfactory.