### PR TITLE
Fix placement of abovelinestext when number of staff lines is not 4 (#1614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a bug that caused a custos to sometimes change into a clef. See [#1373](https://github.com/gregorio-project/gregorio/issues/1373).
 - Fixed the alignment of 2-line initials so that an initial's baseline more exactly aligns with the baseline of the lowest line it appears next to.
 - When fancyhdr and GregorioTeX are used together, GregorioTeX's disabling of hyphenation and its `post_linebreak` modification of the `post_linebreak_filter` interfere with multiline headers.  Using the `fancyhdr/before` and `fancyhdr/after` hooks we temporarily reenable hyphenation and disable our `post_linebreak` modification while headers and footers are being processed in the middle of a score.  See [#1603](https://github.com/gregorio-project/gregorio/issues/1603).
+- Fixed the placement of above-lines text (`<alt>`) when the number of staff lines is not 4. See [#1614](https://github.com/gregorio-project/gregorio/issues/1614).
 
 ### Changed
 - Modified gregorio to append to the log file specified as an argument and to send early messages to it.  See [#1541](https://github.com/gregorio-project/gregorio/issues/1541).

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1279,9 +1279,6 @@ Sets the number of staff lines.
   \#1 & integer & The number of staff lines\\
 \end{argtable}
 
-\macroname{\textbackslash gre@count@stafflines}{}{gregoriotex-main.tex}
-Count containing the number of staff lines.
-
 \macroname{\textbackslash gre@romannumeral@majuscule}{\#1}{gregoriotex-main.tex}
 Typesets its numeric argument as an upper-case Roman numeral.
 
@@ -1968,6 +1965,8 @@ Boolean indicating that some aspect of the next syllable is being evaluated in a
 \macroname{\textbackslash ifgre@noteadditionalspacelinestext}{}{gregoriotex-main.tex}
 Boolean indicating that the additional space needed between the notes and the lyrics due to really low notes should follow the user setting of noteadditionalspacelinestext (as opposed to being calculated automatically, the default).
 
+\macroname{\textbackslash gre@count@stafflines}{}{gregoriotex-main.tex}
+Count containing the number of staff lines.
 
 \subsection{Boxes}
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1279,8 +1279,8 @@ Sets the number of staff lines.
   \#1 & integer & The number of staff lines\\
 \end{argtable}
 
-\macroname{\textbackslash gre@stafflines}{}{gregoriotex-main.tex}
-Contains the number of staff lines.
+\macroname{\textbackslash gre@count@stafflines}{}{gregoriotex-main.tex}
+Count containing the number of staff lines.
 
 \macroname{\textbackslash gre@romannumeral@majuscule}{\#1}{gregoriotex-main.tex}
 Typesets its numeric argument as an upper-case Roman numeral.
@@ -1874,15 +1874,6 @@ Boolean set by \verb=\GreSyllable= indicating if the Lua pass may add an hyphen 
 
 \macroname{\textbackslash ifgre@scale@stafflinefactor}{}{gregoriotex-spaces.tex}
 Boolean indicating whether the stafflinefactor should scale with changes of \texttt{grefactor}, or not.
-
-\macroname{\textbackslash ifgre@haslinethree}{}{gregoriotex-spaces.tex}
-Boolean indicating whether the staff has a third line.
-
-\macroname{\textbackslash ifgre@haslinefour}{}{gregoriotex-spaces.tex}
-Boolean indicating whether the staff has a fourth line.
-
-\macroname{\textbackslash ifgre@haslinefive}{}{gregoriotex-spaces.tex}
-Boolean indicating whether the staff has a fifth line.
 
 \macroname{\textbackslash gre@count@shiftaftermora}{}{gregoriotex-signs.tex}
 Count indicating when the presence of a punctum mora at the end of a syllable should affect the spacing with the next syllable.

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -788,45 +788,17 @@
     \vbox attr \gre@attrid@part=2 {%
       \gre@style@normalstafflines%
       \vskip\glueexpr(\gre@dimen@additionaltopspace+\gre@space@skip@spaceabovelines+\gre@dimen@currentabovelinestextheight)\relax%
-      \ifgre@showlines %
-        \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-      \else %
-        \vskip\gre@dimen@stafflineheight\relax%
-      \fi %
-      \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-      \kern\gre@skip@temp@four %
-      \ifgre@showlines %
-        \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-      \else %
-        \vskip\gre@dimen@stafflineheight\relax%
-      \fi %
-      \ifgre@haslinethree %
-        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-        \kern\gre@skip@temp@four %
+      \gre@count@temp@one=0\relax
+      \loop
         \ifgre@showlines %
           \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
         \else %
           \vskip\gre@dimen@stafflineheight\relax%
         \fi %
-      \fi %
-      \ifgre@haslinefour %
-        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-        \kern\gre@skip@temp@four %
-        \ifgre@showlines %
-          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-        \else %
-          \vskip\gre@dimen@stafflineheight\relax%
-        \fi %
-      \fi %
-      \ifgre@haslinefive %
-        \gre@skip@temp@four = \gre@dimen@interstafflinespace\relax%
-        \kern\gre@skip@temp@four %
-        \ifgre@showlines %
-          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
-        \else %
-          \vskip\gre@dimen@stafflineheight\relax%
-        \fi %
-      \fi %
+        \advance\gre@count@temp@one by 1\relax
+        \ifnum\gre@count@temp@one<\gre@count@stafflines
+          \kern\gre@dimen@interstafflinespace\relax
+        \repeat
       \kern\dimexpr(\gre@space@dimen@spacelinestext+\gre@dimen@additionalbottomspace+\gre@space@dimen@spacebeneathtext+\gre@dimen@currenttranslationheight)\relax%
       \endgre@style@normalstafflines %
     }%
@@ -1048,13 +1020,11 @@
 % gre@attr@dash (see its definition in gregorio-syllable) is 0 when we are in a score, and unset when we are not
 
 \newif\ifgre@beginningofscore%
-\newif\ifgre@haslinethree%
-\newif\ifgre@haslinefour%
-\newif\ifgre@haslinefive%
 
+\newcount\gre@count@stafflines
 \def\gre@setstafflines#1{%
   \gre@trace{gre@setstafflines{#1}}%
-  \def\gre@stafflines{#1}%
+  \gre@count@stafflines=#1\relax
   \ifcase#1% 0
     \gre@error{Invalid number of staff lines}%
   \or % 1
@@ -1079,9 +1049,6 @@
     \let\gre@char@bar@divisiomaior\GreCPDivisioMaiorTwo %
     \let\gre@char@bar@divisiomaiordotted\GreCPDivisioMaiorDottedTwo %
     \let\gre@char@bar@divisiomaiordottedbacking\GreCPDivisioMaiorDottedBackingTwo %
-    \gre@haslinethreefalse %
-    \gre@haslinefourfalse %
-    \gre@haslinefivefalse %
   \or % 3
     \let\gre@pitch@adjust@top\gre@pitch@h %
     \let\gre@pitch@abovestaff\gre@pitch@i %
@@ -1102,9 +1069,6 @@
     \let\gre@char@bar@divisiomaior\GreCPDivisioMaiorThree %
     \let\gre@char@bar@divisiomaiordotted\GreCPDivisioMaiorDottedThree %
     \let\gre@char@bar@divisiomaiordottedbacking\GreCPDivisioMaiorDottedBackingThree %
-    \gre@haslinethreetrue %
-    \gre@haslinefourfalse %
-    \gre@haslinefivefalse %
   \or % 4
     \let\gre@pitch@adjust@top\gre@pitch@j %
     \let\gre@pitch@abovestaff\gre@pitch@k %
@@ -1125,9 +1089,6 @@
     \let\gre@char@bar@divisiomaior\GreCPDivisioMaiorFour %
     \let\gre@char@bar@divisiomaiordotted\GreCPDivisioMaiorDottedFour %
     \let\gre@char@bar@divisiomaiordottedbacking\GreCPDivisioMaiorDottedBackingFour %
-    \gre@haslinethreetrue %
-    \gre@haslinefourtrue %
-    \gre@haslinefivefalse %
   \or % 5
     \let\gre@pitch@adjust@top\gre@pitch@l %
     \let\gre@pitch@abovestaff\gre@pitch@m %
@@ -1148,9 +1109,6 @@
     \let\gre@char@bar@divisiomaior\GreCPDivisioMaiorFive %
     \let\gre@char@bar@divisiomaiordotted\GreCPDivisioMaiorDottedFive %
     \let\gre@char@bar@divisiomaiordottedbacking\GreCPDivisioMaiorDottedBackingFive %
-    \gre@haslinethreetrue %
-    \gre@haslinefourtrue %
-    \gre@haslinefivetrue %
   \else %
     \gre@error{Invalid number of staff lines}%
   \fi %

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -214,8 +214,7 @@
 \let\gre@pitch@underbrace\gre@pitch@b %
 \let\gre@pitch@overbraceglyph\gre@pitch@g %
 \let\gre@pitch@bar\gre@pitch@g %
-\let\gre@pitch@dummy\gre@pitch@g %
-\let\gre@pitch@nominal\gre@pitch@e %
+\let\gre@pitch@dummy\gre@pitch@e % not above or below staff, even if 2 lines
 
 % factor is the factor with which you open you font (the number after the at). It will decide almost everything (spaces, etc.), so it is particularly important.
 % it is set to the default value : 17 (the value that makes it look like a standard graduale)
@@ -735,8 +734,8 @@
   \else%
     \gre@dimen@temp@five=\gre@dimen@additionaltopspacenabc\relax%
   \fi%
-  \gre@dimen@temp@five=\dimexpr(4\gre@dimen@stafflineheight %
-    + 4\gre@dimen@interstafflinespace %
+  \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
+    + \gre@dimen@interstafflinespace %
     + \gre@space@dimen@spacebeneathtext %
     + \gre@dimen@currenttranslationheight %
     + \gre@space@dimen@spacelinestext %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -705,44 +705,44 @@
   \or\gre@fontchar@custostoplong %
   \or\gre@fontchar@custostopshort %
   \or %
-    \ifgre@haslinethree %
+    \ifnum\gre@count@stafflines>2\relax
       \gre@fontchar@custostoplong %
     \else %
       \gre@fontchar@custosbottomlong %
     \fi %
   \or %
-    \ifgre@haslinethree %
+    \ifnum\gre@count@stafflines>2\relax
       \gre@fontchar@custostopshort %
     \else %
       \gre@fontchar@custosbottomshort %
     \fi %
   \or %
-    \ifgre@haslinefour %
+    \ifnum\gre@count@stafflines>3\relax
       \gre@fontchar@custostoplong %
     \else %
       \gre@fontchar@custosbottomlong %
     \fi %
   \or %
-    \ifgre@haslinefour %
+    \ifnum\gre@count@stafflines>3\relax
       \gre@fontchar@custostopshort %
     \else %
-      \ifgre@haslinethree %
+      \ifnum\gre@count@stafflines>2\relax
         \gre@fontchar@custosbottomshort %
       \else %
         \gre@fontchar@custosbottommiddle %
       \fi %
     \fi %
   \or %
-    \ifgre@haslinefive %
+    \ifnum\gre@count@stafflines>4\relax
       \gre@fontchar@custostoplong %
     \else %
       \gre@fontchar@custosbottomlong %
     \fi %
   \or %
-    \ifgre@haslinefive %
+    \ifnum\gre@count@stafflines>4\relax
       \gre@fontchar@custostopshort %
     \else %
-      \ifgre@haslinefour %
+      \ifnum\gre@count@stafflines>3\relax
         \gre@fontchar@custosbottomshort %
       \else %
         \gre@fontchar@custosbottommiddle %
@@ -750,7 +750,7 @@
     \fi %
   \or\gre@fontchar@custosbottomlong %
   \or %
-    \ifgre@haslinefive %
+    \ifnum\gre@count@stafflines>4\relax
       \gre@fontchar@custosbottomshort %
     \else %
       \gre@fontchar@custosbottommiddle %
@@ -1637,8 +1637,8 @@
       + \gre@space@dimen@spacebeneathtext %
       + \gre@space@dimen@spacelinestext %
       + \gre@dimen@currenttranslationheight %
-      + \gre@stafflines\gre@dimen@interstafflinespace %
-      + \gre@stafflines\gre@dimen@stafflineheight)\relax%
+      + \gre@count@stafflines\gre@dimen@interstafflinespace %
+      + \gre@count@stafflines\gre@dimen@stafflineheight)\relax%
   \or % 1
     \gre@dimen@glyphraisevalue=%
       \dimexpr(\gre@dimen@additionalbottomspace %

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -231,8 +231,8 @@
 \def\gre@calculate@staffheight{%
   \gre@trace{gre@calculate@staffheight}%
   \global\gre@dimen@staffheight = \dimexpr %
-    \gre@stafflines\gre@dimen@stafflineheight %
-    + \gre@stafflines\gre@dimen@interstafflinespace %
+    \gre@count@stafflines\gre@dimen@stafflineheight %
+    + \gre@count@stafflines\gre@dimen@interstafflinespace %
     - \gre@dimen@interstafflinespace\relax%
   \relax %
   \gre@trace@end%
@@ -733,7 +733,7 @@
     \global\gre@isonalinetrue%
   \or\gre@count@temp@three=\number 8%
   \or\gre@count@temp@three=\number 9%
-    \ifgre@haslinethree %
+    \ifnum\gre@count@stafflines>2\relax
       \global\gre@isonalinetrue%
     \else %
       \ifgre@ledgerline@above %
@@ -742,10 +742,10 @@
     \fi %
   \or\gre@count@temp@three=\number 10%
   \or\gre@count@temp@three=\number 11%
-    \ifgre@haslinefour %
+    \ifnum\gre@count@stafflines>3\relax
       \global\gre@isonalinetrue%
     \else %
-      \ifgre@haslinethree %
+      \ifnum\gre@count@stafflines>2\relax
         \ifgre@ledgerline@above %
           \global\gre@isonalinetrue%
         \fi %
@@ -753,10 +753,10 @@
     \fi %
   \or\gre@count@temp@three=\number 12%
   \or\gre@count@temp@three=\number 13%
-    \ifgre@haslinefive %
+    \ifnum\gre@count@stafflines>4\relax
       \global\gre@isonalinetrue%
     \else %
-      \ifgre@haslinefour %
+      \ifnum\gre@count@stafflines>3\relax
         \ifgre@ledgerline@above %
           \global\gre@isonalinetrue%
         \fi %
@@ -764,7 +764,7 @@
     \fi %
   \or\gre@count@temp@three=\number 14%
   \or\gre@count@temp@three=\number 15%
-    \ifgre@haslinefive %
+    \ifnum\gre@count@stafflines>4\relax
       \ifgre@ledgerline@above %
         \global\gre@isonalinetrue%
       \fi %

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -788,8 +788,8 @@ local function post_linebreak(h, groupcode, glyphes)
 
           if new_score_heights then
             local glyph_id = has_attribute(n, glyph_id_attr)
-            local glyph_top = has_attribute(n, glyph_top_attr) or 9 -- 'g'
-            local glyph_bottom = has_attribute(n, glyph_bottom_attr) or 9 -- 'g'
+            local glyph_top = has_attribute(n, glyph_top_attr) or 7 -- 'e' = \gre@pitch@dummy
+            local glyph_bottom = has_attribute(n, glyph_bottom_attr) or 7 -- 'e' = \gre@pitch@dummy
             if glyph_id and glyph_id > prev_line_id then
               if not line_id or glyph_id > line_id then
                 line_id = glyph_id


### PR DESCRIPTION
The first commit fixes the bug; the second commit is some opportunistic cleaning up of code related to staff lines, and I can understand if you want to postpone that.

Closes #1614.
