### PR TITLE
Fix some collisions above/below staff (fixes #1634, half of #1633)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed the placement of above-lines text (`<alt>`) relative to a note above the staff or when the number of staff lines is not 4. See [#1613](https://github.com/gregorio-project/gregorio/issues/1613) and [#1614](https://github.com/gregorio-project/gregorio/issues/1614).
 - Fixed a bug where the above-lines text (`<alt>`) could collid with a note above the staff. See [#1613](https://github.com/gregorio-project/gregorio/issues/1613).
 - Fixed a bug that could cause the clef and staff to be printed too high. See [#1503](https://github.com/gregorio-project/gregorio/issues/1503).
+- Fixed a bug that could cause insufficient additional space to be added above or below the staff. See [#1633](https://github.com/gregorio-project/gregorio/issues/1633) and [#1634](https://github.com/gregorio-project/gregorio/issues/1634).
 
 ### Changed
 - Modified gregorio to append to the log file specified as an argument and to send early messages to it.  See [#1541](https://github.com/gregorio-project/gregorio/issues/1541).

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1153,9 +1153,7 @@
   \gre@calculate@additionalspaces{#2}{#3}{#4}{#5}%
   #8%
   \directlua{
-    gregoriotex.at_score_beginning([[#1]], #2, #3, #4, #5,
-        \gre@pitch@adjust@top, \gre@pitch@adjust@bottom,
-        "\luatexluaescapestring{\gre@gregoriofontname}")
+    gregoriotex.at_score_beginning([[#1]])
     gregoriotex.adjust_line_height(1)
   }%
   %TODO do something like LaTeX's AtBeginDocument

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -961,16 +961,7 @@ local inside_score = false
 --- Start a score
 -- Prepare all variables for processing a new score and add our callbacks
 -- @param score_id score identifier
--- @param top_height height of highest score element
--- @param bottom_height height of lowest score element
--- @param has_translation does this score have a translation?
--- @param has_above_lines_text does this score have above lines text?
--- @param top_height_adj limit below which a top_height doesn't require adjustment
--- @param bottom_height_adj limit above which a bottom_height doesn't require adjustment
--- @param score_font_name which font does this score use for the neumes
-local function at_score_beginning(score_id, top_height, bottom_height,
-    has_translation, has_above_lines_text, top_height_adj, bottom_height_adj,
-    score_font_name)
+local function at_score_beginning(score_id)
   inside_score = true
   local inclusion = score_inclusion[score_id] or 1
   score_inclusion[score_id] = inclusion + 1

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -976,9 +976,7 @@ local function at_score_beginning(score_id, top_height, bottom_height,
   score_inclusion[score_id] = inclusion + 1
   score_id = score_id..'.'..inclusion
   cur_score_id = score_id
-  if (top_height > top_height_adj or bottom_height < bottom_height_adj
-      or has_translation ~= 0 or has_above_lines_text ~= 0)
-      and tex.count['gre@variableheightexpansion'] == 1 then
+  if tex.count['gre@variableheightexpansion'] == 1 then
     score_heights = line_heights[score_id] or {}
     if new_line_heights then
       new_score_heights = {}


### PR DESCRIPTION
The C code was telling the Lua code when to compute line heights, and it was missing some cases, causing not enough additional space to be added. Now the Lua code always computes line heights (which is simpler).

This breaks several tests: clef_change.gabc and nabc-edge-cases.gabc because the old results had bugs, but fix-569 because it uncovers a new bug (#1636).

The fact that the C code does not always know when additional space is needed points to the fact that uniform line heights probably have several bugs (i.e., whenever `\GreGlyphHeights` is called from inside the TeX code). The first half of #1633 is one of these cases, but I haven't tested the others.
