### PR TITLE
Trim staff lines on last line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
 - Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the option `\gresetlastline` was ignored; now, a final `Z` or `z` is ignored, and `\gresetlastline` determines whether the last line is ragged, justified, or trimmed.
+### Deprecated
 - The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
 
 ## [6.1.0] - 2025-02-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
 - Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the option `\gresetlastline` was ignored; now, a final `Z` or `z` is ignored, and `\gresetlastline` determines whether the last line is ragged, justified, or trimmed.
+- The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
 
 ## [6.1.0] - 2025-02-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][CTAN]
 ### Added
 - Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
+
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
 - Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the option `\gresetlastline` was ignored; now, if `Z` is used with `\gresetlastline{justified}` or `z` is used with `\gresetlastline{ragged}` or `\gresetlastline{trimmed}`, a warning is printed; in a future release, this will be an error.
+
 ### Deprecated
 - The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
-- Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the option `\gresetlastline` was ignored; now, if `Z` is used with `\gresetlastline{justified}` or `z` is used with `\gresetlastline{ragged}` or `\gresetlastline{trimmed}`, a warning is printed; in a future release, this will be an error.
+- Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the appearance of the last line would sometimes depend on `Z` versus `z` and sometimes depend on `\gresetlastline{ragged}` versus `\gresetlastline{justified}`. Now, the appearance of the last line always depends on `\gresetlastline`.
 
 ### Deprecated
 - The count `grefinalpenalty` no longer has any effect and will be removed in a future release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][CTAN]
+### Added
+- Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 
 
 ## [6.1.0] - 2025-02-28
@@ -34,7 +36,6 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Allow `\gresetinitiallines{n}` where `n` is any number of lines (a non-negative integer). The manual linebreaks (`z`) that used to be required for 2-line initials are no longer required. See [#1488](https://github.com/gregorio-project/gregorio/issues/1488). Added new options `\gresetinitialanchor` and `\gresetinitialposition` to control the placement of initials.
 - Added new alterations: soft flat (X) and sharp (##), which appear when there is no previous flat or sharp (respectively) in effect, and soft natural (Y), which appears when there is a previous flat or sharp in effect. A new option `\gresetalterationeffect` determines what the "effect" of an alteration is. It defaults to `line`, which is useful for Dominican chant. See [#157](https://github.com/gregorio-project/gregorio/issues/157) and also [#1575](https://github.com/gregorio-project/gregorio/issues/1575).
 - 9 new St. Gall neume glyphs have been added to the `gregall` font.
-- Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 
 ## [6.0.0] - 2021-03-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Allow `\gresetinitiallines{n}` where `n` is any number of lines (a non-negative integer). The manual linebreaks (`z`) that used to be required for 2-line initials are no longer required. See [#1488](https://github.com/gregorio-project/gregorio/issues/1488). Added new options `\gresetinitialanchor` and `\gresetinitialposition` to control the placement of initials.
 - Added new alterations: soft flat (X) and sharp (##), which appear when there is no previous flat or sharp (respectively) in effect, and soft natural (Y), which appears when there is a previous flat or sharp in effect. A new option `\gresetalterationeffect` determines what the "effect" of an alteration is. It defaults to `line`, which is useful for Dominican chant. See [#157](https://github.com/gregorio-project/gregorio/issues/157) and also [#1575](https://github.com/gregorio-project/gregorio/issues/1575).
 - 9 new St. Gall neume glyphs have been added to the `gregall` font.
-
+- Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 
 ## [6.0.0] - 2021-03-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
+- Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the option `\gresetlastline` was ignored; now, a final `Z` or `z` is ignored, and `\gresetlastline` determines whether the last line is ragged, justified, or trimmed.
 
 ## [6.1.0] - 2025-02-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
-- Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the option `\gresetlastline` was ignored; now, a final `Z` or `z` is ignored, and `\gresetlastline` determines whether the last line is ragged, justified, or trimmed.
+- Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the option `\gresetlastline` was ignored; now, if `Z` is used with `\gresetlastline{justified}` or `z` is used with `\gresetlastline{ragged}` or `\gresetlastline{trimmed}`, a warning is printed; in a future release, this will be an error.
 ### Deprecated
 - The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Allow `\gresetinitiallines{n}` where `n` is any number of lines (a non-negative integer). The manual linebreaks (`z`) that used to be required for 2-line initials are no longer required. See [#1488](https://github.com/gregorio-project/gregorio/issues/1488). Added new options `\gresetinitialanchor` and `\gresetinitialposition` to control the placement of initials.
 - Added new alterations: soft flat (X) and sharp (##), which appear when there is no previous flat or sharp (respectively) in effect, and soft natural (Y), which appears when there is a previous flat or sharp in effect. A new option `\gresetalterationeffect` determines what the "effect" of an alteration is. It defaults to `line`, which is useful for Dominican chant. See [#157](https://github.com/gregorio-project/gregorio/issues/157) and also [#1575](https://github.com/gregorio-project/gregorio/issues/1575).
 - 9 new St. Gall neume glyphs have been added to the `gregall` font.
-
+- Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 
 ## [6.0.0] - 2021-03-13
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,7 +12,7 @@ The count `grefinalpenalty` no longer has any effect and will be removed in a fu
 
 ### Final `Z` and `z`
 
-Forced line breaks (`Z` or `z`) at the very end of a score are discouraged. If `Z` is used with `\gresetlastline{justified}` or `z` is used with `\gresetlastline{ragged}` or `\gresetlastline{trimmed}`, a warning is printed; in a future release, this will be an error.
+Forced line breaks (`Z` or `z`) at the very end of a score are discouraged. Please use `\gresetlastline{ragged}` or `\gresetlastline{justified}` instead to set the appearance of the last line.
 
 ## 6.1
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,6 +10,10 @@ This file contains instructions to upgrade to a new release of Gregorio.  These 
 
 The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
 
+### Final `Z` and `z`
+
+Forced line breaks (`Z` or `z`) at the very end of a score are discouraged. If `Z` is used with `\gresetlastline{justified}` or `z` is used with `\gresetlastline{ragged}` or `\gresetlastline{trimmed}`, a warning is printed; in a future release, this will be an error.
+
 ## 6.1
 
 ### Multiline initials

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,10 @@ This file contains instructions to upgrade to a new release of Gregorio.  These 
 
 ## [Unreleased][develop]
 
+## [Unreleased][CTAN]
+
+- The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
+
 ## 6.1
 
 ### Multiline initials

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,7 +6,9 @@ This file contains instructions to upgrade to a new release of Gregorio.  These 
 
 ## [Unreleased][CTAN]
 
-- The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
+### `grefinalpenalty`
+
+The count `grefinalpenalty` no longer has any effect and will be removed in a future release.
 
 ## 6.1
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1184,11 +1184,12 @@ Equivalent of \verb=\grebolshiftcleftype= but valid only until the next end of a
 \end{argtable}
 
 \macroname{\textbackslash gresetlastline}{\{\#1\}}{gregoriotex-main.tex}
-Macro to determine whether the last line of the score should be justified or not.
+Macro to determine how the last line of the score should be printed.
 
 \begin{argtable}
   \#1 & \texttt{justified} & Set the last line justified with the rest of the score\\
-  & \texttt{ragged} & Set the last line ragged (default)
+  & \texttt{ragged} & Set the last line ragged (default)\\
+  & \texttt{trimmed} & Set the last line ragged and trim the staff lines
 \end{argtable}
 
 \macroname{\textbackslash gresetunbreakablesyllablenotes}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-syllable.tex}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -2170,7 +2170,7 @@ Penalty to force a line break.
 \end{gcount}
 
 \begin{gcount}{finalpenalty}
-The penalty applied after the final element of a score.
+The penalty applied after the final element of a score. Deprecated.
 \end{gcount}
 
 \macroname{looseness}{}{gregoriotex-gsp-default.tex}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -127,9 +127,6 @@ Calculates the value of \texttt{textlower}.  Default is \texttt{spacebeneathtext
 \macroname{\textbackslash gre@calculate@linewidth}{}{gregoriotex-spaces.tex}
 Calculates the line width.  Default is the width of the printable space (\verb=\hsize=).
 
-\macroname{\textbackslash gre@calculate@stafflinewidth}{}{gregoriotex-spaces.tex}
-Calculates the width of the staff lines.  Default is \texttt{linewidth}.
-
 \macroname{\textbackslash gre@calculate@stafflineheight}{}{gregoriotex-spaces.tex}
 Calculates the height (thickness) of the staff lines.  Dependent on \texttt{stafflineheightfactor} and \texttt{gre@factor}.
 
@@ -1891,8 +1888,8 @@ Boolean which indicates if line breaks are prohibited in an \texttt{euouae} area
 \macroname{\textbackslash ifgre@in@euouae}{}{gregoriotex-main.tex}
 Boolean which indicates that we are in an \texttt{euouae} area.
 
-\macroname{\textbackslash ifgre@justifylastline}{}{gregoriotex-main.tex}
-Boolean which indicates that the last line of the score should be justified.
+\macroname{\textbackslash gre@count@lastline}{}{gregoriotex-main.tex}
+Count which indicates that the last line of the score should be justified (0), ragged (1), or trimmed (2).
 
 \macroname{\textbackslash ifgre@showclef}{}{gregoriotex-main.tex}
 Boolean which indicates that the clef should be visible.
@@ -2150,10 +2147,6 @@ Dimension representing the space between the 0 of the gregorian fonts and the ef
 
 \macroname{\textbackslash gre@dimen@currenttranslationheight}{}{gregoriotex-spaces.tex}
 Dimension representing the space for the translation beneath the text.
-
-\macroname{\textbackslash gre@dimen@stafflinewidth}{}{gregoriotex-spaces.tex}
-Dimension representing the width of a line of staff.  Can vary, for
-example, at the first line.
 
 \macroname{\textbackslash gre@dimen@linewidth}{}{gregoriotex-spaces.tex}
 Dimension representing the width of the score (including initial).

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -127,9 +127,6 @@ Calculates the value of \texttt{textlower}.  Default is \texttt{spacebeneathtext
 \macroname{\textbackslash gre@calculate@linewidth}{}{gregoriotex-spaces.tex}
 Calculates the line width.  Default is the width of the printable space (\verb=\hsize=).
 
-\macroname{\textbackslash gre@calculate@stafflinewidth}{}{gregoriotex-spaces.tex}
-Calculates the width of the staff lines.  Default is \texttt{linewidth}.
-
 \macroname{\textbackslash gre@calculate@stafflineheight}{}{gregoriotex-spaces.tex}
 Calculates the height (thickness) of the staff lines.  Dependent on \texttt{stafflineheightfactor} and \texttt{gre@factor}.
 
@@ -1854,8 +1851,8 @@ Boolean which indicates if line breaks are prohibited in an \texttt{euouae} area
 \macroname{\textbackslash ifgre@in@euouae}{}{gregoriotex-main.tex}
 Boolean which indicates that we are in an \texttt{euouae} area.
 
-\macroname{\textbackslash ifgre@justifylastline}{}{gregoriotex-main.tex}
-Boolean which indicates that the last line of the score should be justified.
+\macroname{\textbackslash gre@count@lastline}{}{gregoriotex-main.tex}
+Count which indicates that the last line of the score should be justified (0), ragged (1), or trimmed (2).
 
 \macroname{\textbackslash ifgre@showclef}{}{gregoriotex-main.tex}
 Boolean which indicates that the clef should be visible.
@@ -2063,10 +2060,6 @@ Dimension representing the space between the 0 of the gregorian fonts and the ef
 
 \macroname{\textbackslash gre@dimen@currenttranslationheight}{}{gregoriotex-spaces.tex}
 Dimension representing the space for the translation beneath the text.
-
-\macroname{\textbackslash gre@dimen@stafflinewidth}{}{gregoriotex-spaces.tex}
-Dimension representing the width of a line of staff.  Can vary, for
-example, at the first line.
 
 \macroname{\textbackslash gre@dimen@linewidth}{}{gregoriotex-spaces.tex}
 Dimension representing the width of the score (including initial).

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -896,7 +896,7 @@ Gabc has a few codes to control line breaks.
   \texttt{</nlba>} & mark the end of a set of neumes where no line breaks are
                      allowed \\
 \end{tabularx}
-A line break at the very end of a score is discouraged, and whether the last line is justified or ragged should be specified by \verb|\gresetlastline| instead. If \texttt{Z} is used with \verb|\gresetlastline{justified}| or \texttt{z} is used with \verb|\gresetlastline{ragged}| or \verb|\gresetlastline{trimmed}|, a warning is printed; in a future release, this will be an error.
+A line break at the very end of a score is discouraged, and whether the last line is justified or ragged should be specified by \verb|\gresetlastline| instead.
 
 \subsubsection{Choral Signs}
 

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -896,6 +896,7 @@ Gabc has a few codes to control line breaks.
   \texttt{</nlba>} & mark the end of a set of neumes where no line breaks are
                      allowed \\
 \end{tabularx}
+If the very last line of a score ends with a \texttt{Z} or \texttt{z}, it is ignored; instead, whether the last line is justified or ragged is determined by \verb|\gresetlastline|.
 
 \subsubsection{Choral Signs}
 

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -896,7 +896,7 @@ Gabc has a few codes to control line breaks.
   \texttt{</nlba>} & mark the end of a set of neumes where no line breaks are
                      allowed \\
 \end{tabularx}
-If the very last line of a score ends with a \texttt{Z} or \texttt{z}, it is ignored; instead, whether the last line is justified or ragged is determined by \verb|\gresetlastline|.
+A line break at the very end of a score is discouraged, and whether the last line is justified or ragged should be specified by \verb|\gresetlastline| instead. If \texttt{Z} is used with \verb|\gresetlastline{justified}| or \texttt{z} is used with \verb|\gresetlastline{ragged}| or \verb|\gresetlastline{trimmed}|, a warning is printed; in a future release, this will be an error.
 
 \subsubsection{Choral Signs}
 

--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -38,8 +38,6 @@
 \grechangecount{endafterbarpenalty}{-200}%
 % penalty right after a bar with nothing printed
 \grechangecount{endafterbaraltpenalty}{-200}%
-% penalty at the end of the score
-\grechangecount{finalpenalty}{0}%
 % penalty at the end of a breakable neumatic element (typically at a space
 % between elements)
 \grechangecount{endofelementpenalty}{-50}%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -266,11 +266,18 @@
     \ifnum\gre@insidediscretionary=0\relax %
       \gre@updateleftbox %
     \fi %
-    \ifnum#1=1\relax %
-      \GreNoBreak %
-      \hfill %
-    \fi %
-    \gre@penalty{-10001}%
+    % If this is the last element, just end the paragraph here, ignoring #1
+    % and letting \gre@count@lastline determine justification of the last line.
+    \ifgre@endofscore
+      \par
+    % Otherwise, force a line break
+    \else
+      \ifnum#1=1\relax
+        \GreNoBreak
+        \hfill
+      \fi
+      \gre@penalty{-10001}%
+    \fi
   \fi %
   %%
   \GreResetEolCustos\relax %
@@ -1113,7 +1120,6 @@
   \ifgre@keeprightbox\else %
     \gre@localrightbox{}%
   \fi %
-  \hfil %
   \par %
   \ifgre@keeprightbox%
     \global\gre@keeprightboxfalse%
@@ -1194,9 +1200,6 @@
 
 % called at element level, before the final element
 \def\GreLastOfScore{%
-  %\gre@localleftbox{}% For an unknown reason, if I uncomment this line, the
-  %blank line removing algorithm (in lua) will let some blank space after the
-  %last line... (see bug #20953)
   \global\gre@endofscoretrue %
   \GreSuppressEolCustos%
   \gre@debugmsg{eolshift}{set lastoflinecount to 1}%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -363,19 +363,6 @@
   \setbox\gre@box@initial=\hbox{#1}%
 }%
 
-% Set paragraph shape.
-% #1: How many lines are indented
-% #2: The amount of the indentation
-\def\gre@makeparshape#1#2{%
-  \edef\gre@parshape@dims{\numexpr#1+1\relax}%
-  \gre@count@temp@one=0\relax
-  \loop
-    \edef\gre@parshape@dims{\gre@parshape@dims#2\dimexpr\gre@dimen@linewidth-#2\relax}%
-    \advance\gre@count@temp@one by 1\relax
-  \ifnum\gre@count@temp@one<#1\repeat
-  \parshape\gre@parshape@dims0pt\gre@dimen@linewidth
-}
-
 \def\gre@setinitial#1{%
   \gre@trace{gre@setinitial{#1}}%
   \gre@debugmsg{annotation}{Time to calculate the true raise.}%
@@ -444,7 +431,8 @@
     \global\advance\gre@dimen@initialwidth by \gre@dimen@temp@four%
   }%
   % Set the paragraph shape. This should happen before anything is printed.
-  \gre@makeparshape{\gre@count@initiallines}{\wd\gre@box@temp@width}%
+  \hangindent=\wd\gre@box@temp@width\relax
+  \hangafter=-\gre@count@initiallines\relax
   % Set the initial. If it has more than one line, we smash it so it
   % doesn't disrupt anything, in particular the glue between lines.
   % The Lua function lower_initial will insert vertical space
@@ -785,13 +773,13 @@
 \def\gre@generatelines{%
   \gre@trace{gre@generatelines}%
   \setbox\gre@box@lines=\hbox to 0pt{%
-    \vbox attr \gre@attrid@part=2 {%
+    \vbox attr \gre@attrid@part=2 {% width will be adjusted in Lua
       \gre@style@normalstafflines%
       \vskip\glueexpr(\gre@dimen@additionaltopspace+\gre@space@skip@spaceabovelines+\gre@dimen@currentabovelinestextheight)\relax%
       \gre@count@temp@one=0\relax
       \loop
         \ifgre@showlines %
-          \hrule height \gre@dimen@stafflineheight width \gre@dimen@stafflinewidth\relax%
+          \hrule height \gre@dimen@stafflineheight\relax%
         \else %
           \vskip\gre@dimen@stafflineheight\relax%
         \fi %
@@ -977,17 +965,21 @@
 %% other macros
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\newif\ifgre@justifylastline%
-\gre@justifylastlinefalse%
+% Whether the last line of a score should be:
+% 0 = justified, 1 = ragged, 2 = trimmed
+\newcount\gre@count@lastline
+\gre@count@lastline=1\relax
 
 \def\gresetlastline#1{%
   \IfStrEqCase{#1}{%
     {justified}%
-      {\gre@justifylastlinetrue}%
+      {\gre@count@lastline=0}%
     {ragged}%
-      {\gre@justifylastlinefalse}%
+      {\gre@count@lastline=1}%
+    {trimmed}%
+      {\gre@count@lastline=2}%
     }[% all other cases
-      \gre@error{Unrecognized option "#1" for \protect\gresetlastline\MessageBreak Possible options are: 'justified' and 'ragged'}%
+      \gre@error{Unrecognized option "#1" for \protect\gresetlastline\MessageBreak Possible options are: 'justified', 'ragged', and 'trimmed'}%
     ]%
 }%
 
@@ -1138,7 +1130,7 @@
   \let\gre@pitch@clefbottom\gre@pitch@dummy %
   \xdef\gre@gabcname{#6}%
   \gre@setstafflines{#7}%
-  \ifgre@justifylastline%
+  \ifnum\gre@count@lastline=0\relax
     \xdef\gre@saved@parfillskip{\the\parfillskip}%
     \parfillskip=0pt plus 0pt minus 0pt\relax%
   \fi %
@@ -1208,7 +1200,7 @@
   \unsetluatexattribute{\gre@attr@glyph@bottom}%
   \unsetluatexattribute{\gre@attr@dash}%
   \xdef\gre@bolshiftcleftypelocal{\gre@bolshiftcleftypeglobal}%
-  \ifgre@justifylastline%
+  \ifnum\gre@count@lastline=0\relax
     \parfillskip=\gre@saved@parfillskip\relax%
   \fi %
   \global\setluatexattribute\gre@attr@glyph@id{0}%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -270,16 +270,9 @@
     % and letting \gre@count@lastline determine justification of the last line.
     \ifgre@endofscore
       \ifcase#1\relax
-        \ifcase\gre@count@lastline
-          \or
-            \gre@warning{Justified line break 'z' at end of score clashes with \protect\gresetlastline{ragged}.\MessageBreak Setting last line ragged; in a future release, this will be an error.}%
-          \or
-            \gre@warning{Justified line break 'z' at end of score clashes with \protect\gresetlastline{trimmed}.\MessageBreak Setting last line trimmed; in a future release, this will be an error.}%
-        \fi
+        \gre@warning{Ignoring forced line break ('z') at end of score.\MessageBreak Please use \protect\gresetlastline{justified} to justify the last line}%
       \or
-        \ifcase\gre@count@lastline
-            \gre@warning{Ragged line break 'Z' at end of score clashes with \protect\gresetlastline{justified}.\MessageBreak Setting last line justified; in a future release, this will be an error.}%
-        \fi
+        \gre@warning{Ignoring forced line break ('Z') at end of score.\MessageBreak Please use \protect\gresetlastline{ragged} to set the last line ragged, or \protect\gresetlastline{trimmed} to set the last line ragged and trim the staff lines}%
       \fi
       \par
     % Otherwise, force a line break

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -269,6 +269,18 @@
     % If this is the last element, just end the paragraph here, ignoring #1
     % and letting \gre@count@lastline determine justification of the last line.
     \ifgre@endofscore
+      \ifcase#1\relax
+        \ifcase\gre@count@lastline
+          \or
+            \gre@warning{Justified line break 'z' at end of score clashes with \protect\gresetlastline{ragged}.\MessageBreak Setting last line ragged; in a future release, this will be an error.}%
+          \or
+            \gre@warning{Justified line break 'z' at end of score clashes with \protect\gresetlastline{trimmed}.\MessageBreak Setting last line trimmed; in a future release, this will be an error.}%
+        \fi
+      \or
+        \ifcase\gre@count@lastline
+            \gre@warning{Ragged line break 'Z' at end of score clashes with \protect\gresetlastline{justified}.\MessageBreak Setting last line justified; in a future release, this will be an error.}%
+        \fi
+      \fi
       \par
     % Otherwise, force a line break
     \else

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -238,6 +238,7 @@
 }%
 
 \def\GreFinalNewLine{%
+  \gre@warning{Ignoring forced line break ('z') at end of score.}%
 }%
 
 % the macro we call each time we force a changing of line

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -238,7 +238,7 @@
 }%
 
 \def\GreFinalNewLine{%
-  \gre@warning{Ignoring forced line break ('z') at end of score.}%
+  \gre@warning{Ignoring forced line break ('Z' or 'z') at end of score.}%
 }%
 
 % the macro we call each time we force a changing of line

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -147,15 +147,6 @@
   \gre@trace@end%
 }%
 
-% stafflinewidth is the width of a line of staff, this can vary, for example at the first line
-\newdimen\gre@dimen@stafflinewidth\relax%
-\def\gre@calculate@stafflinewidth{%
-  \gre@trace{gre@calculate@stafflinewidth}%
-  \gre@dimen@stafflinewidth=\gre@dimen@linewidth\relax%
-  \gre@trace@end%
-}%
-
-
 % linewidth is the width of a line of a score (including the initial)
 \newdimen\gre@dimen@linewidth\relax%
 \def\gre@calculate@linewidth{%
@@ -243,7 +234,6 @@
 %% Dependencies:
 %% textlower: spacebeneathtext
 %% linewidth: hsize
-%% stafflinewidth: linewidth
 %% stafflineheight: stafflinefactor & gre@factor
 %% interstafflinespace: stafflineheight & gre@factor
 %% stafflinediff: stafflineheight & gre@factor
@@ -253,7 +243,6 @@
   \gre@trace{gre@computespaces}%
   \gre@calculate@textlower%
   \gre@calculate@linewidth%
-  \gre@calculate@stafflinewidth%
   \gre@calculate@stafflineheight%
   \gre@calculate@interstafflinespace%
   \gre@calculate@stafflinediff%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1472,8 +1472,15 @@
 }%
 
 \def\grechangecount#1#2{%
-  \expandafter\csname gre@space@count@#1\endcsname=#2%
-  \relax %
+  \IfStrEqCase{#1}{% DEPRECATED
+    {finalpenalty}{\gre@warning{The count 'finalpenalty' no longer has any effect and will be removed in a future release}}% DEPRECATED
+  }[% DEPRECATED
+    \ifcsname gre@space@count@#1\endcsname
+      \expandafter\csname gre@space@count@#1\endcsname=#2\relax
+    \else
+      \gre@error{Unknown count '#1'}%
+    \fi
+  ]% DEPRECATED
 }
 
 % The common internals for \grecreatedim and \grechangedim.

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1617,7 +1617,7 @@
 \newcount\gre@space@count@endofsyllablepenalty%
 \newcount\gre@space@count@endafterbarpenalty%
 \newcount\gre@space@count@endafterbaraltpenalty%
-\newcount\gre@space@count@finalpenalty%
+\newcount\gre@space@count@finalpenalty% DEPRECATED
 \newcount\gre@space@count@endofelementpenalty%
 \newcount\gre@space@count@hyphenpenalty%
 \newcount\gre@space@count@brokenpenalty%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -117,7 +117,6 @@
   \global\unsetluatexattribute{\gre@attr@glyph@top}%
   \global\unsetluatexattribute{\gre@attr@glyph@bottom}%
   \ifgre@endofscore %
-    \gre@penalty{\the\gre@space@count@finalpenalty}%
     \gre@localleftbox{}%
     \gre@localrightbox{}%
   \fi %
@@ -1410,8 +1409,6 @@
     \else %
       \ifgre@endofscore %
         \gre@localleftbox{}%
-        \gre@debugmsg{barspacing}{after bar penalty: \gre@space@count@endafterbarpenalty}%
-        \gre@penalty{\the\gre@space@count@finalpenalty}%
       \else %
         \ifnum\gre@newlinearg=-1\else %
           \gre@debugmsg{barspacing}{calling new line with argument: \gre@newlinearg}%

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -857,40 +857,26 @@ local function post_linebreak(h, groupcode, glyphes)
   
   -- we explore the lines
   for line in traverse(h) do
-    -- Remove a line if it has two or fewer hboxes (one for the stafflines, one for the clef)
-    -- Exception: Don't remove the first line
-    if line.id == glue then
-      if line.next ~= nil and line.next.id == hlist
-          and has_attribute(line.next, dash_attr)
-          and linenum > 0 and count(hlist, line.next.head) <= 2 then
-        debugmessage('linesglues', 'deleting glue above empty line')
-        h, line = remove(h, line)
-      end
-    elseif line.id == hlist and has_attribute(line, dash_attr) then
-      if linenum > 0 and count(hlist, line.head) <= 2 then
-        debugmessage('linesglues', 'deleting empty line')
-        h, line = remove(h, line)
-      else
-        linenum = linenum + 1
-        debugmessage('linesglues', 'line %d: %s factor %.0f%%', linenum, glue_sign_name[line.glue_sign], line.glue_set*100)
-        centerstartnode = nil
+    if line.id == hlist and has_attribute(line, dash_attr) then
+      linenum = linenum + 1
+      debugmessage('linesglues', 'line %d: %s factor %.0f%%', linenum, glue_sign_name[line.glue_sign], line.glue_set*100)
+      centerstartnode = nil
 
-        for n in traverse_id(hlist, line.head) do
-          syl_id = has_attribute(n, syllable_id_attr) or syl_id
-          if has_attribute(n, center_attr, startcenter) then
-            centerstartnode = n
-          elseif has_attribute(n, center_attr, endcenter) then
-            if not centerstartnode then
-              warn("End of a translation centering area encountered on a\nline without translation centering beginning,\nskipping translation...")
-            else
-              center_translation(centerstartnode, n, line.glue_set, line.glue_sign, line.glue_order)
-            end
+      for n in traverse_id(hlist, line.head) do
+        syl_id = has_attribute(n, syllable_id_attr) or syl_id
+        if has_attribute(n, center_attr, startcenter) then
+          centerstartnode = n
+        elseif has_attribute(n, center_attr, endcenter) then
+          if not centerstartnode then
+            warn("End of a translation centering area encountered on a\nline without translation centering beginning,\nskipping translation...")
+          else
+            center_translation(centerstartnode, n, line.glue_set, line.glue_sign, line.glue_order)
           end
         end
+      end
 
-        if new_score_last_syllables and syl_id then
-          new_score_last_syllables[syl_id] = syl_id
-        end
+      if new_score_last_syllables and syl_id then
+        new_score_last_syllables[syl_id] = syl_id
       end
     end
   end

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -712,17 +712,18 @@ local function post_linebreak(h, groupcode, glyphes)
   local syl_id                  = nil
   -- we explore the lines
   for line in traverse(h) do
+    -- Remove a line if it has two or fewer hboxes (one for the stafflines, one for the clef)
+    -- Exception: Don't remove the first line
     if line.id == glue then
       if line.next ~= nil and line.next.id == hlist
           and has_attribute(line.next, dash_attr)
-          and count(hlist, line.next.head) <= 2 then
-        --log("eating glue")
+          and linenum > 0 and count(hlist, line.next.head) <= 2 then
+        debugmessage('linesglues', 'deleting glue above empty line')
         h, line = remove(h, line)
       end
     elseif line.id == hlist and has_attribute(line, dash_attr) then
-      -- the next two lines are to remove the dumb lines
-      if count(hlist, line.head) <= 2 then
-        --log("eating line")
+      if linenum > 0 and count(hlist, line.head) <= 2 then
+        debugmessage('linesglues', 'deleting empty line')
         h, line = remove(h, line)
       else
         linenum = linenum + 1
@@ -861,8 +862,7 @@ local function post_linebreak(h, groupcode, glyphes)
   end
 
   --dump_nodes(h)
-  -- due to special cases, we don't return h here (see comments in bug #20974)
-  return true
+  return h
 end
 
 -- In gregoriotex, hyphenation is made by the process function, so TeX hyphenation

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -572,29 +572,32 @@ gregoriotex.module.debugmessage = debugmessage
 -- line width, and adjust them to actually take up the full line
 -- width.
 local function adjust_fullwidth (line)
-  -- Determine line width, ignoring \leftskip
+  -- Determine line width, ignoring \leftskip and \rightskip
+  -- and, optionally, \parfillskip
   local line_width = line.width
   for child in node.traverse(line.head) do
-    if child.id == glue and child.subtype == 8 then
+    if child.id == glue and (
+      child.subtype == 8 -- leftskip
+      or child.subtype == 9 -- rightskip
+      or tex.count['gre@count@lastline'] == 2 and child.subtype == 15 -- parfillskip
+    ) then
       line_width = line_width - node.effective_glue(child, line)
     end
   end
-  debugmessage("stafflines", "line width %spt", line_width/2^16)
+  debugmessage("adjust_fullwidth", "line width %spt", line_width/2^16)
 
   local function visit(cur)
     for child in node.traverse_list(cur.head) do
-      if has_attribute(child, part_attr, part_commentary) then
-        debugmessage("adjust_fullwidth", "commentary width %spt -> %spt", child.width/2^16, line_width/2^16)
-        child.width = line_width
-        local new = node.hpack(child.head, line_width, 'exactly')
-        cur.head = node.insert_before(cur.head, child, new)
-        cur.head = node.remove(cur.head, child)
-      elseif has_attribute(child, part_attr, part_stafflines) then
-        debugmessage("adjust_fullwidth", "staff width %spt -> %spt", child.width/2^16, line_width/2^16)
-        for r in traverse_id(rule, child.head) do
-          r.width = line_width
+      local attr = has_attribute(child, part_attr)
+      if attr == part_commentary or attr == part_stafflines then
+        debugmessage("adjust_fullwidth", "width %spt -> %spt", child.width/2^16, line_width/2^16)
+        if child.id == hlist then
+          local new = node.hpack(child.head, line_width, 'exactly')
+          cur.head = node.insert_before(cur.head, child, new)
+          cur.head = node.remove(cur.head, child)
+        else
+          child.width = line_width
         end
-        child.width = line_width
       else
         visit(child)
       end
@@ -602,24 +605,6 @@ local function adjust_fullwidth (line)
   end
 
   visit(line)
-end
-
--- Adjust height and depth of an hlist to fit its contents
-local function adjust_hlist(cur)
-  local new_height = 0
-  local new_depth = 0
-  for child in traverse(cur.head) do
-    if child.id == hlist or child.id == vlist then
-      new_height = math.max(new_height, child.height - child.shift)
-      new_depth = math.max(new_depth, child.depth + child.shift)
-    elseif child.id == rule or child.id == glyph then
-      new_height = math.max(new_height, child.height)
-      new_depth = math.max(new_depth, child.depth)
-    end
-  end
-  debugmessage('adjust_hlist', 'height %spt -> %spt, depth %spt -> %spt', cur.height/2^16, new_height/2^16, cur.depth/2^16, new_depth/2^16)
-  cur.height = new_height
-  cur.depth = new_depth
 end
 
 local function find_attr(cur, attr, val)


### PR DESCRIPTION
Adds an option `\gresetlastline{trimmed}` that trims the staff lines on the last line. Closes #1418.

Also removes some unneeded code related to paragraph shape, and makes `adjust_fullwidth` a little more general.