### PR TITLE
Clean-up failed install

### DIFF
--- a/install-gtex.sh
+++ b/install-gtex.sh
@@ -107,6 +107,7 @@ RM=${RM:-rm}
 GENERATE_UNINSTALL=${GENERATE_UNINSTALL:-true}
 AUTO_UNINSTALL=${AUTO_UNINSTALL:-false}
 REMOVE_OLD_FILES=${REMOVE_OLD_FILES:-true}
+install_start=false
 
 arg="$1"
 case "$arg" in
@@ -167,6 +168,12 @@ UNINSTALL_SCRIPT="${TEXMFROOT}/${UNINSTALL_SCRIPT_DIR}/${UNINSTALL_SCRIPT_FILE}"
 
 function die {
     echo 'Failed.'
+    if $install_start
+    then
+        echo "Cleaning up partial install"
+        source "${UNINSTALL_SCRIPT}"
+        rm "${UNINSTALL_SCRIPT}"
+    fi
     exit 1
 }
 
@@ -175,6 +182,8 @@ function install_to {
     shift
     mkdir -p "${TEXMFROOT}/$dir" || die
     $CP "$@" "${TEXMFROOT}/$dir" || die
+
+    install_start=true
 
     if ${GENERATE_UNINSTALL}
     then

--- a/install-gtex.sh
+++ b/install-gtex.sh
@@ -170,9 +170,12 @@ function die {
     echo 'Failed.'
     if $install_start
     then
-        echo "Cleaning up partial install"
-        source "${UNINSTALL_SCRIPT}"
-        rm "${UNINSTALL_SCRIPT}"
+        if [ -f ${UNINSTALL_SCRIPT} ]
+        then
+            echo "Cleaning up partial install"
+            source "${UNINSTALL_SCRIPT}"
+            rm "${UNINSTALL_SCRIPT}"
+        fi
     fi
     exit 1
 }


### PR DESCRIPTION
The uninstall script stub is installed fairly early in the process, before many of the installed files are put into place (it's populated as the files are installed).  Since the presence of this script is considered a block to future installations (barring the use of the AUTO_UNINSTALL variable) this makes life difficult when the installation fails part-way through.  Since a partial installation won't work anyway, this change makes use of the uninstall script stub to remove the partial install and then removes the stub itself, clearing the way for a clean installation after the problem causing the failure has been fixed.