### PR TITLE
Update language information

### DIFF
--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -938,9 +938,9 @@ Macro to set how the text of the lyrics aligns with the alignment point of its r
   & \texttt{firstletter} & The center of the first letter/character of the syllable will align with the alignment point of the neumes\\
 \end{argtable}
 
-\textbf{Nota Bene:} What constitutes the ``vowel'' of the syllable is determined by the language the lyric text is written in, as specified by the use of the \texttt{language} header in the gabc file.  Out of the box, Gregorio\TeX\ explicitly supports only Latin and English, but the rules for Latin have a high degree of overlap with many Romance languages, allowing them to fall back on the Latin rules with acceptable results.
+\textbf{Nota Bene:} What constitutes the ``vowel'' of the syllable is determined by the language the lyric text is written in, as specified by the use of the \texttt{language} header in the gabc file.  Out of the box, Gregorio\TeX\ explicitly supports Latin, English, Church Slavonic and Hungarian.  Polish, Czech, and Slovak are supported as aliases for Church Slavonic.  Furthermore the rules for Latin have a high degree of overlap with many Romance languages, allowing them to fall back on the Latin rules with acceptable results.
 
-You can also define your own languages in \texttt{gregorio-vowels.dat}.  If you do define a language, please consider sharing your work by submitting it to the project (see CONTRIBUTING.md for instructions).
+You can also define your own languages in \texttt{gregorio-vowels.dat} (see \nameref{customvowels} for details).  If you do define a language, please consider sharing your work by submitting it to the project (see CONTRIBUTING.md for instructions).
 
 Finally, in cases where you want some sort of exceptional alignment, you can force Gregorio to consider a particular part of the syllable to be the ``vowel'' by enclosing it in curly braces (``\{'' and ``\}'') in your gabc file.  Curly braces only affect alignment when using vowel centering.  Syllable centering will always use the entire syllable, and firstletter centering will always use the first character of the syllable --- regardless of curly braces in the gabc file.
 

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -388,6 +388,8 @@ If no vowel is found, the notes are centered around the whole syllable.
 
 If you are using a language for which built-in language rules do not exist and the fallbacks are insufficient, then you may wish to provide your own set of vowel detection rules.  This can be done with a special file:\verb=gregorio-vowels.dat=.  See \nameref{customvowels} for information about how to create and use this file.
 
+Languages which are currently supported are Latin, English, Church Slavonic and Hungarian.  Polish, Czech, and Slovak are supported as aliases for Church Slavonic.  All of these languages can be specified by name (in which case both titlecase and lowercase names are recognized) and by using their ISO 639 (-1 two-letter, -2/T three-letter, or -2/B three-letter) standard abbreviations.
+
 
 \subsection{Notation --- Note Syntax}\label{notesyntax}
 
@@ -1101,6 +1103,8 @@ for the specified language.  It must be followed by the language name,
 enclosed in square brackets, and a semicolon.  The language specified
 applies until the next language statement.
 
+When choosing the name for your language, it is preferable that you use the ISO 639-1 standard (two-letter) code.  All other names should be listed as aliases (see above).  If you plan to submit your vowel detection rules for inclusion in the Gregorio source, then this will be required.
+
 \item[vowel]
 
 The \texttt{vowel} keyword indicates that the characters which follow,
@@ -1138,9 +1142,11 @@ the syllabic consonants \emph{l} and \emph{r} in Czech.
 By way of example, here is a vowel file that works for English:
 
 \begin{lstlisting}[autogobble]
-alias [english] to [English];
+alias [english] to [en];
+alias [English] to [en];
+alias [eng] to [en];
 
-language [English];
+language [en];
 
 vowel aàáAÀÁ;
 vowel eèéëEÈÉË;


### PR DESCRIPTION
In responding to #1454, I noticed that the language information in the docs was out of date.  This brings it up to date, listing all languages supported and noting the standards used when defining aliases and language names.