### PR TITLE
The version number on the executable is a suffix, not a prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You need a recent and working [TeXLive](https://www.tug.org/texlive/), on top of
 
 ## Building for inclusion in TeXLive
 
-When building gregorio for inclusion in TeXLive, the gregorio executable must not have the version number prefix that is used for other builds.  To make this happen, run `configure` with the `--disable-version-in-exe` option, and the generated Makefile will create a gregorio executable without the version number prefix (i.e., the executable will simply be named `gregorio`).
+When building gregorio for inclusion in TeXLive, the gregorio executable must not have the version number suffix that is used for other builds.  To make this happen, run `configure` with the `--disable-version-in-exe` option, and the generated Makefile will create a gregorio executable without the version number suffix (i.e., the executable will simply be named `gregorio`).
 
 ## Documentation
 


### PR DESCRIPTION
I think I made that change too late in the evening.  Should be "suffix", not "prefix".

I don't think it's necessary to make a new build for this, and being just a change to README.md, I will merge it for people reading the github site.