### PR TITLE
Name font calibration distances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - GregorioTeX will now look in additional places for scores using.  Users can specify paths to look in using `\gresetgregpath`.  If scores are not found in the current working directory or the list of provided paths, we fall back on kpse to try and find them.  See [#1395](https://github.com/gregorio-project/gregorio/issues/1395).
 - Added the ability to toggle the visibility of the translation and above lines text.  See [user request on mailing list](https://groups.google.com/g/gregorio-users/c/J-V0dkBMevY).
 
-### Deprecated
-- `noteadditionalspacelinestext` is removed in favor of calculating the actual amount of additional space needed by low notes.
+### Changed
+- `noteadditionalspacelinestext` now calculates the actual amount of additional space needed by low notes.  To enable the old behavior (when `noteadditionalspacelinestext` is set by the user), use `\gresetnoteadditionalspacelinestext{manual}`.  See [#1521](https://github.com/gregorio-project/gregorio/issues/1521) and [#1526](https://github.com/gregorio-project/gregorio/pull/1526).
 
 
 ## [5.2.1] - 2019-04-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - GregorioTeX will now look in additional places for scores using.  Users can specify paths to look in using `\gresetgregpath`.  If scores are not found in the current working directory or the list of provided paths, we fall back on kpse to try and find them.  See [#1395](https://github.com/gregorio-project/gregorio/issues/1395).
 - Added the ability to toggle the visibility of the translation and above lines text.  See [user request on mailing list](https://groups.google.com/g/gregorio-users/c/J-V0dkBMevY).
 
-### Removed
-- `noteadditionalspacelinestext` is removed in favor of calculating the actual amount of additional space needed by low notes.  Because the replacement is an automatic calculation, we skip straight to marking `noteadditionalspacelinestext` as obsolete (as we generally require deprecated code to still be functional).
+### Deprecated
+- `noteadditionalspacelinestext` is removed in favor of calculating the actual amount of additional space needed by low notes.
 
 
 ## [5.2.1] - 2019-04-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - GregorioTeX will now look in additional places for scores using.  Users can specify paths to look in using `\gresetgregpath`.  If scores are not found in the current working directory or the list of provided paths, we fall back on kpse to try and find them.  See [#1395](https://github.com/gregorio-project/gregorio/issues/1395).
 - Added the ability to toggle the visibility of the translation and above lines text.  See [user request on mailing list](https://groups.google.com/g/gregorio-users/c/J-V0dkBMevY).
 
+### Removed
+- `noteadditionalspacelinestext` is removed in favor of calculating the actual amount of additional space needed by low notes.  Because the replacement is an automatic calculation, we skip straight to marking `noteadditionalspacelinestext` as obsolete (as we generally require deprecated code to still be functional).
+
 
 ## [5.2.1] - 2019-04-06
 ### Fixed

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1422,10 +1422,8 @@ baseline.
 \end{gcount}
 
 \begin{gcount}{noteadditionalspacelinestextthreshold}
-The number of low notes which will add on the
-\texttt{noteadditionalspacelinestext} space.  For instance, with a threshold of
-\texttt{2}, every note below \texttt{c} will add {noteadditionalspacelinestext}
-space for each pitch needed below \texttt{c}, accounting for the various signs.
+The number of low notes which will add space between the lines and the lyrics.  For instance, with a threshold of
+\texttt{2}, every note below \texttt{c} will add space for each pitch needed below \texttt{c}, accounting for the various signs.
 \end{gcount}
 
 \subsection{Distances}\label{distances}
@@ -1729,11 +1727,6 @@ The space above the lines.
 
 \begin{gdimension}{spacelinestext}
 The space between the lines and the bottom of the text.
-\end{gdimension}
-
-\begin{gdimension}{noteadditionalspacelinestext}
-The space added between the lines and the bottom of the text for every pitch
-below the \texttt{noteadditionalspacelinestextthreshold}.
 \end{gdimension}
 
 \begin{gdimension}{spacebeneathtext}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -410,6 +410,13 @@ staff).  The \texttt{\textit{n}} should be set to indicate whether the
 system should act as if the ledger line exists (\texttt{1}) or not
 (\texttt{0}).
 
+\macroname{\textbackslash gresetnoteadditionalspacelinestext}{\{\#1\}}{gregoriotex-main.tex}
+Macro which determines how much additional space between the notes and the lyrics for really low notes.
+
+\begin{argtable}
+  \#1 & \texttt{automatic} & additional space between the notes and the lyrics is computed automatically (default)\\
+  & \texttt{manual} & additional space between the notes and the lyrics is based on the user setting of \texttt{noteadditionalspacelinestext} (a spacing adjustable using \verb=\grechangedim=)
+\end{argtable}
 
 \subsubsection{Staff Lines}
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1948,6 +1948,10 @@ Boolean indicating that the text of this syllable should not overlap any previou
 \macroname{\textbackslash ifgre@evaluatingnextsyllable}{}{gregoriotex-syllable.tex}
 Boolean indicating that some aspect of the next syllable is being evaluated in advance.
 
+\macroname{\textbackslash ifgre@noteadditionalspacelinestext}{}{gregoriotex-main.tex}
+Boolean indicating that the additional space needed between the notes and the lyrics due to really low notes should follow the user setting of noteadditionalspacelinestext (as opposed to being calculated automatically, the default).
+
+
 \subsection{Boxes}
 
 Boxes are used to store elements of the score before they are printed for the purposes of reusing them and/or measuring them in order to determine their appropriate placement.

--- a/tex/gregoriotex-common.tex
+++ b/tex/gregoriotex-common.tex
@@ -79,7 +79,11 @@
 }%
 
 \def\gre@obsolete#1#2{%
-  \gre@error{#1\space is obsolete.\MessageBreak Use #2\space instead}%
+  \ifx&#2&%
+    \gre@error{#1\space is obsolete and no longer has any effect}%
+  \else%
+    \gre@error{#1\space is obsolete.\MessageBreak Use #2\space instead}%
+  \fi%
   \relax%
 }%
 

--- a/tex/gregoriotex-common.tex
+++ b/tex/gregoriotex-common.tex
@@ -71,9 +71,17 @@
 % #2 - the correct macro to use
 \def\gre@deprecated#1#2{%
   \ifgre@allowdeprecated%
-    \gre@warning{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+    \ifx&#2&%
+      \gre@warning{#1\space is deprecated and marked for removal}%
+    \else%
+      \gre@warning{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+    \fi%
   \else%
-    \gre@error{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+    \ifx&#2&%
+      \gre@error{#1\space is deprecated and marked for removal}%
+    \else%
+      \gre@error{#1\space is deprecated.\MessageBreak Use #2\space instead}%
+    \fi%
   \fi%
   \relax%
 }%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1126,6 +1126,19 @@
     ]%
 }%
 
+\newif\ifgre@noteadditionalspacelinestext%
+\def\gresetnoteadditionalspacelinestext#1{%
+  \IfStrEqCase{#1}{%
+    {automatic}%
+      {\gre@noteadditionalspacelinestextfalse}%
+    {manual}%
+      {\gre@noteadditionalspacelinestexttrue}%
+    }[% all other cases
+      \gre@error{Unrecognized option "#1" for \protect\gresetnoteadditionalspacelinestext\MessageBreak Possible options are: 'automatic' and 'manual'}%
+    ]%
+}%
+\gresetnoteadditionalspacelinestext{automatic}%default setting
+
 % gre@attr@dash (see its definition in gregorio-syllable) is 0 when we are in a score, and unset when we are not
 
 \newif\ifgre@beginningofscore%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1787,6 +1787,14 @@
   \gre@trace@end%
 }%
 
+%% font calibration distances
+\newdimen\gre@dimen@stafflinethicknessbase%
+\newdimen\gre@dimen@glyphraisebase%
+\newdimen\gre@dimen@interstafflinedistancebase%
+\newdimen\gre@dimen@inclinatumonlinemoravshiftbase%
+\newdimen\gre@dimen@inclinatumonlinemorahshiftbase%
+\newdimen\gre@dimen@inclinatumofflinemorahshiftbase%
+
 \def\gre@setgregoriofontscaled[#1]#2#3{%
   \gre@trace{gre@setgregoriofontscaled[#1]{#2}{#3}}%
   \IfStrEq{#2}{parmesan}{%%% OBSOLETE
@@ -1805,7 +1813,13 @@
       \gdef\GreCPVirgaReversaAscendensOnDLine##1{\GreCPVirgaReversaLongqueueAscendens}%
     \fi %
   }%%% OBSOLETE
-  \relax %
+  % currently all fonts use the same calibration distances
+  \gre@dimen@stafflinethicknessbase=1500sp\relax %
+  \gre@dimen@glyphraisebase=-22000sp\relax%
+  \gre@dimen@interstafflinedistancebase=30000sp\relax%
+  \gre@dimen@inclinatumonlinemoravshiftbase=4500sp\relax%
+  \gre@dimen@inclinatumonlinemorahshiftbase=3700sp\relax%
+  \gre@dimen@inclinatumofflinemorahshiftbase=2500sp\relax%
   \gre@trace@end%
 }%
 

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1210,12 +1210,12 @@
   % here we shift a bit left in the case where we have a punctum inclinatum on a line
   \ifnum#4=1\relax %
     \ifgre@isonaline %
-      \gre@dimen@temp@three=\dimexpr(3700sp * \gre@factor)\relax %
+      \gre@dimen@temp@three=\dimexpr(\gre@dimen@inclinatumonlinemorahshiftbase * \gre@factor)\relax %
       \kern-\gre@dimen@temp@three %
-      \gre@dimen@temp@three=\dimexpr(4500sp * \gre@factor)\relax%
+      \gre@dimen@temp@three=\dimexpr(\gre@dimen@inclinatumonlinemoravshiftbase * \gre@factor)\relax%
       \advance\gre@dimen@glyphraisevalue by -\gre@dimen@temp@three %
     \else %
-      \gre@dimen@temp@three=\dimexpr(2500sp * \gre@factor)\relax %
+      \gre@dimen@temp@three=\dimexpr(\gre@dimen@inclinatumofflinemorahshiftbase * \gre@factor)\relax %
       \advance\gre@dimen@glyphraisevalue by -\gre@dimen@temp@three %
     \fi %
   \fi %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1011,7 +1011,11 @@
   \gre@num@min{#2}{\gre@pitch@clefbottom}%
   \gre@count@temp@one=\numexpr(\gre@pitch@adjust@bottom - \gre@count@temp@one)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionalbottomspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
+    \ifgre@allowdeprecated% DEPRECATED
+          \global\gre@dimen@additionalbottomspace=\dimexpr(\gre@space@dimen@noteadditionalspacelinestext * \gre@count@temp@one)\relax % DEPRECATED
+    \else% DEPRECATED
+      \global\gre@dimen@additionalbottomspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax % keep this line
+    \fi% DEPRECATED
   \else %
     \global\gre@dimen@additionalbottomspace=0 sp%
   \fi %
@@ -1579,7 +1583,7 @@
 
 % a macro for changing a dimension.  Unlike \grecreatedim, this function won’t create a new distance, just change an existing one.
 \def\grechangedim#1#2#3{%
-  \IfStrEq{noteadditionalspacelinestext}{#1}{\gre@obsolete{noteadditionalspacelinestext}{}}{}%%% OBSOLETE
+  \IfStrEq{noteadditionalspacelinestext}{#1}{\gre@deprecated{noteadditionalspacelinestext}{}}{}%%% DEPRECATED
   \gre@rubberpermit{#1}%
   % figure out our prefix
   \ifgre@rubber%
@@ -1899,6 +1903,7 @@
     {alterationadjustmentbar}{\gre@rubberfalse}%
     {bracketupshift}{\gre@rubberfalse}%
     {bracketdownshift}{\gre@rubberfalse}%
+    {noteadditionalspacelinestext}{\gre@rubberfalse}% DEPRECATED
   }[\gre@rubbertrue]%
   \gre@trace@end%
 }%
@@ -2349,6 +2354,9 @@
     \gre@count@temp@two = \numexpr((\gre@stafflinefactor * #2) / #1)\relax%
     \xdef\gre@stafflinefactor{\the\gre@count@temp@two}%
   \fi%
+  \ifgre@scale@noteadditionalspacelinestext% DEPRECATED
+    \gre@changeonedimenfactor{noteadditionalspacelinestext}{#1}{#2}% DEPRECATED
+  \fi% DEPRECATED
   \relax %
   \gre@trace@end%
 }%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1011,11 +1011,11 @@
   \gre@num@min{#2}{\gre@pitch@clefbottom}%
   \gre@count@temp@one=\numexpr(\gre@pitch@adjust@bottom - \gre@count@temp@one)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \ifgre@allowdeprecated% DEPRECATED
-          \global\gre@dimen@additionalbottomspace=\dimexpr(\gre@space@dimen@noteadditionalspacelinestext * \gre@count@temp@one)\relax % DEPRECATED
-    \else% DEPRECATED
-      \global\gre@dimen@additionalbottomspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax % keep this line
-    \fi% DEPRECATED
+    \ifgre@noteadditionalspacelinestext%
+      \global\gre@dimen@additionalbottomspace=\dimexpr(\gre@space@dimen@noteadditionalspacelinestext * \gre@count@temp@one)\relax%
+    \else%
+      \global\gre@dimen@additionalbottomspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@factor * \gre@count@temp@one)\relax%
+    \fi%
   \else %
     \global\gre@dimen@additionalbottomspace=0 sp%
   \fi %
@@ -1583,7 +1583,6 @@
 
 % a macro for changing a dimension.  Unlike \grecreatedim, this function won’t create a new distance, just change an existing one.
 \def\grechangedim#1#2#3{%
-  \IfStrEq{noteadditionalspacelinestext}{#1}{\gre@deprecated{noteadditionalspacelinestext}{}}{}%%% DEPRECATED
   \gre@rubberpermit{#1}%
   % figure out our prefix
   \ifgre@rubber%
@@ -1903,7 +1902,7 @@
     {alterationadjustmentbar}{\gre@rubberfalse}%
     {bracketupshift}{\gre@rubberfalse}%
     {bracketdownshift}{\gre@rubberfalse}%
-    {noteadditionalspacelinestext}{\gre@rubberfalse}% DEPRECATED
+    {noteadditionalspacelinestext}{\gre@rubberfalse}%
   }[\gre@rubbertrue]%
   \gre@trace@end%
 }%
@@ -2354,9 +2353,9 @@
     \gre@count@temp@two = \numexpr((\gre@stafflinefactor * #2) / #1)\relax%
     \xdef\gre@stafflinefactor{\the\gre@count@temp@two}%
   \fi%
-  \ifgre@scale@noteadditionalspacelinestext% DEPRECATED
-    \gre@changeonedimenfactor{noteadditionalspacelinestext}{#1}{#2}% DEPRECATED
-  \fi% DEPRECATED
+  \ifgre@scale@noteadditionalspacelinestext%
+    \gre@changeonedimenfactor{noteadditionalspacelinestext}{#1}{#2}%
+  \fi%
   \relax %
   \gre@trace@end%
 }%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1011,7 +1011,7 @@
   \gre@num@min{#2}{\gre@pitch@clefbottom}%
   \gre@count@temp@one=\numexpr(\gre@pitch@adjust@bottom - \gre@count@temp@one)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionalbottomspace=\dimexpr(\gre@space@dimen@noteadditionalspacelinestext * \gre@count@temp@one)\relax %
+    \global\gre@dimen@additionalbottomspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
   \else %
     \global\gre@dimen@additionalbottomspace=0 sp%
   \fi %
@@ -1579,6 +1579,7 @@
 
 % a macro for changing a dimension.  Unlike \grecreatedim, this function won’t create a new distance, just change an existing one.
 \def\grechangedim#1#2#3{%
+  \IfStrEq{noteadditionalspacelinestext}{#1}{\gre@obsolete{noteadditionalspacelinestext}{}}{}%%% OBSOLETE
   \gre@rubberpermit{#1}%
   % figure out our prefix
   \ifgre@rubber%
@@ -1898,7 +1899,6 @@
     {alterationadjustmentbar}{\gre@rubberfalse}%
     {bracketupshift}{\gre@rubberfalse}%
     {bracketdownshift}{\gre@rubberfalse}%
-    {noteadditionalspacelinestext}{\gre@rubberfalse}%
   }[\gre@rubbertrue]%
   \gre@trace@end%
 }%
@@ -2348,9 +2348,6 @@
   \ifgre@scale@stafflinefactor%
     \gre@count@temp@two = \numexpr((\gre@stafflinefactor * #2) / #1)\relax%
     \xdef\gre@stafflinefactor{\the\gre@count@temp@two}%
-  \fi%
-  \ifgre@scale@noteadditionalspacelinestext%
-    \gre@changeonedimenfactor{noteadditionalspacelinestext}{#1}{#2}%
   \fi%
   \relax %
   \gre@trace@end%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -166,35 +166,29 @@
 
 % Messing with the staff line thickness directly is messy, so we provide the following interface to make life easier on the user:
 % stafflineheight is the height of a staff line
-% = 1500 * stafflinefactor
+% = gre@dimen@stafflinethicknessbase * stafflinefactor
 \newdimen\gre@dimen@stafflineheight\relax%
 \def\gre@calculate@stafflineheight{%
   \gre@trace{gre@calculate@stafflineheight}%
-  \global\gre@dimen@stafflineheight=\dimexpr(1500 sp * \gre@stafflinefactor)\relax %
+  \global\gre@dimen@stafflineheight=\dimexpr(\gre@dimen@stafflinethicknessbase * \gre@stafflinefactor)\relax %
   \gre@trace@end%
 }%
 
 % interstafflinespace is the space between two lines of staff
-% = (30000 - (stafflineheight/gre@factor - 1500)) * gre@factor = 31500 * gre@factor - stafflineheight
+% = (gre@dimen@interstafflinedistancebase + gre@dimen@stafflinethicknessbase) * gre@factor - gre@dimen@stafflinethicknessbase * gre@stafflinefactor
 \newdimen\gre@dimen@interstafflinespace\relax%
 \def\gre@calculate@interstafflinespace{%
   \gre@trace{gre@calculate@interstafflinespace}%
-  \global\gre@dimen@interstafflinespace=\dimexpr((31500sp * \gre@factor) %
-    - \gre@dimen@stafflineheight)\relax%
+  \global\gre@dimen@interstafflinespace=\dimexpr((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) * \gre@factor - \gre@dimen@stafflinethicknessbase * \gre@stafflinefactor)\relax%
   \gre@trace@end%
 }%
 
 % a distance to help place glyphs when the lines are not their default thickness
-% = (stafflineheight/gre@factor - 1500sp)/2 * gre@factor
+% = gre@dimen@stafflinethicknessbase * (gre@stafflinefactor - gre@factor) / 2
 \newdimen\gre@dimen@stafflinediff\relax%
 \def\gre@calculate@stafflinediff{%
   \gre@trace{gre@calculate@stafflinediff}%
-  \global\gre@dimen@stafflinediff = \dimexpr(%
-    ( ( ( \gre@dimen@stafflineheight %
-          / \gre@factor)%
-        - 1500sp)%
-      / 2)%
-    * \gre@factor)\relax%
+  \global\gre@dimen@stafflinediff = \dimexpr( \gre@dimen@stafflinethicknessbase * (\gre@stafflinefactor - \gre@factor) / 2 )\relax%
   \gre@trace@end%
 }%
 
@@ -217,7 +211,7 @@
 % to calculate that, we take the bottom of the third line : it is at 200 in the fonts, and it must be at grespacelinestext + grespacebeneathtext + 2*greinterstafflinespace + 2*grestafflineheight + translationheight
 \def\gre@calculate@constantglyphraise{%
   \gre@trace{gre@calculate@constantglyphraise}%
-  \global\gre@dimen@constantglyphraise = \dimexpr((-22000 sp * \gre@factor) %
+  \global\gre@dimen@constantglyphraise = \dimexpr((\gre@dimen@glyphraisebase * \gre@factor) %
     + \gre@dimen@additionalbottomspace %
     + \gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext %
@@ -812,7 +806,7 @@
     \fi%
   \fi%
   \global\advance\gre@count@temp@three by -8 %
-  \global\gre@dimen@glyphraisevalue = \dimexpr(15750 sp * \gre@factor * \gre@count@temp@three)\relax %
+  \global\gre@dimen@glyphraisevalue = \dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@factor * \gre@count@temp@three)\relax %
   \ifcase#2 %
   \or\or\or%3: if it is a vertical episema on a line, we shift it a bit higher, so that it's more beautiful
     \ifgre@isonaline%
@@ -996,21 +990,21 @@
   \gre@num@max{#1}{\gre@pitch@cleftop}%
   \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacethreshold)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionaltopspace=\dimexpr(15750 sp * \gre@count@temp@one * \gre@factor)\relax %
+    \global\gre@dimen@additionaltopspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
   \else %
     \global\gre@dimen@additionaltopspace=0 sp%
   \fi %
   \gre@num@max{#1}{\gre@pitch@cleftop}%
   \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacealtthreshold)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionaltopspacealt=\dimexpr(15750 sp * \gre@count@temp@one * \gre@factor)\relax %
+    \global\gre@dimen@additionaltopspacealt=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
   \else %
     \global\gre@dimen@additionaltopspacealt=0 sp%
   \fi %
   \gre@num@max{#1}{\gre@pitch@cleftop}%
   \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacenabcthreshold)\relax %
   \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionaltopspacenabc=\dimexpr(15750 sp * \gre@count@temp@one * \gre@factor)\relax %
+    \global\gre@dimen@additionaltopspacenabc=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
   \else %
     \global\gre@dimen@additionaltopspacenabc=0 sp%
   \fi %

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -358,6 +358,8 @@
 \grechangecount{additionaltopspacenabcthreshold}{4}%
 %the space between the lines and the bottom of the text
 \grecreatedim{spacelinestext}{0.60617 cm}{scalable}%
+% DEPRECATED the per-note additional space between lines and the bottom of the text  DEPRECATED
+\grecreatedim{noteadditionalspacelinestext}{0.14413 cm}{scalable}% DEPRECATED
 % this counter is the number of low notes which will add on additional distance
 \grechangecount{noteadditionalspacelinestextthreshold}{2}%
 %the space beneath the text

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -358,8 +358,8 @@
 \grechangecount{additionaltopspacenabcthreshold}{4}%
 %the space between the lines and the bottom of the text
 \grecreatedim{spacelinestext}{0.60617 cm}{scalable}%
-% DEPRECATED the per-note additional space between lines and the bottom of the text  DEPRECATED
-\grecreatedim{noteadditionalspacelinestext}{0.14413 cm}{scalable}% DEPRECATED
+% the per-note additional space between lines and the bottom of the text
+\grecreatedim{noteadditionalspacelinestext}{0.14413 cm}{scalable}%
 % this counter is the number of low notes which will add on additional distance
 \grechangecount{noteadditionalspacelinestextthreshold}{2}%
 %the space beneath the text

--- a/tex/gsp-default.tex
+++ b/tex/gsp-default.tex
@@ -358,12 +358,7 @@
 \grechangecount{additionaltopspacenabcthreshold}{4}%
 %the space between the lines and the bottom of the text
 \grecreatedim{spacelinestext}{0.60617 cm}{scalable}%
-%the per-note additional space between lines and the bottom of the text
-\grecreatedim{noteadditionalspacelinestext}{0.14413 cm}{scalable}%
-% this counter is the number of low notes which will add on the
-% noteadditionalspacelinestext.  For instance, with a threshold of 2, every
-% note below c will add noteadditionalspacelinestext space for each pitch needed
-% below c, accounting for the various signs.
+% this counter is the number of low notes which will add on additional distance
 \grechangecount{noteadditionalspacelinestextthreshold}{2}%
 %the space beneath the text
 \grecreatedim{spacebeneathtext}{0 cm}{scalable}%


### PR DESCRIPTION
There were several "magic distances" still in the code.  All of these distances are related to calibrating things to the fonts and so should not be user editable.  However, having those numbers scattered through the codebase is harder to maintain (if you change one, you have to figure out which of the others also needs to change, by how much, and where they all are), so based on relationships between the numbers, I've reduced them to 6 named dimensions which are then used as needed in the various calculations.

Fixes #1521.