### PR TITLE
Ligatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][CTAN]
+### Fixed
+- Corrected interaction issues between text styles and ligatures.  The LaTeX commands like `\textit` insert italics correction, preventing ligatures being formed between their arguments if two occur sequentially.  On the other hand the switches like `\itshape` do not.  Since gregorio breaks up syllables around the vowel and then applies the formating commands to each part, this behavior showed up.  We switch to using the switches to avoid this (except for underlining, for which a switch does not exist).  We also fix this for color tags by loading `luacolor` which changes how the `\color` tag is implemented to allow ligatures to span groups.  See [#1444](https://github.com/gregorio-project/gregorio/issues/1444).
 
 
 ## [5.2.1] - 2019-04-06

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -2551,15 +2551,13 @@
   \gre@trace{gre@fillhole{#1}{#2}}%
   \ifgre@boxing\else %
     \global\gre@count@lastglyphiscavum=1\relax %
+    \setbox\gre@box@temp@sign=\hbox to 0pt {%
+      {\color{grebackgroundcolor}#1}%
+      \rule{0pt}{0pt}% this trick prevents the color from leaking out of this box
+      \hss}%
+    \luacolorProcessBox\gre@box@temp@sign%
     \ifcase#2\raise \gre@dimen@glyphraisevalue\fi%
-    \hbox to 0pt{%
-      {%
-      \color{grebackgroundcolor}%
-      #1 %
-      }%
-      %\pdfliteral{}% this is a ugly hack for old versions of LuaTeX to work
-      \hss %
-    }%
+    \copy\gre@box@temp@sign%
     \GreNoBreak %
   \fi %
   \relax %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -2551,12 +2551,11 @@
   \gre@trace{gre@fillhole{#1}{#2}}%
   \ifgre@boxing\else %
     \global\gre@count@lastglyphiscavum=1\relax %
-    \setbox\gre@box@temp@sign=\hbox{#1}%
     \ifcase#2\raise \gre@dimen@glyphraisevalue\fi%
     \hbox to 0pt{%
       {%
       \color{grebackgroundcolor}%
-      \copy\gre@box@temp@sign %
+      #1 %
       }%
       %\pdfliteral{}% this is a ugly hack for old versions of LuaTeX to work
       \hss %

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -25,6 +25,7 @@
 \ifcsname gregoriotex@symbols@loaded\endcsname\gre@error{Loading gregoriotex after\MessageBreak gregoriosyms is not supported.  Please remove the\MessageBreak loading of gregoriosyms (its contents are loaded\MessageBreak by gregoriotex)}\fi%
 
 \RequirePackage{xcolor}%
+\RequirePackage{luacolor}%
 \RequirePackage{kvoptions}%
 \RequirePackage{ifluatex}%
 \RequirePackage{graphicx}% for \resizebox

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -102,22 +102,22 @@
 %%%%%%%%%
 
 \def\GreItalic#1{%
-  \textit{#1}%
+  {\itshape #1}%
   \relax %
 }
 
 \def\GreSmallCaps#1{%
-  \textsc{#1}%
+  {\scshape #1}%
   \relax %
 }
 
 \def\GreBold#1{%
-  \textbf{#1}%
+  {\bfseries #1}%
   \relax %
 }
 
 \def\GreTypewriter#1{%
-  \texttt{#1}%
+  {\ttfamily #1}%
   \relax %
 }
 


### PR DESCRIPTION
Corrected interaction issues between text styles and ligatures.  The LaTeX commands like `\textit` insert italics correction, preventing ligatures being formed between their arguments if two occur sequentially.  On the other hand the switches like `\itshape` do not.  Since gregorio breaks up syllables around the vowel and then applies the formating commands to each part, this behavior showed up.  We switch to using the switches to avoid this (except for underlining, for which a switch does not exist).  We also fix this for color tags by loading `luacolor` which changes how the `\color` tag is implemented to allow ligatures to span groups.  See [#1444](https://github.com/gregorio-project/gregorio/issues/1444).
