### PR TITLE
Remove TeXShop auto-configure script

### DIFF
--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -30,56 +30,5 @@ else
     exit 1
 fi
 
-#Add 'gabc' to the list of file extensions which TeXShop knows
-TeXShopDir=`osascript -e 'POSIX path of (path to app "TeXShop")'`
-
-echo "Adding gabc to list of valid extensions in TeXShop"
-sudo defaults write "$TeXShopDir/Contents/Info.plist" CFBundleDocumentTypes -array-add '<dict>
-<key>CFBundleTypeExtensions</key>
-<array>
-<string>gabc</string>
-</array>
-<key>CFBundleTypeName</key>
-<string>gabc</string>
-<key>CFBundleTypeOSTypes</key>
-<array>
-<string>GABC</string>
-</array>
-<key>CFBundleTypeRole</key>
-<string>Editor</string>
-<key>LSItemContentTypes</key>
-<array>
-<string>com.unknown.gabc</string>
-</array>
-<key>LSTypeIsPackage</key>
-<false/>
-<key>NSDocumentClass</key>
-<string>TSDocument</string>
-<key>NSPersistentStoreTypeKey</key>
-<string>Binary</string>
-</dict>'
-
-echo "Adding Gregorio file extensions to appropriate preference lists"
-#enable syntax coloring and the Typeset button for gabc files
-TeXExtensions=$(defaults read TeXShop OtherTeXExtensions 2>/dev/null)
-if [[ ! $TeXExtensions == *gabc* ]]; then
-  defaults write TeXShop OtherTeXExtensions -array-add "gabc"
-fi
-if [[ ! $TeXExtensions == *gtex* ]]; then
-  defaults write TeXShop OtherTeXExtensions -array-add "gtex"
-fi
-
-#Add gtex and gaux to the list of aux files deleted with Trash Aux Files
-TrashExtensions=$(defaults read TeXShop OtherTrashExtensions 2>/dev/null)
-if [[ ! $TrashExtensions == *gtex* ]]; then
-  defaults write TeXShop OtherTrashExtensions -array-add "gtex"
-fi
-if [[ ! $TrashExtensions == *gaux* ]]; then
-  defaults write TeXShop OtherTrashExtensions -array-add "gaux"
-fi
-if [[ ! $TrashExtensions == *glog* ]]; then
-  defaults write TeXShop OtherTrashExtensions -array-add "glog"
-fi
-
 echo "Configuration complete"
 exit 0


### PR DESCRIPTION
As it turns out, the script was causing TeXShop to misbehave, even to the point of not opening.  After some emailing back and forth with Richard Koch (the maker of TeXShop) it’s been worked out that support opening and editing Gregorio related files will appear built-in to the next release of TeXShop itself.  What I’ve done, therefore, is removed the problematic portions of the configuration script.  All it really does now is copy the engine into the appropriate directory.