### PR TITLE
TeXShop engine modifications

### DIFF
--- a/contrib/TeXShop/LuaLaTeX+se.engine
+++ b/contrib/TeXShop/LuaLaTeX+se.engine
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if [ -z ${2+x} ]; then
+if [[ -n ${2:+x} ]]; then
+    echo "I will add $2 to the input path"
     export TEXINPUTS="$2//:"
     export LUAINPUTS="$2//:"
 fi

--- a/contrib/TeXShop/LuaTeX+se.engine
+++ b/contrib/TeXShop/LuaTeX+se.engine
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if [ -z ${2+x} ]; then
+if [[ -n ${2:+x} ]]; then
+    echo "I will add $2 to the input path"
     export TEXINPUTS="$2//:"
     export LUAINPUTS="$2//:"
 fi

--- a/contrib/TeXShop/LuaTeX+se.engine
+++ b/contrib/TeXShop/LuaTeX+se.engine
@@ -4,4 +4,4 @@ if [ -z ${2+x} ]; then
     export TEXINPUTS="$2//:"
     export LUAINPUTS="$2//:"
 fi
-lualatex --shell-escape -file-line-error -synctex=1 "$1"
+luatex --shell-escape -file-line-error -synctex=1 "$1"

--- a/contrib/TeXShop/Makefile.am
+++ b/contrib/TeXShop/Makefile.am
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU General Public License
 # along with Gregorio.  If not, see <http://www.gnu.org/licenses/>.
 
-EXTRA_DIST = auto-configure.command LuaLaTeX+se.engine
+EXTRA_DIST = auto-configure.command LuaLaTeX+se.engine LuaTeX+se.engine

--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -29,6 +29,15 @@ else
     echo "Please try running the Gregorio intaller again"
     exit 1
 fi
+SOURCE="/Users/Shared/Gregorio/contrib/TeXShop/LuaTeX+se.engine"
+if [ -e "$SOURCE" ]; then
+    echo "Copying LuaTeX+se.engine into TeXShop configuration"
+    cp "$SOURCE" "$ENGINEDIR"
+else
+    echo "Cannot find LuaTeX+se.engine"
+    echo "Please try running the Gregorio intaller again"
+    exit 1
+fi
 
 echo "Configuration complete"
 exit 0


### PR DESCRIPTION
TeXShop 3.77 has a new feature (by my request) that allows one to add an additional parameter to TeX files which can then be exploited by the engine files.  For these engines I’ve used the parameter to add a folder (specified by the parameter) to the input paths.
I’ve also added a Plain TeX version of the engine.