### PR TITLE
Implemented control over automatic linebreaks between unison notes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ ctan
 *.pyg
 .agignore
 *.orig
+compile_commands.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ## [Unreleased][develop]
 
+- Added a configurable setting `\gresetunisonbreakbehavior` to control automatic line breaks between unison notes above a syllable.  Defaults to `breakable` for backwards compatibility, but may be set to `unbreakable` if that behavior is desired.  See [#1504](https://github.com/gregorio-project/gregorio/issues/1504).
 
 ## [Unreleased][CTAN]
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1178,6 +1178,19 @@ Configures how notes should be kept together on line breaks.
                   lines.  Defaults to \getgrecount{unbreakablefinalnotes}.\\
 \end{argtable}
 
+\macroname{\textbackslash gresetunisonbreakbehavior}{\{\#1\}}{gregoriotex-main.tex}
+Macro to determine whether an automatic linebreak may occur between unison notes
+over a syllable.  This behavior governs how the system works when no explicit
+space is put between the notes.  In other words, any explicit space between the
+notes take precedence over this setting.
+
+\begin{argtable}
+  \#1 & \texttt{breakable}   & Allow automatic linebreaks between unison notes
+                               (default)\\
+      & \texttt{unbreakable} & Disallow automatic linebreaks between unison
+                               notes\\
+\end{argtable}
+
 
 \subsubsection{Bar spacing}
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -450,7 +450,7 @@ Macro to end a glyph without ending the element.
 
 \macroname{\textbackslash GreFinalCustos}{\#1\#2}{gregoriotex-signs.tex}
 Typesets a custos after the final bar in a score.
-um
+
 \begin{argtable}
   \#1 & integer & Height number of custos.\\
   \#2 & \texttt{Flat} & The custos should have a flat.\\

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -402,6 +402,7 @@ Macro to end elements.
   & \texttt{4} & Ad-hoc space.\\
   \#2 & \texttt{0} & Space is breakable.\\
   & \texttt{1} & Space is unbreakable.\\
+  & \texttt{2} & Space is breakable according to the \verb=\setunisonbreakbehavior= setting.\\
   \#3 & integer & The number of notes in the syllable prior to this macro.\\
 \end{argtable}
 
@@ -444,11 +445,12 @@ Macro to end a glyph without ending the element.
   & \texttt{20} & Space between a punctum inclinatum and a ``no-bar'' glyph two pitches above. \\
   & \texttt{21} & Space between a punctum inclinatum and a ``no-bar'' glyph three or four pitches above \\
   & \texttt{22} & Half-space. \\
+  & \texttt{23} & Space between unison puncta inclinata. \\
 \end{argtable}
 
 \macroname{\textbackslash GreFinalCustos}{\#1\#2}{gregoriotex-signs.tex}
 Typesets a custos after the final bar in a score.
-
+um
 \begin{argtable}
   \#1 & integer & Height number of custos.\\
   \#2 & \texttt{Flat} & The custos should have a flat.\\

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1961,6 +1961,10 @@ Boolean indicating that the next syllable had a forced center in the gabc which 
 \macroname{\textbackslash ifgre@unbreakableendofelement}{}{gregoriotex-main.tex}
 Boolean used by \verb=\GreEndOfElement= to store whether the line may be broken at that point.
 
+\macroname{\textbackslash gre@unbreakableendofelement@unison}{}{gregoriotex-main.tex}
+Alias that sets \verb=\ifgre@unbreakableendofelement= according to the
+\verb=\setunisonbreakbehavior= preference.
+
 \macroname{\textbackslash gre@count@syllablenotes}{}{gregoriotex-syllable.tex}
 Count containing the number of notes in the syllable.
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1506,13 +1506,28 @@
 }%
 
 \newif\ifgre@unbreakableendofelement %
+\def\gresetunisonbreakbehavior#1{%
+  \IfStrEqCase{#1}{%
+    {breakable}%
+      {\global\let\gre@unbreakableendofelement@unison\gre@unbreakableendofelementfalse\relax}%
+    {unbreakable}%
+      {\global\let\gre@unbreakableendofelement@unison\gre@unbreakableendofelementtrue\relax}%
+    }[% all other cases
+      \gre@error{Unrecognized option "#1" for \protect\gresetunisonbreakbehavior\MessageBreak Possible options are: 'breakable' and 'unbreakable'}%
+    ]%
+}%
+\gresetunisonbreakbehavior{breakable}
+
 % macro to end elements, #1 is the type of space, it can be :
 %% 0: default space
 %% 1: larger space
 %% 2: glyph space
 %% 3: zero-width space
 %% 4: custom space
-% #2 is if the space is unbreakable (1) or not (0)
+% #2 is whether the space is breakable :
+%% 0: breakable
+%% 1: unbreakable
+%% 2: unison (breakable according to the unisonbreakbehavior setting)
 % #3 is the number of notes emitted in this syllable before this macro
 \def\GreEndOfElement#1#2#3{%
   \ifnum\gre@count@syllablenotes<\gre@count@unbreakabletotalnotes\relax %
@@ -1525,10 +1540,14 @@
           \gre@count@unbreakablefinalnotes\relax %
         \gre@unbreakableendofelementtrue %
       \else %
-        \ifnum#2=1\relax %
-          \gre@unbreakableendofelementtrue %
-        \else %
+        \ifcase#2\relax %
           \gre@unbreakableendofelementfalse %
+        \or% case 1
+          \gre@unbreakableendofelementtrue %
+        \or% case 2
+          \gre@unbreakableendofelement@unison %
+        \else %
+          \gre@error{Unrecognized breakable argument #2}%
         \fi %
       \fi %
     \fi %
@@ -1538,7 +1557,7 @@
   \else %
     \gre@penalty{\the\gre@space@count@endofelementpenalty}%
   \fi %
-  \ifcase#1%
+  \ifcase#1\relax%
     \gre@skip@temp@four = \gre@space@skip@interelementspace\relax%
     \gre@hskip\gre@skip@temp@four %
   \or% case 1
@@ -1552,6 +1571,8 @@
     \gre@hskip\gre@skip@temp@four %
   \or% case 4
     \gre@hskip\gre@skip@temp@four %
+  \else%
+    \gre@error{Unrecognized space type #1}%
   \fi%
   \ifgre@unbreakableendofelement %
     \GreNoBreak %


### PR DESCRIPTION
Fixes #1504

I added a new `\gresetunisonbreakbehavior` setting which defaults to {breakable} to keep backwards compatibility.