### PR TITLE
Stafflinethickness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][CTAN]
+### Fixed
+- Staff line thickness is now set in gsp-default.tex.  This corrects a problem with the staff lines changing thickness when the default spacing configuration is loaded while the staff size is something other than the default (17).  See [#1461](https://github.com/gregorio-project/gregorio/issues/1461).
 
 
 ## [5.2.1] - 2019-04-06

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -187,7 +187,7 @@
 \newif\ifgre@scale@stafflinefactor%
 \gre@scale@stafflinefactortrue
 
-% a macro for setting the thickness of the staff lines.  This changes the stafflinefactor and then adjusts the spaces that are affected by the thicker staff lines.
+% a macro for setting the thickness of the staff lines.  The changes to stafflinefactor will be automatically picked up when the staff lines are redrawn
 \def\grechangestafflinethickness#1{%
   \xdef\gre@stafflinefactor{#1}%
   \relax %

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -92,6 +92,9 @@
 %% If you’re creating your own space configuration file, you may set this to some other value, should you so desire.
 \greconffactor=17%
 
+%How thick the lines should be.  When set equal to \greconffactor (above) the staff lines will be their default thickness.  Larger numbers result in thicker lines.
+\grechangestafflinethickness{17}%
+
 % the additional width of the additional lines (compared to the width of the glyph they're associated with)
 \grecreatedim{additionallineswidth}{0.14584 cm}{scalable}%
 % width of the additional lines, used only for the custos (maybe should depend on the width of the custos...)


### PR DESCRIPTION
Fixes #1461 

Staff line thickness scales with the size of the staff, but was not being set in gsp-default.tex.  As a result, whenever the default spacings were loaded and the staff size wasn't currently set to the default, the line thickness would change.  This change puts the setting of the staff line thickness into gsp-default so that it will scale as expected.