### PR TITLE
Orientated an oriscus at the unison towards the first non-unison note.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 ### Changed
 - The default behaviour of `\gregorioscore` has been changed to autocompile.
+- When the note after an oriscus is at the same pitch, the oriscus direction now depends on the first non-unison, non-oriscus note after the oriscus (see [#1179](https://github.com/gregorio-project/gregorio/issues/1179)).
 
 ## [5.0.0-beta1] - 2017-01-31
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,6 +33,10 @@ Note: You may need to use a construct such as `/!` to keep notes that are separa
 
 As of version 5.0, the `\gresethyphenprotrusion{percentage}` command is deprecated.  To set this protrusion factor, use `\gresetprotrusionfactor{eolhyphen}{factor}` instead.  Note that the `factor` taken by the new command is a factor rather than the percentage taken by the deprecated command, so for example, use `\gresetprotrusionfactor{eolhyphen}{0.5}` instead of `\gresethyphenprotrusion{50}`.
 
+### Oriscus orientation at the unison
+
+As of version 4.2, when the note after the oriscus is at the same pitch as the oriscus, the oriscus will point towards the first non-unison note after the oriscus or downwards if at the end of the score.  Use the `0` (for downwards) `1` (for upwards) modifiers to force a different orientation.
+
 ## 4.2
 
 ### Executable file name
@@ -46,10 +50,6 @@ Unfortunately, there appears to be no easier way to let a user-installed Gregori
 ### Stemmed oriscus flexus orientation
 
 As of version 4.2, the orientation of the stemmed oriscus flexus `(gOe)` is consistent with the unstemmed oriscus flexus `(goe)` in that the oriscus points downwards (since the note which follows is of lower pitch).  If you prefer the oriscus to point upwards, you will need to use the `1` modifier (as in `(gO1e)`), which will force an upward orientation of the oriscus.
-
-### Oriscus orientation at the unision
-
-As of version 4.2, when the note after the oriscus is at the same pitch as the oriscus, the oriscus will point downwards by default.  If you prefer it to point upwards, append the `1` modifier to force the upward orientation.
 
 ### Podatus followed by a virga
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,7 +35,7 @@ As of version 5.0, the `\gresethyphenprotrusion{percentage}` command is deprecat
 
 ### Oriscus orientation at the unison
 
-As of version 4.2, when the note after the oriscus is at the same pitch as the oriscus, the oriscus will point towards the first non-unison note after the oriscus or downwards if at the end of the score.  Use the `0` (for downwards) `1` (for upwards) modifiers to force a different orientation.
+As of version 5.0, when the note after the oriscus is at the same pitch as the oriscus, the oriscus will point towards the first non-unison note after the oriscus or downwards if at the end of the score.  Use the `0` (for downwards) `1` (for upwards) modifiers to force a different orientation.
 
 ## 4.2
 


### PR DESCRIPTION
Fixes #1179.

Note: if there are intervening oriscus notes within the unison sequence, all of the oriscus notes will point at the first non-unison note after the sequence.

Some of the oriscus tests change appropriately, and I added some test cases for this change.

Please review and merge if satisfactory.