### PR TITLE
Added note about package ordering as related to microtype.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ## [Unreleased][unreleased]
 - Fixed issue with Tex Live 2017 latexmk not detecting auto-compiled gabc files as dependencies (see [#1367](https://github.com/gregorio-project/gregorio/issues/1367)).
+- Added note about loading microtype after gregoriotex (see [#1364](https://github.com/gregorio-project/gregorio/issues/1364)).
 
 ## [5.0.2] - 2017-05-24
 - Worked around an issue discovered during the TeX Live 2017 pre-test.  See [#1362](https://github.com/gregorio-project/gregorio/issues/1362).

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -80,6 +80,12 @@ Gregorio\TeX{} two-pass processing is compatible with \texttt{latexmk}.
 
 If you only need the special symbols which Gregorio\TeX\ contains, and not the ability to include scores or musical glyphs, then you can load \texttt{gregoriosyms} instead of \texttt{gregoriotex}.  It supports all of the above options except those specifically related to scores.  \textbf{You should not try to load both packages}.
 
+\subsubsection{Gregorio\TeX{} and \texttt{microtype}}
+
+If you are using the \texttt{microtype} package or a package that itself uses
+\texttt{microtype}, please load it after \texttt{gregoriotex}.  If you load
+\texttt{microtype} before \texttt{gregoriotex}, you may receive an error about
+an ``undefined control sequence'' if you use certain Gregorio\TeX{} features.
 
 \subsection{Commands}
 


### PR DESCRIPTION
Fixes #1364.

Tests are (obviously) not affected.

Please review and merge if satisfactory.