### PR TITLE
Make end of element unbreakable by default

### DIFF
--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -4140,7 +4140,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                                         && element->next->type == GRE_ALT
                                         && element->next->next->type ==
                                         GRE_ELEMENT))) {
-                    fprintf(f, "\\GreEndOfElement{0}{0}{%u}%%\n",
+                    fprintf(f, "\\GreEndOfElement{0}{1}{%u}%%\n",
                             note_unit_count);
                 }
                 break;


### PR DESCRIPTION
This is a proposal to fix #1504 if there is no objection. It restores the old behavior: line breaks are allowed between neumatic elements only if a `/` is typed.