### PR TITLE
Rewrite Scribus tool

### DIFF
--- a/contrib/900_gregorio.xml
+++ b/contrib/900_gregorio.xml
@@ -22,73 +22,42 @@
  See the different comments in the file to change the default configuration.
 -->
 <editorsettings description="gregorio" icon="gregorio.png">
-    <executable command="texlua"/>
+    <executable command="lualatex --shell-escape --interaction nonstopmode" />
     <imagefile extension=".pdf"/>
     <highlighter>
         <rule name="gabc header" regex="[a-zA-Z]+:" color="blue" minimal="true"/>
         <rule name="gabc delimiter" regex="%%" color="green" minimal="true"/>
         <rule name="gabc notes" regex="\([^)]*\)" color="red" minimal="true"/>
     </highlighter>
-    <empty-frame-text>name: myscore;
-%%
-(c3) Pó(eh/hi)pu(h)lus(h) Si(hi)on,(hgh.)
+    <empty-frame-text>
+        name: myscore;
+        %%
+        (c3) Pó(eh/hi)pu(h)lus(h) Si(hi)on,(hgh.)
     </empty-frame-text>
-    <!-- you can change the basic headers there -->
-    <preamble>data_from_scribus = [==========[% Generated from Scribus
-\documentclass[a4paper,$scribus_grefontsize$]{extarticle}
-\usepackage[left=0cm,top=0cm,right=0cm,bottom=0cm,nohead,nofoot]{geometry}
-\usepackage{color}
-\title{Scribus-Latex-gregorio-File}
-$scribus_additionalgreheaders$
-\usepackage{gregoriotex}
-\author{Scribus}
-\pagestyle{empty}
-\setlength{\textwidth}{$scribus_realwidth$ pt}
-\begin{document}
-$scribus_greconf$
-%%% BEGIN GABC %%%
-</preamble>
-    <postamble>]==========]
-require"lfs"
+    <!-- you can change the basic headers here -->
+    <preamble>
+		    \documentclass[$scribus_grefontsize$]{extarticle}
+		    \usepackage[paperwidth=$scribus_realwidth$ pt,
+		                paperheight=$scribus_realheight$ pt,
+          					left=0cm,top=0cm,right=0cm,bottom=0cm,nohead,nofoot]{geometry}
+        \usepackage[autocompile]{gregoriotex}
+        \usepackage{filecontents}
+    		\title{Scribus-Latex-File}
+    		$scribus_additionalgreheaders$
+    		\author{Scribus}
+		    \pagestyle{empty}
+    		\setlength{\textwidth}{$scribus_realwidth$ pt}
 
-local latexmkbin = "latexmk"
-local lualatexbin = "lualatex"
+        \begin{filecontents}{scribus_file-score.gabc}
+    </preamble>
+    <postamble>
+        \end{filecontents}
 
-local function basename(name)
-  return name and string.match(name,"^.+[/\\](.-)$") or name
-end
-
-local f = basename(arg[0])
-
-local texfile = io.open(f .. ".tex", "w")
-local gabcfile = io.open(f .. "-score.gabc", "w")
-local in_tex = true
-local l
-for l in string.gmatch(data_from_scribus, "[^\r\n]+") do
-  if l == "%%% BEGIN GABC %%%" then
-    in_tex = false
-  elseif in_tex then
-    texfile:write(l .. '\n')
-  else
-    gabcfile:write(l .. '\n')
-  end
-end
-
-local format = string.format
-
-texfile:write("\n\\gregorioscore[f]{" .. f .. "-score}\n\\end{document}\n")
-texfile:close()
-gabcfile:close()
-
-print("calling "..latexmkbin.."\n")
-os.exec({
-    latexmkbin,
-    '-g',
-    '-pdf',
-    '-pdflatex=' .. lualatexbin .. ' --interaction=nonstopmode --shell-escape',
-    f
-})
-</postamble>
+        \begin{document}
+        $scribus_greconf$
+        \gregorioscore{scribus_file-score}
+        \end{document}
+    </postamble>
     <tab type="settings">
         <title>
             <i18n>

--- a/contrib/Scribus.sh
+++ b/contrib/Scribus.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+export PATH=$PATH:/Library/TeX/texbin:/usr/local/bin
+
+logger "`dirname \"$0\"`/Scribus"
+
+exec "`dirname \"$0\"`/Scribus" $@

--- a/contrib/TeXShop/auto-configure.command
+++ b/contrib/TeXShop/auto-configure.command
@@ -39,5 +39,9 @@ else
     exit 1
 fi
 
+#double check the execution bits
+chmod +x "$ENGINEDIR/LuaLaTeX+se.engine"
+chmod +x "$ENGINEDIR/LuaTeX+se.engine"
+
 echo "Configuration complete"
 exit 0


### PR DESCRIPTION
This is a rewrite of the Scribus tool to make it simpler.  Instead of Scribus writing a lua script and calling texlua on it to write two files (the gabc and tex file) and then run lualatex on the result, I make use of the filecontents package to make the writing of the gabc file part of what calling lualatex on the tex file does.  Thus Scribus writes the tex file and calls lualatex on it directly.
Tested as working on both Ubuntu and macOS using Scribus 1.4.6.