### PR TITLE
Fix computation of top and bottom pitches of glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a bug that caused a custos to sometimes change into a clef. See [#1373](https://github.com/gregorio-project/gregorio/issues/1373).
 - Fixed the alignment of 2-line initials so that an initial's baseline more exactly aligns with the baseline of the lowest line it appears next to.
 - When fancyhdr and GregorioTeX are used together, GregorioTeX's disabling of hyphenation and its `post_linebreak` modification of the `post_linebreak_filter` interfere with multiline headers.  Using the `fancyhdr/before` and `fancyhdr/after` hooks we temporarily reenable hyphenation and disable our `post_linebreak` modification while headers and footers are being processed in the middle of a score.  See [#1603](https://github.com/gregorio-project/gregorio/issues/1603).
+- Fixed a bug where the above-lines text (`<alt>`) could collid with a note above the staff. See [#1613](https://github.com/gregorio-project/gregorio/issues/1613).
 
 ### Changed
 - Modified gregorio to append to the log file specified as an argument and to send early messages to it.  See [#1541](https://github.com/gregorio-project/gregorio/issues/1541).

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -154,16 +154,21 @@
 % #7 is the line:char:column for a textedit link
 \def\GreGlyph#1#2#3#4#5#6#7{%
   \gre@newglyphcommon %
+  % Create box containing the new glyph.
   \setbox\gre@box@temp@width=\hbox{\gre@pointandclick{\gre@font@music #1}{#7}}%
   \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %
   % the three next lines are a trick to get the additional lines below the glyphs
   \gre@skip@temp@one = \gre@dimen@lastglyphwidth\relax%
   \kern\gre@skip@temp@one %
+  % #5 contains things like ledger lines, but also calls to \GreGlyphHeights
   #5\relax %
   \kern-\gre@skip@temp@one %
   \gre@calculate@glyphraisevalue{#2}{0}{}%
   \raise\gre@dimen@glyphraisevalue%
-  \copy\gre@box@temp@width%
+  % Since \gre@box@temp@width was created before the calls
+  % to \GreGlyphHeights, we need to rebox it to
+  % set \gre@attr@glyph@top and \gre@attr@glyph@bottom correctly.
+  \hbox{\unhcopy\gre@box@temp@width}%
   \ifgre@endofscore\else\ifgre@boxing\else %
     #3%
   \fi\fi %


### PR DESCRIPTION
This is just a one-line change.

Closes #1613.