### PR TITLE
Modify vowel message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ### Added
 - Default spacings are now designated internal and thus always loaded.  `gsp-sample.tex` is added to the `doc` folder to show users how to create their own custom spacing configuration.  As part of this change, spacing configuration files no longer need to be complete.  Since the default configuration is always loaded at package startup, all needed penalties and spacings will be defined and the user's configuration file need only specify those whose value they wish to customize.  Addresses issues raised in [#1460](https://github.com/gregorio-project/gregorio/issues/1460).  **This is a change to the user interface and warrants a major release.**
+- Added additional message to verbose output of command-line tool to prevent confusion when a custom Latin vowel convention is found that the internal Latin rules will be used.  See [#1470](https://github.com/gregorio-project/gregorio/issues/1470).
 
 ## [Unreleased][CTAN]
 ### Fixed

--- a/src/characters.c
+++ b/src/characters.c
@@ -86,7 +86,7 @@ static bool read_vowel_rules(char *const lang) {
         }
     }
     if ((strcmp(language, "Latin") == 0 || strcmp(language, "latin") == 0 || strcmp(language, "la") == 0 || strcmp(language, "lat") == 0) && status == RFPS_NOT_FOUND) {
-        gregorio_messagef("read_rules", VERBOSITY_INFO, 0, "Falling back on internal Latin");
+        gregorio_messagef("read_rules", VERBOSITY_INFO, 0, "Falling back on internal Latin vowel rules");
     }
     if (status == RFPS_ALIASED) {
         gregorio_messagef("read_rules", VERBOSITY_WARNING, 0,
@@ -111,7 +111,7 @@ void gregorio_set_centering_language(char *const language)
         if (strcmp(language, "Latin") != 0 && strcmp(language, "latin") != 0 && strcmp(language, "la") != 0 && strcmp(language, "lat") != 0) {
             gregorio_messagef("gregorio_set_centering_language",
                     VERBOSITY_WARNING, 0, _("unable to read vowel files for "
-                        "%s; defaulting to Latin rules"), language);
+                        "%s; defaulting to Latin vowel rules"), language);
         }
 
         gregorio_vowel_tables_init();

--- a/src/characters.c
+++ b/src/characters.c
@@ -85,6 +85,9 @@ static bool read_vowel_rules(char *const lang) {
             break;
         }
     }
+    if ((strcmp(language, "Latin") == 0 || strcmp(language, "latin") == 0 || strcmp(language, "la") == 0 || strcmp(language, "lat") == 0) && status == RFPS_NOT_FOUND) {
+        gregorio_messagef("read_rules", VERBOSITY_INFO, 0, "Falling back on internal Latin");
+    }
     if (status == RFPS_ALIASED) {
         gregorio_messagef("read_rules", VERBOSITY_WARNING, 0,
                 _("Unable to resolve alias for %s"), lang);


### PR DESCRIPTION
There is no Latin vowel definitions in gregorio-vowels.dat by default because they are built into the binary itself.  The user can, however, define their own alternative, so it is conceivable that there might be.  We thus print a little extra information when were falling back to the internal Latin vowel definitions so that the user isn't confused by the "Could not find" message.

Fixes #1470.

No testing changes.