### PR TITLE
Prevented the change of \gre@diment@lastglyphwidth by a custos alteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][unreleased]
 - Fixed issue with Tex Live 2017 latexmk not detecting auto-compiled gabc files as dependencies (see [#1367](https://github.com/gregorio-project/gregorio/issues/1367)).
 - Added note about loading microtype after gregoriotex (see [#1364](https://github.com/gregorio-project/gregorio/issues/1364)).
+- Fixed issue where an altered note (glyph) throws off the position of an episema in the glyph that immediately precedes it (see [#1379](https://github.com/gregorio-project/gregorio/issues/1379)).
 
 ## [5.0.2] - 2017-05-24
 - Worked around an issue discovered during the TeX Live 2017 pre-test.  See [#1362](https://github.com/gregorio-project/gregorio/issues/1362).

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1713,6 +1713,9 @@ Count to indicate how the clivis is to be aligned with its respective syllable t
 \macroname{\textbackslash gre@insidediscretionary}{}{gregoriotex-signs.tex}
 Macro which indicates whether we are currently inside a discretionary (\texttt{1}) or not (\texttt{0}).  Cannot be converted to a \TeX\ boolean because it’s value needs to be passed to Lua.
 
+\macroname{\textbackslash ifgre@in@custos}{}{gregoriotex-signs.tex}
+Boolean which indicates whether typesetting is currently in the context of a custos.
+
 \macroname{\textbackslash ifgre@isonaline}{}{gregoriotex-syllable.tex}
 Boolean which indicates whether the current note is on a line or not (used to adjust the height of some symbols so they won’t print on a line).
 

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -451,10 +451,14 @@
   \gre@trace@end%
 }%
 
+\newif\ifgre@in@custos %
+\gre@in@custosfalse %
+
 % custos just typesets a custos, useful for before the key changes for example
 % #1 is the height
 \def\GreCustos#1#2{%
   \gre@trace{GreCustos{#1}{#2}}%
+  \gre@in@custostrue %
   \GreNoBreak %
   \ifdim\gre@skip@bar@lastskip=0pt\else % we're after a bar:
     \kern-\gre@skip@bar@lastskip %
@@ -505,6 +509,7 @@
   \fi %
   \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \relax %
+  \gre@in@custosfalse %
   \gre@trace@end%
 }%
 
@@ -522,6 +527,7 @@
 \edef\gre@nextcustosalteration{}%
 \def\GreNextCustos#1#2{%
   \gre@trace{GreNextCustos{#1}{#2}}%
+  \gre@in@custostrue %
   \gre@debugmsg{custos}{nextcustos = #1,#2}%
   \ifnum\gre@insidediscretionary=0\relax %
     \gre@debugmsg{custos}{not discretionary}%
@@ -561,6 +567,7 @@
     \fi %
   \fi %
   \relax%
+  \gre@in@custosfalse %
   \gre@trace@end%
 }%
 
@@ -2404,7 +2411,9 @@
   \ifnum#4=0\relax %
     \gre@newglyphcommon %
   \fi %
-  \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %
+  \ifgre@in@custos\else\relax %
+    \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %
+  \fi %
   % the three next lines are a trick to get the additional lines below the glyphs
   \gre@skip@temp@one = \gre@dimen@lastglyphwidth\relax%
   \kern\gre@skip@temp@one %


### PR DESCRIPTION
Fixes #1379.

I added a test for this change (from the MWE).  I also accepted a minor difference in another test (due, I think, to slight typesetting changes in fonts and/or TeX Live 2017).

Please review and merge if satisfactory.