### PR TITLE
Changed --enable-texlive to --disable-version-in-exe per Élie Roux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You need a recent and working [TeXLive](https://www.tug.org/texlive/), on top of
 
 ## Building for inclusion in TeXLive
 
-When building gregorio for inclusion in TeXLive, the gregorio executable must not have the version number prefix that is used for other builds.  To make this happen, run `configure` with the `--enable-texlive` option and the generated Makefile will create a gregorio executable without the version number prefix (i.e., the executable will simply be named `gregorio`).
+When building gregorio for inclusion in TeXLive, the gregorio executable must not have the version number prefix that is used for other builds.  To make this happen, run `configure` with the `--disable-version-in-exe` option, and the generated Makefile will create a gregorio executable without the version number prefix (i.e., the executable will simply be named `gregorio`).
 
 ## Documentation
 

--- a/configure.ac
+++ b/configure.ac
@@ -104,11 +104,11 @@ AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug@<:@=sanitize,coverage@:>@]
     CPPFLAGS+=" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 "
 ])
 
-AC_ARG_ENABLE([texlive], AS_HELP_STRING([--enable-texlive], [Enable TeX Live executable name.]), [
+AC_ARG_ENABLE([version-in-exe], AS_HELP_STRING([--disable-version-in-exe], [Disable version in executable name.]), [
     AS_IF([test "x$enableval" != "xno"], [
-        GREGORIO_EXE_SUFFIX=""
-    ], [
         GREGORIO_EXE_SUFFIX="-$FILENAME_VERSION"
+    ], [
+        GREGORIO_EXE_SUFFIX=""
     ])
 ], [
     GREGORIO_EXE_SUFFIX="-$FILENAME_VERSION"


### PR DESCRIPTION
Part of the implementation for #1292.

This changes the option to `--disable-version-in-exe`.

@rpspringuel If you agree with this change, please merge this.