### PR TITLE
Added --enable-texlive flag and support for a suffix-less executable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ You need a recent and working [TeXLive](https://www.tug.org/texlive/), on top of
 - Switch to TeXLive 2015 (which uses an earlier version of `luaotfload`) to build the docs.
 - Upgrade your `luaotfload` to a more recent version (v2.8 or later).
 
+## Building for inclusion in TeXLive
+
+When building gregorio for inclusion in TeXLive, the gregorio executable must not have the version number prefix that is used for other builds.  To make this happen, run `configure` with the `--enable-texlive` option and the generated Makefile will create a gregorio executable without the version number prefix (i.e., the executable will simply be named `gregorio`).
+
 ## Documentation
 
 You can find documentation and useful links in the [documentation](doc/), on [the main website](http://gregorio-project.github.io/) and on [a wiki](http://gregoriochant.org).

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,17 @@ AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug@<:@=sanitize,coverage@:>@]
     CPPFLAGS+=" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 "
 ])
 
+AC_ARG_ENABLE([texlive], AS_HELP_STRING([--enable-texlive], [Enable TeX Live executable name.]), [
+    AS_IF([test "x$enableval" != "xno"], [
+        GREGORIO_EXE_SUFFIX=""
+    ], [
+        GREGORIO_EXE_SUFFIX="-$FILENAME_VERSION"
+    ])
+], [
+    GREGORIO_EXE_SUFFIX="-$FILENAME_VERSION"
+])
+AC_SUBST(GREGORIO_EXE_SUFFIX)
+
 AC_CONFIG_HEADERS([src/config_.h])
 AC_CONFIG_FILES([
     Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,8 +19,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/gabc  -I$(top_srcdir)/src/
 AM_CFLAGS = $(KPSE_CFLAGS)
 LDADD = $(KPSE_LIBS)
 
-bin_PROGRAMS = gregorio-$(FILENAME_VERSION)
-gregorio___FILENAME_VERSION__SOURCES = \
+bin_PROGRAMS = gregorio$(GREGORIO_EXE_SUFFIX)
+gregorio__GREGORIO_EXE_SUFFIX__SOURCES = \
 	gregorio-utils.c characters.c characters.h messages.c messages.h struct.c \
 	struct.h struct_iter.h enum_generator.h unicode.c unicode.h sha1.c sha1.h \
 	support.c support.h config.h bool.h plugins.h utf8strings.h dump/dump.c \
@@ -47,7 +47,7 @@ gregorio___FILENAME_VERSION__SOURCES = \
 @MK@endif
 
 # gabc files
-gregorio___FILENAME_VERSION__SOURCES += \
+gregorio__GREGORIO_EXE_SUFFIX__SOURCES += \
 	gabc/gabc-elements-determination.c gabc/gabc-write.c \
 	gabc/gabc-glyphs-determination.c gabc/gabc.h \
 	gabc/gabc-score-determination.h gabc/gabc-score-determination.c \
@@ -72,7 +72,7 @@ if HAVE_RC
 gregorio-resources.o: ../windows/gregorio-resources.rc ../windows/gregorio.ico
 	$(RC) $(RCFLAGS) $< -o $@
 
-gregorio___FILENAME_VERSION__SOURCES += ../windows/gregorio-resources.rc ../windows/gregorio.ico
+gregorio__GREGORIO_EXE_SUFFIX__SOURCES += ../windows/gregorio-resources.rc ../windows/gregorio.ico
 LDADD += gregorio-resources.o
 endif
 


### PR DESCRIPTION
Fixes #1292.

Because we laid so much groundwork for this, it took less time to implement than I thought, but I need help testing it in anything other than Linux.

I'm also not sure how to document this.  This is not a user-visible change, so it doesn't belong in CHANGELOG.md, and no entry is needed in UPGRADE.md.  As mentioned in #1292, it basically allows the build files to be set up for TeX Live.

Note: I changed @rpspringuel's code a bit because (1) redirection to `/dev/null` will likely not work under Windows, (2) to make executable check lazy, so it's only done (once per run) if needed, and (3) to try to find the suffixed executable before the suffix-less executable.

Please review and give suggestions, or merge if this is good enough.