### PR TITLE
Fix documentation

### DIFF
--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -461,6 +461,8 @@ Note that the font will be looked up by name through luaotfload, see the documen
   & \texttt{granapadano} & Use the Grana Padano font.\\
 \end{argtable}
 
+\textbf{Nota Bene:} The Gregorio and Grana Padano fonts are not included by default in a basic installation.  To get them you need to download and install them from the \verb=supp-fonts-##.zip= file (where \#\# is the version number of your release).  See \url{https://github.com/gregorio-project/gregorio/releases} for the list of releases.
+
 \macroname{\textbackslash gresetgregoriofontscaled}{[\optional{\#1}]\{\#2\}\{\#3\}}{gregoriotex-main.tex}
 
 This function is the same as above, with a third argument to scale the font. The fonts shipped with Gregorio do not need to use this function, but some custom fonts do. Note that you cannot use this to scale glyphs up or down, as they would not be placed correctly on the staff.

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -964,8 +964,8 @@ Macro to specify how the translation text should be aligned with it respective s
 Macro to specify which line of the annotation should be used to determine its starting placement (i.e. before \texttt{annotationraise} is applied).
 
 \begin{argtable}
-  \#1 & \texttt{firstline} & Annotation placement is determined by the first line (default)\\
-  & \texttt{lastline} & annotation placement is determined by the last line\\
+  \#1 & \texttt{topline} & Annotation placement is determined by the first line (default)\\
+  & \texttt{bottomline} & annotation placement is determined by the last line\\
 \end{argtable}
 
 \macroname{\textbackslash gresetannotationvalign}{\{\#1\}}{gregoriotex-main.tex}

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -491,7 +491,7 @@ Some examples:
     g(g) g<sp>~~</sp>(g~) g<(g<) g>(g>) go(go) go<sp>~~</sp>(go~) gw(gw)
     gv(gv) gV(gV) gs(gs) gs<(gs<) g=(g=)
     ( ) (z) ( )
-    gr(gr) gR(gR) gr0(gr0) G(G) G0(G0) G1(G1) G~(G~) G>(G>) Gr(Gr) gx(gx)
+    gr(gr) gR(gR) gr0(gr0) G(G) G0(G0) G1(G1) G<sp>~~</sp>(G~) G>(G>) Gr(Gr) gx(gx)
     g#(g#) gy(gy)
     ( )
   }


### PR DESCRIPTION
These keywords in the documentation were not aligned with the code base.