### PR TITLE
Added drawing of pes quadratum initio debilis glyphs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+### Fixed
+- Glyphs for pes quadratum shapes with initio debilis are no longer missing. Use `-fqg` to engrave them.  See [#1310](https://github.com/gregorio-project/gregorio/issues/1310).
+
 ### Changed
 - The default behaviour of `\gregorioscore` has been changed to autocompile.
 - When the note after an oriscus is at the same pitch, the oriscus direction now depends on the first non-unison, non-oriscus note after the oriscus (see [#1179](https://github.com/gregorio-project/gregorio/issues/1179)).

--- a/fonts/squarize.py
+++ b/fonts/squarize.py
@@ -1254,6 +1254,14 @@ def pes_quadratum():
             S_PES_QUADRATUM_LONGQUEUE, stemshape=S_PES_QUADRATUM, qtype='long')
     write_pes_quadratum(1, "PunctumLineTR", "VirgaBaseLineBL",
             S_PES_QUADRATUM_OPENQUEUE, stemshape=S_PES_QUADRATUM, qtype='open')
+    write_all_pes_quadratum("idebilis", "VirgaBaseLineBL", S_PES_QUADRATUM,
+            lique=L_INITIO_DEBILIS, stemshape=S_PES_QUADRATUM, qtype='short')
+    write_all_pes_quadratum("idebilis", "VirgaBaseLineBL",
+            S_PES_QUADRATUM_LONGQUEUE, lique=L_INITIO_DEBILIS,
+            stemshape=S_PES_QUADRATUM, qtype='long')
+    write_pes_quadratum(1, "idebilis", "VirgaBaseLineBL",
+            S_PES_QUADRATUM_OPENQUEUE, lique=L_INITIO_DEBILIS,
+            stemshape=S_PES_QUADRATUM, qtype='open')
     precise_message("pes quassus")
     write_all_pes_quadratum("AscendensOriscusLineTR", "VirgaBaseLineBL",
             S_PES_QUASSUS, stemshape=S_PES_QUASSUS, qtype='short')


### PR DESCRIPTION
Fixes #1310.

I'm labeling this a bug because gregorio does parse `-fqg` into a code point that did not exist before this change.

Additional changes will be necessary if `-fgv` should generate these figures in addition to `-fqg`.