### PR TITLE
Remove redirection in restricted mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ ctan
 .agignore
 *.orig
 compile_commands.json
+*.err

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][develop]
-
+- Allow capture of kpathsea error via redirection when `--shell-escape` error is enabled.  This error cannot safely be captured in restricted mode.  See [#1628](https://github.com/gregorio-project/gregorio/issues/1628).
 
 ## [Unreleased][CTAN]
 

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -1152,7 +1152,7 @@ local function compile_gabc(gabc_file, gtex_file, glog_file, allow_deprecated)
 
   local cmd = string.format('%s %s -W -o %s -l %s "%s"', gregorio_exe(),
       extra_args, gtex_file, glog_file, gabc_file)
-  if status.shell_escape then
+  if status.shell_escape == 1 then
     cmd = string.format('%s 2> %s.err', cmd, glog_file)
   else
     info('Running in restricted mode.\n Some file related errors may not be caputered.\n'

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -1155,7 +1155,7 @@ local function compile_gabc(gabc_file, gtex_file, glog_file, allow_deprecated)
   if status.shell_escape == 1 then
     cmd = string.format('%s 2> %s.err', cmd, glog_file)
   else
-    info('Running in restricted mode.\n Some file related errors may not be caputered.\n'
+    info('Running in restricted mode.\n Some kpse file related errors may not be caputered.\n'
       ..'Try running with --shell-escape active for more complete error loging.')
   end
   res = os.execute(cmd)

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -1150,8 +1150,14 @@ local function compile_gabc(gabc_file, gtex_file, glog_file, allow_deprecated)
     extra_args = extra_args..' -D'
   end
 
-  local cmd = string.format('%s %s -W -o %s -l %s "%s" 2> %s', gregorio_exe(),
-      extra_args, gtex_file, glog_file, gabc_file, glog_file)
+  local cmd = string.format('%s %s -W -o %s -l %s "%s"', gregorio_exe(),
+      extra_args, gtex_file, glog_file, gabc_file)
+  if status.shell_escape then
+    cmd = string.format('%s 2> %s.err', cmd, glog_file)
+  else
+    info('Running in restricted mode.\n Some file related errors may not be caputered.\n'
+      ..'Try running with --shell-escape active for more complete error loging.')
+  end
   res = os.execute(cmd)
   if res == nil then
     err("\nSomething went wrong when executing\n    '%s'.\n"


### PR DESCRIPTION
Since the redirection doesn't work in restricted mode, we only add it when `--shell-escape` has been given.  Further, rather than reusing the glog file, we create a special file for capturing the redirection error.  This addresses #1628.