### PR TITLE
Update for Lua 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][CTAN]
-
+### Fixed
+- Eliminated implicit casting from float to integer in string formatting (something no longer allowed in Lua 5.3)
 
 ## [5.2.0] - 2019-03-10
 ### Fixed

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -547,7 +547,7 @@ local function post_linebreak(h, groupcode, glyphes)
         h, line = remove(h, line)
       else
         linenum = linenum + 1
-        debugmessage('linesglues', 'line %d: %s factor %d%%', linenum, glue_sign_name[line.glue_sign], line.glue_set*100)
+        debugmessage('linesglues', 'line %d: %s factor %.0f%%', linenum, glue_sign_name[line.glue_sign], line.glue_set*100)
         centerstartnode = nil
         line_id = nil
         line_top = nil


### PR DESCRIPTION
Turns out there is an integer/float issue that needed to be dealt with.  This change works under both TeX Live 2018 and TeX Live 2019.
This change does not affect any tests.