### PR TITLE
Fixes to Scribus tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][develop]
-
+### Fixed
+- Fixed some problem in 900_gregorio.xml (Scribus render frame tool).  First, the use of `filecontents` rather than `filecontents*` was leading to a comment header that made it impossible for Gregorio to find the gabc headers in the temporary score file.  Further, some of the indenting (which makes the file more human readable) was leading to errors in the formatting of the created files because they are processed in a way which handles whitespace differently from XML.  See [#1457](https://github.com/gregorio-project/gregorio/issues/1457).
 
 ## [Unreleased][CTAN]
 

--- a/contrib/900_gregorio.xml
+++ b/contrib/900_gregorio.xml
@@ -48,10 +48,10 @@
 		    \pagestyle{empty}
     		\setlength{\textwidth}{$scribus_realwidth$ pt}
 
-        \begin{filecontents}{scribus_file-score.gabc}
-    </preamble>
-    <postamble>
-        \end{filecontents}
+        \begin{filecontents*}{scribus_file-score.gabc}
+</preamble>
+<postamble>
+\end{filecontents*}
 
         \begin{document}
         $scribus_greconf$


### PR DESCRIPTION
The use of `filecontents` rather than `filecontents*` was leading to a comment header that made it impossible for Gregorio to find the gabc headers in the temporary score file.
Some of the indenting (which makes the file more human readable) was leading to errors in the formatting of the created files because they are processed in a way which handles whitespace differently from XML.

This is not a file which is uploaded to CTAN so I've made this PR against develop (for inclusion in the next enhancement release).  However, since the file is not uploaded to CTAN, this commit could be cherry-picked if the next release turns out to be a bugfix rather than an enhancement.  Some rewriting of the CHANGELOG would be needed in that event.

See #1457.