### PR TITLE
Enumerate ancient font options

### DIFF
--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1366,7 +1366,7 @@ For a full description of how to make use of the ancient notation capabilities o
 Macro to set the font to be used for the ancient notation.
 
 \begin{argtable}
-  \#1 & string & the name of the font\\
+  \#1 & string & the name of the font, either \texttt{gregall}, \texttt{grelaon}, or \texttt{gresgmodern}\\
   \#2 & integer & point size at which the font should be loaded\\
 \end{argtable}
 


### PR DESCRIPTION
Generally when there is a limited number of options, we enumerate them.  I've therefore listed the possible ancient fonts.  Technically a user could add their own, but I'm not sure that's realistic.