### PR TITLE
Stop custos from erroneously changing into clef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed the interaction between hyphens and styles.  See [#1538](https://github.com/gregorio-project/gregorio/issues/1538).
 - Fixed the loss of ongoing styles when a syllable starts with a forced center.  See [#1551](https://github.com/gregorio-project/gregorio/issues/1551).
 - Fixed first syllables of one letter with a style causing a segfault.  See [#1585](https://github.com/gregorio-project/gregorio/issues/1585).
+- Fixed a bug that caused a custos to sometimes change into a clef. See [#1373](https://github.com/gregorio-project/gregorio/issues/1373).
 
 ### Added
 - Added a configurable setting `\gresetunisonbreakbehavior` to control automatic line breaks between unison notes above a syllable.  Defaults to `breakable` for backwards compatibility, but may be set to `unbreakable` if that behavior is desired.  See [#1504](https://github.com/gregorio-project/gregorio/issues/1504).

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -537,6 +537,13 @@
       \gre@debugmsg{custos}{not blocked}%
       \gre@calculate@glyphraisevalue{#1}{0}{}%
       %here we need some tricks to draw the line before the custos (for the color)
+      % we make \wd\gre@box@temp@sign contain the width of a custos
+      % the \gre@custosalteration changes \gre@box@temp@width, so do this first
+      \setbox\gre@box@temp@sign=\hbox{%
+        \gre@custosalteration{#1}{#2}%
+        \GreNoBreak%
+        \gre@pickcustos{#1}{0}\relax %
+      }%
       \setbox\gre@box@temp@width=\hbox{%
         % we type a hskip and the we type the custos
         \gre@hskip\gre@space@skip@spacebeforeeolcustos\relax %
@@ -548,12 +555,6 @@
         }%
       }%
       \gre@dimen@temp@three=\wd\gre@box@temp@width %
-      % we make \wd\gre@box@temp@sign contain the width of a custos
-      \setbox\gre@box@temp@sign=\hbox{%
-        \gre@custosalteration{#1}{#2}%
-        \GreNoBreak%
-        \gre@pickcustos{#1}{0}\relax %
-      }%
       \gre@localrightbox{%
         \ifgre@showlines %
           \ifnum#1<\gre@pitch@belowstaff\relax %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -215,7 +215,7 @@
 % sets \gre@box@temp@width with the clef, the arguments are the same as \gre@typeclef
 \def\gre@boxclef#1#2#3#4#5#6#7#8{%
   \gre@trace{gre@boxclef{#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}}%
-  \global\setbox\gre@box@temp@width=\hbox{%
+  \setbox\gre@box@temp@width=\hbox{%
     \ifcase#7%
       \gre@typesingleclef{#1}{#2}{#3}{#5}%
     \else %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -537,13 +537,6 @@
       \gre@debugmsg{custos}{not blocked}%
       \gre@calculate@glyphraisevalue{#1}{0}{}%
       %here we need some tricks to draw the line before the custos (for the color)
-      % we make \wd\gre@box@temp@sign contain the width of a custos
-      % the \gre@custosalteration changes \gre@box@temp@width, so do this first
-      \setbox\gre@box@temp@sign=\hbox{%
-        \gre@custosalteration{#1}{#2}%
-        \GreNoBreak%
-        \gre@pickcustos{#1}{0}\relax %
-      }%
       \setbox\gre@box@temp@width=\hbox{%
         % we type a hskip and the we type the custos
         \gre@hskip\gre@space@skip@spacebeforeeolcustos\relax %
@@ -555,6 +548,12 @@
         }%
       }%
       \gre@dimen@temp@three=\wd\gre@box@temp@width %
+      % we make \wd\gre@box@temp@sign contain the width of a custos
+      \setbox\gre@box@temp@sign=\hbox{%
+        \gre@custosalteration{#1}{#2}%
+        \GreNoBreak%
+        \gre@pickcustos{#1}{0}\relax %
+      }%
       \gre@localrightbox{%
         \ifgre@showlines %
           \ifnum#1<\gre@pitch@belowstaff\relax %


### PR DESCRIPTION
`\GreNextCustos` was setting `\gre@box@temp@width` to a custos, then sometimes calling `\gre@custosalteration` which changed `\gre@box@temp@width` to a clef, then using `\gre@box@temp@width`, causing a clef to appear in place of the custos. This changes the order to avoid the problem; not sure if another fix is preferable.

Closes #1604.