### PR TITLE
One-pass computation of line spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][CTAN]
-
+### Changed
+- Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
 
 ## [6.1.0] - 2025-02-28
 ### Fixed

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -66,13 +66,13 @@ To use the \texttt{allowdeprecated=false} option, you'll need \verb=\gre@allowde
 The compilation options can be set using \verb=\gresetcompilegabc= (see below).
 
 \textbf{Important:} Gregorio\TeX{} may require up to two passes (runs of
-\texttt{lualatex} or \texttt{luatex}) to compute the line heights correctly.  If a second
+\texttt{lualatex} or \texttt{luatex}) to compute certain things correctly.  If a second
 pass is required, Gregorio\TeX{} will emit the following
 warning:\par\medskip
 
 \begin{scriptsize}
 \begin{latexcode}
-Module gregoriotex warning: Line heights or variable brace lengths may have changed. Rerun to fix.
+Module gregoriotex warning: Variable brace lengths or soft flats/sharps may have changed. Rerun to fix.
 \end{latexcode}
 \end{scriptsize}
 
@@ -274,7 +274,7 @@ Macro to change one of Gregorio\TeX’s distances.  This function will check to 
 \end{argtable}
 
 \macroname{\textbackslash grechangenextscorelinedim}{\{\#1\}\{\#2\}\{\#3\}\{\#4\}}{gregoriotex-spaces.tex}
-Changes one of Gregorio\TeX’s distances for a given line in the next included score.  This works with \texttt{spaceabovelines}, \texttt{spacebeneathtext}, and \texttt{spacelinestext}.
+Changes one of Gregorio\TeX’s distances for a given line in the next included score.  This works with \texttt{abovelinestextheight}, \texttt{spaceabovelines}, \texttt{abovelinestextraise}, \texttt{spacelinestext}, \texttt{spacebeneathtext}, and \texttt{translationheight}.
 
 \begin{argtable}
   \#1 & list of integers & A comma-separated list of line numbers in the next
@@ -311,7 +311,7 @@ Macro to change one of Gregorio\TeX’s counts or penalities (numeric values).
 \end{argtable}
 
 \macroname{\textbackslash grechangenextscorelinecount}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-spaces.tex}
-Changes one of Gregorio\TeX’s counts or penalties for a given line in the next included score.
+Changes one of Gregorio\TeX’s counts or penalties for a given line in the next included score. This works with \texttt{additionaltopspacethreshold}, \texttt{additionaltopspacealtthreshold}, \texttt{additionaltopspacenabcthreshold}, and \texttt{noteadditionalspacelinestextthreshold}. 
 
 \begin{argtable}
   \#1 & list of integers & A comma-separated list of line numbers in the next
@@ -350,32 +350,14 @@ above or below the staff lines.
 \end{argtable}
 
 By default, Gregorio\TeX{} uses \texttt{variable} line expansion.  This
-produces output similar to modern liturgical books.  However, this
-feature imposes a slight performance impact and typically requires a
-second pass (run of \texttt{lualatex}) to get the heights right.\bigskip
+produces output similar to modern liturgical books.
 
 The older behavior of Gregorio\TeX{}, \texttt{uniform} line expansion,
-does not have this performance impact.  However, the extra space it adds
-below the staff lines may look out-of-place in a section where there are
+adds extra space below the staff lines that may look out-of-place in a section where there are
 no notes below the staff lines.\bigskip
 
 This behavior may be switched as needed within a \TeX{} document and
-affects all the scores which follow.  However, if \texttt{variable} line
-expansion is enabled anywhere in the document, the second pass will be
-necessary.
-
-\begin{small}
-\begin{framed}
-    \textit{For experts only:}\bigskip
-
-    It is possible to suppress the line height computation and just use
-    whatever has been computed from the previous run.  If you are sure
-    that the score line heights haven't changed from the previous run,
-    define the \verb=\greskipheightcomputation= control sequence before
-    including the Gregorio\TeX{} package.  This will save a little bit
-    of time per run.
-\end{framed}
-\end{small}
+affects all the scores which follow.
 
 \macroname{\textbackslash gresetledgerlineheuristic}{\{\#1\}}{gregoriotex-spaces.tex}
 Macro which enables or disables ledger line heuristics.  Currently, ledger
@@ -1098,7 +1080,7 @@ emit the following warning:\par\medskip
 
 \begin{scriptsize}
 \begin{latexcode}
-Module gregoriotex warning: Line heights or variable brace lengths may have changed. Rerun to fix.
+Module gregoriotex warning: Variable brace lengths or soft flats/sharps may have changed. Rerun to fix.
 \end{latexcode}
 \end{scriptsize}
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -53,8 +53,7 @@ Macro to start a score.
       & 1 & there is above lines text somewhere in the score\\
   \#6 & string  & the absolute filename of the gabc file if point-and-click is enabled\\
   \#7 & integer & the number of staff lines\\
-  \#8 & \TeX\ code & macros to run before the score (\eg, setting clef
-                     extrema)\\
+  \#8 & \TeX\ code & macros to run before the score\\
 \end{argtable}
 
 \macroname{\textbackslash GreEndScore}{}{gregoriotex-main.tex}
@@ -709,7 +708,7 @@ Same as \verb=\GreDivisioMinor= except inside a syllable.
 Same as \verb=\GreDominica= except inside a syllable.
 
 \macroname{\textbackslash GreInitialClefPosition}{\#1\#2}{gregoriotex-signs.tex}
-Saves the extrema of the initial clef.
+Saves the extrema of the initial clef (DEPRECATED).
 
 \begin{argtable}
   \#1 & integer & the line of the primary clef (1 is the bottom line)\\

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -43,11 +43,13 @@ Macro to start a score.
 
 \begin{argtable}
   \#1 & string  & a unique identifier for the score (currently an SHA-1-based digest of the gabc file)\\
-  \#2 & integer & the height number of the top pitch of the entire score, including signs\\
-  \#3 & integer & the height number of the bottom pitch of the entire score, including signs\\
-  \#4 & 0 & there is no translation line in the score\\
+  \#2 & integer & the height number of the top pitch of the entire score, including signs (DEPRECATED)\\
+  \#3 & integer & the height number of the bottom pitch of the entire score, including signs (DEPRECATED)\\
+  \#4 & integer & whether there is a translation line (DEPRECATED)\\
+      & 0 & there is no translation line in the score\\
       & 1 & there is a translation line somewhere in the score\\
-  \#5 & 0 & there is no above lines text in the score\\
+  \#5 & integer & whether there is above lines text (DEPRECATED)\\
+      & 0 & there is no above lines text in the score\\
       & 1 & there is above lines text somewhere in the score\\
   \#6 & string  & the absolute filename of the gabc file if point-and-click is enabled\\
   \#7 & integer & the number of staff lines\\

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -85,24 +85,8 @@ Macro holding the list of directories to be searched for scores.  \verb=\input@p
 \macroname{\textbackslash gre@calculate@constantglyphraise}{}{gregoriotex-spaces.tex}
 Macro to calculate \verb=\gre@constantglyphraise=
 
-\macroname{\textbackslash gre@addtranslationspace}{}{gregoriotex-spaces.tex}
-Macro to tell Gregorio to set space for the translation.
-
-\macroname{\textbackslash gre@removetranslationspace}{}{gregoriotexspaces.tex}
-Macro to tell Gregorio to remove the space allocated to the translation.
-
-\macroname{\textbackslash gre@calculate@additionalspaces}{\#1\#2\#3\#4}{gregoriotex-spaces.tex}
-Macro which calculates \verb=\gre@additionalbottomspace= and\\
-\verb=\gre@additionaltopspace=
-
-\begin{argtable}
-  \#1 & integer & the height number of the top pitch, including signs\\
-  \#2 & integer & the height number of the bottom pitch, including signs\\
-  \#3 & \texttt{0} & there is no translation line\\
-  & \texttt{1} & there is a translation line\\
-  \#4 & \texttt{0} & there is no above lines text\\
-  & \texttt{1} & there is above lines text
- \end{argtable}
+\macroname{\textbackslash gre@calculate@additionalspaces}{}{gregoriotex-spaces.tex}
+Macro which initializes various dimensions and counts used for variable line height computation.
 
 \macroname{\textbackslash gre@calculate@textaligncenter}{\#1\#2\#3\#4}{gregoriotex-spaces.tex}
 Macro for calculating \verb=\gre@textaligncenter=.
@@ -479,12 +463,6 @@ Macro called when no initial is being set.
 
 \macroname{\textbackslash gre@setinitial}{\#1}{gregoriotex-main.tex}
 Macro to set the initial in the score.
-
-\macroname{\textbackslash gre@addspaceabove}{}{gregoriotex-main.tex}
-Macro to increase the space above the lines to account for above lines text.
-
-\macroname{\textbackslash gre@removespaceabove}{}{gregoriotex-main.tex}
-Macro to decrease the space above the lines as there is no longer any above lines text.
 
 \macroname{\textbackslash gre@alteration}{\#1\#2\#3\#4\#5\#6}{gregoriotex-signs.tex}
 Macro to typeset an alteration.
@@ -1140,12 +1118,6 @@ Macro set to \verb=0= for full-syllable centering, \verb=1= for vowel centering 
 \macroname{\textbackslash gre@rightfill}{}{gregoriotex-main.tex}
 Macro set to \verb=\hfil= or \verb=\relax= depending on alignment choices.
 
-\macroname{\textbackslash gre@mark@abovelinestext}{}{gregoriotex-main.tex}
-Macro to set the point-and-click position for above lines text.
-
-\macroname{\textbackslash gre@mark@translation}{}{gregoriotex-main.tex}
-Macro to set the point-and-click position for translations.
-
 \macroname{\textbackslash gre@pitch@[a-n,p]}{}{gregoriotex-main.tex}
 Macros which map gabc pitch letters (the final part of the macro name) to the numerical value that Gregorio\TeX\ uses in processing note placement.
 
@@ -1277,15 +1249,8 @@ Alias for \verb=\resizebox=.
 \macroname{\textbackslash gre@dimension}{}{gregoriotex-spaces.tex}
 Workhorse function for setting distances in \verb=\grecreatedim= and \verb=\grechangedim=.
 
-\macroname{\textbackslash gre@changedimforline}{\#1\#2\#3}{gregoriotex-spaces.tex}
-Saves the current value of the dimension and then changes it.  The arguments
-are the same as \verb=\grechangedim=.  Used to temporarily change the dimension
-for a given line, which is restored at the next beginning of the next line.
-
-\macroname{\textbackslash gre@changecountforline}{\#1\#2}{gregoriotex-spaces.tex}
-Saves the current value of the count and then changes it.  The arguments
-are the same as \verb=\grechangeocount=.  Used to temporarily change the count
-for a given line, which is restored at the next beginning of the next line.
+\macroname{\textbackslash gre@luasavedim}{}{gregoriotex-spaces.tex}
+Makes a distance, which is a macro and therefore only visible in TeX code, also visible in Lua code.
 
 \macroname{\textbackslash gre@setstafflines}{\#1}{gregoriotex-main.tex}
 Sets the number of staff lines.
@@ -1412,12 +1377,6 @@ Puts the greater of its two integer arguments into \verb=\gre@count@temp@one=.
 
 \macroname{\textbackslash gre@evaluatenextsyllable}{\#1}{gregoriotex-syllable.tex}
 Evaluates its first argument as an advance computation against the next syllable.  Twiddles the \verb=ifgre@evaluatingnextsyllable= flag around evaluation of the macro argument.
-
-\macroname{\textbackslash gre@save@additionalspaces}{}{gregoriotex-spaces.tex}
-Macro to save the additional vertical spaces associated with the line (\texttt{additionalbottomspace}, \texttt{additionaltopspace}, \texttt{additionaltopspacealt}, \texttt{additionaltopspacenabc}, \texttt{currenttranslationheight}, \texttt{textlower}, \texttt{currentabovelinestextheight}, and \texttt{constantglyphraise}) so that they can be restored later.
-
-\macroname{\textbackslash gre@restore@additionalspaces}{}{gregoriotex-spaces.tex}
-Macro to restore the additional vertical spaces associated with the line from their saved values.
 
 \macroname{\textbackslash gre@clearsyllable}{\#1}{gregoriotex-spaces.tex}
 Prevents the current syllable from overlapping with the previous syllable.
@@ -1794,9 +1753,6 @@ A Lua\TeX\ attribute which indicates whether a syllable takes a dash if it ends 
 
 \macroname{\textbackslash gre@attr@center}{}{gregoriotex-main.tex}
 A Lua\TeX\ attribute which indicates the type of translation centering.
-
-\macroname{\textbackslash gre@attr@glyph@id}{}{gregoriotex-main.tex}
-A Lua\TeX\ attribute which identifies the glyph we are at.  Used for dynamic line spacing.
 
 \macroname{\textbackslash gre@attr@glyph@top}{}{gregoriotex-main.tex}
 A Lua\TeX\ attribute which identifies the high point of the glyph.  Used for dynamic line spacing.

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1118,12 +1118,6 @@ Macro set to \verb=\hfil= or \verb=\relax= depending on alignment choices.
 \macroname{\textbackslash gre@pitch@[a-n,p]}{}{gregoriotex-main.tex}
 Macros which map gabc pitch letters (the final part of the macro name) to the numerical value that Gregorio\TeX\ uses in processing note placement.
 
-\macroname{\textbackslash gre@pitch@adjust@top}{}{gregoriotex-main.tex}
-If any note appears above this pitch, the space above the lines must be adjusted to account for it.
-
-\macroname{\textbackslash gre@pitch@adjust@bottom}{}{gregoriotex-main.tex}
-If any note appears below this pitch, the space below the lines must be adjusted to account for it.
-
 \macroname{\textbackslash gre@pitch@abovestaff}{}{gregoriotex-main.tex}
 The pitch above the staff.
 
@@ -1355,22 +1349,6 @@ Macro to make adjustments to \verb=nextbegindifference= in order to account for 
 
 \macroname{\textbackslash gre@punctummoraadjustment}{}{gregoriotex-spaces.tex}
 Macro to make adjustments to cursor position and \verb=previousenddifference= based on the presence of a punctum mora at the end of the last syllable.
-
-\macroname{\textbackslash gre@num@min}{\#1\#2}{gregoriotex-spaces.tex}
-Puts the lower of its two integer arguments into \verb=\gre@count@temp@one=.
-
-\begin{argtable}
-  \#1 & integer & the first value to compare\\
-  \#2 & integer & the second value to compare\\
-\end{argtable}
-
-\macroname{\textbackslash gre@num@max}{\#1\#2}{gregoriotex-spaces.tex}
-Puts the greater of its two integer arguments into \verb=\gre@count@temp@one=.
-
-\begin{argtable}
-  \#1 & integer & the first value to compare\\
-  \#2 & integer & the second value to compare\\
-\end{argtable}
 
 \macroname{\textbackslash gre@evaluatenextsyllable}{\#1}{gregoriotex-syllable.tex}
 Evaluates its first argument as an advance computation against the next syllable.  Twiddles the \verb=ifgre@evaluatingnextsyllable= flag around evaluation of the macro argument.

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -105,9 +105,6 @@ Macro to calculate \verb=\gre@dimen@annotationtrueraise=.
 \macroname{\textbackslash gre@calculate@commentarytrueraise}{}{gregoriotex-spaces.tex}
 Macro to calculate \verb=\gre@dimen@commentarytrueraise=.
 
-\macroname{\textbackslash gre@calculate@textlower}{}{gregoriotex-spaces.tex}
-Calculates the value of \texttt{textlower}.  Default is \texttt{spacebeneathtext}.
-
 \macroname{\textbackslash gre@calculate@linewidth}{}{gregoriotex-spaces.tex}
 Calculates the line width.  Default is the width of the printable space (\verb=\hsize=).
 
@@ -127,7 +124,7 @@ Calculates a correction factor for when the staff lines are not their default th
 Calculates the total height of the staff.  Dependent on \texttt{stafflineheight} and \texttt{interstafflinespace}.
 
 \macroname{\textbackslash gre@calculate@constantglyphraise}{}{gregoriotex-spaces.tex}
-Calculates the baseline correction for the glyphs.  Dependent on \texttt{gre@factor}, \texttt{additionalbottomspace}, \texttt{spacebeneathtext}, \texttt{spacelinestext}, \texttt{interstafflinespace}, \texttt{stafflineheight}, \texttt{currenttranslationheight}, and \texttt{stafflinediff}.
+Calculates the baseline correction for the glyphs.  Dependent on \texttt{gre@factor}, \texttt{spacebeneathtext}, \texttt{spacelinestext}, \texttt{interstafflinespace}, \texttt{stafflineheight}, and \texttt{stafflinediff}.
 
 \macroname{\textbackslash gre@computespaces}{}{gregoriotex-spaces.tex}
 Aggregates all of the global distance calculations and calls them in the order needed to respect dependencies.
@@ -2104,32 +2101,12 @@ Width of the clef used to compute bolshift.
 \macroname{\textbackslash gre@dimen@constantglyphraise}{}{gregoriotex-spaces.tex}
 Dimension representing the space between the 0 of the gregorian fonts and the effective 0 of the TeX score.
 
-\macroname{\textbackslash gre@dimen@currenttranslationheight}{}{gregoriotex-spaces.tex}
-Dimension representing the space for the translation beneath the text.
-
 \macroname{\textbackslash gre@dimen@stafflinewidth}{}{gregoriotex-spaces.tex}
 Dimension representing the width of a line of staff.  Can vary, for
 example, at the first line.
 
 \macroname{\textbackslash gre@dimen@linewidth}{}{gregoriotex-spaces.tex}
 Dimension representing the width of the score (including initial).
-
-\macroname{\textbackslash gre@dimen@additionalbottomspace}{}{gregoriotex-spaces.tex}
-Dimension representing extra space below the staff needed for low notes.
-
-\macroname{\textbackslash gre@dimen@additionaltopspace}{}{gregoriotex-spaces.tex}
-Dimension representing extra space above the staff needed for high notes.
-
-\macroname{\textbackslash gre@dimen@additionaltopspacealt}{}{gregoriotex-spaces.tex}
-Dimension representing extra space above the staff needed for above lines text.
-
-\macroname{\textbackslash gre@dimen@additionaltopspacenabc}{}{gregoriotex-spaces.tex}
-Dimension representing extra space above the staff needed for nabc notation.
-
-\macroname{\textbackslash gre@dimen@textlower}{}{gregoriotex-spaces.tex}
-Dimension representing the height of the separation between the 0th
-line (which is invisible except for notes in the a or b position) and
-the bottom of the text.
 
 \macroname{\textbackslash gre@dimen@textaligncenter}{}{gregoriotex-spaces.tex}
 Dimension representing the width from the beginning of the letters in
@@ -2138,9 +2115,6 @@ neumes and syllables.
 
 \macroname{\textbackslash gre@dimen@initialwidth}{}{gregoriotex-spaces.tex}
 Dimension representing the width of the initial (and the space after).
-
-\macroname{\textbackslash gre@dimen@currentabovelinestextheight}{}{gregoriotex-spaces.tex}
-Dimension representing the space allocated above the lines for text.
 
 \macroname{\textbackslash gre@dimen@staffheight}{}{gregoriotex-spaces.tex}
 The total height of the staff including the width of the lines and the spaces between them.

--- a/doc_check.sh
+++ b/doc_check.sh
@@ -101,7 +101,7 @@ sed -i.temp 's:.*gre@char@he@.*::' $CODEFILE
 sed -i.temp 's:\\gre@protrusionfactor@.*::' $CODEFILE
 
 #remove LaTeX internal
-sed -i '/\\input@path/d' $CODEFILE
+sed -i.temp '/\\input@path/d' $CODEFILE
 
 #label file
 echo "00 Macros Defined in TeX" >> $CODEFILE

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -4701,9 +4701,11 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
     }
     fprintf(f, "\\GreBeginScore{%s}{%d}{%d}{%d}{%d}{%s}{%u}"
             "{\\GreInitialClefPosition{%d}{%d}}%%\n",
-            digest_to_hex(score->digest), status.top_height,
-            status.bottom_height, bool_to_int(status.translation),
-            bool_to_int(status.abovelinestext),
+            digest_to_hex(score->digest),
+            status.top_height, /* DEPRECATED: these arguments can be deleted */
+            status.bottom_height, /* DEPRECATED */
+            bool_to_int(status.translation), /* DEPRECATED */
+            bool_to_int(status.abovelinestext), /* DEPRECATED */
             point_and_click_filename? point_and_click_filename : "",
             score->staff_lines, clef.line, clef.secondary_line);
     if (score->nabc_lines) {

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -4700,19 +4700,20 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
         clef = score->first_voice_info->initial_clef;
     }
     /* After removing deprecated arguments, this will become:
-    fprintf(f, "\\GreBeginScore{%s}{%s}{%u}{\\GreInitialClefPosition{%d}{%d}}%%\n",
+    fprintf(f, "\\GreBeginScore{%s}{%s}{%u}{}%%\n",
             digest_to_hex(score->digest),
             point_and_click_filename? point_and_click_filename : "",
-            score->staff_lines, clef.line, clef.secondary_line); */
+            score->staff_lines); */
     fprintf(f, "\\GreBeginScore{%s}{%d}{%d}{%d}{%d}{%s}{%u}"
-            "{\\GreInitialClefPosition{%d}{%d}}%%\n",
+            "{\\GreInitialClefPosition{%d}{%d}}%%\n", /* DEPRECATED */
             digest_to_hex(score->digest),
             status.top_height, /* DEPRECATED */
             status.bottom_height, /* DEPRECATED */
             bool_to_int(status.translation), /* DEPRECATED */
             bool_to_int(status.abovelinestext), /* DEPRECATED */
             point_and_click_filename? point_and_click_filename : "",
-            score->staff_lines, clef.line, clef.secondary_line);
+            score->staff_lines,
+            clef.line, clef.secondary_line); /* DEPRECATED */
     if (score->nabc_lines) {
         fprintf(f, "\\GreScoreNABCLines{%d}", (int)score->nabc_lines);
     }

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -56,10 +56,10 @@ typedef struct gregoriotex_status {
     signed char bottom_height;
 
     /* indicates if there is a translation on the line */
-    bool translation;
+    bool translation; /* DEPRECATED */
 
     /* indicates if there is "above lines text" on the line */
-    bool abovelinestext;
+    bool abovelinestext; /* DEPRECATED */
 
     bool suppressed_custos;
 } gregoriotex_status;
@@ -4699,10 +4699,15 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
     if (score->first_voice_info) {
         clef = score->first_voice_info->initial_clef;
     }
+    /* After removing deprecated arguments, this will become:
+    fprintf(f, "\\GreBeginScore{%s}{%s}{%u}{\\GreInitialClefPosition{%d}{%d}}%%\n",
+            digest_to_hex(score->digest),
+            point_and_click_filename? point_and_click_filename : "",
+            score->staff_lines, clef.line, clef.secondary_line); */
     fprintf(f, "\\GreBeginScore{%s}{%d}{%d}{%d}{%d}{%s}{%u}"
             "{\\GreInitialClefPosition{%d}{%d}}%%\n",
             digest_to_hex(score->digest),
-            status.top_height, /* DEPRECATED: these arguments can be deleted */
+            status.top_height, /* DEPRECATED */
             status.bottom_height, /* DEPRECATED */
             bool_to_int(status.translation), /* DEPRECATED */
             bool_to_int(status.abovelinestext), /* DEPRECATED */

--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -337,7 +337,7 @@
 % Space between lines in the commentary
 \gre@createdim{commentaryseparation}{0.05 cm}{scalable}%
 % Amount to raise (positive) or lower (negative) the commentary from the default position (base line of bottom commentary aligned with top line of staff)
-\gre@createdim{commentaryraise}{0.2 cm}{scalable}%
+\gre@createdim{commentaryraise}{0.17351 cm}{scalable}%
 % space at the beginning of the lines if there is no clef
 \gre@createdim{noclefspace}{0.1 cm}{scalable}%
 % space around a clef change

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -394,14 +394,12 @@
   \fi%
   \gre@debugmsg{annotation}{Width check completed.}%
   % Now compute the raise
-  \gre@dimen@temp@five = \dimexpr(\gre@dimen@textlower+\gre@space@dimen@initialraise)\relax%
+  \gre@dimen@temp@five = \dimexpr(\gre@space@dimen@spacebeneathtext+\gre@space@dimen@initialraise)\relax%
   \ifnum\gre@count@initialposition=0\relax
     \advance\gre@dimen@temp@five by 
       \dimexpr(\gre@dimen@staffheight
       + \gre@space@dimen@spacebeneathtext
-      + \gre@dimen@currenttranslationheight
-      + \gre@space@dimen@spacelinestext
-      + \gre@dimen@additionalbottomspace)\relax%
+      + \gre@space@dimen@spacelinestext)\relax%
   \fi % post_linebreak takes care of the other cases
   \ifcase\gre@count@initialanchor\relax
     % top
@@ -701,19 +699,14 @@
   \gre@debugmsg{spacing}{Raise alt text: \gre@space@dimen@abovelinestextraise}%
   \endgre@style@abovelinestext%
   \ifnum#2=0\relax%
-    \gre@dimen@temp@five=\gre@dimen@additionaltopspacealt\relax%
     \gre@attr@part=6\relax
   \else%
-    \gre@dimen@temp@five=\gre@dimen@additionaltopspacenabc\relax%
     \gre@attr@part=7\relax
   \fi%
   \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
     + \gre@dimen@interstafflinespace %
     + \gre@space@dimen@spacebeneathtext %
-    + \gre@dimen@currenttranslationheight %
     + \gre@space@dimen@spacelinestext %
-    + \gre@dimen@additionalbottomspace %
-    + \gre@dimen@temp@five %
     + \gre@space@dimen@abovelinestextraise)\relax%
   \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
   \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\gre@style@abovelinestext#1\endgre@style@abovelinestext\hss}%
@@ -759,7 +752,7 @@
   \setbox\gre@box@lines=\hbox to 0pt{%
     \vbox attr \gre@attrid@part=2 {%
       \gre@style@normalstafflines%
-      \vskip\glueexpr(\gre@dimen@additionaltopspace+\gre@space@skip@spaceabovelines+\gre@dimen@currentabovelinestextheight)\relax%
+      \vskip\gre@space@skip@spaceabovelines\relax%
       \gre@count@temp@one=0\relax
       \loop
         \ifgre@showlines %
@@ -771,7 +764,7 @@
         \ifnum\gre@count@temp@one<\gre@count@stafflines
           \kern\gre@dimen@interstafflinespace\relax
         \repeat
-      \kern\dimexpr(\gre@space@dimen@spacelinestext+\gre@dimen@additionalbottomspace+\gre@space@dimen@spacebeneathtext+\gre@dimen@currenttranslationheight)\relax%
+      \kern\dimexpr(\gre@space@dimen@spacelinestext+\gre@space@dimen@spacebeneathtext)\relax%
       \endgre@style@normalstafflines %
     }%
     \hss%
@@ -1152,9 +1145,6 @@
   % with some versions of LuaTeX, the \localrightbox and \localleftbox must be set empty in an environment with the good attributes set
   \gre@localleftbox{}%
   \gre@localrightbox{}%
-  \global\gre@dimen@currentabovelinestextheight=0pt\relax
-  \global\gre@dimen@currenttranslationheight=0pt\relax
-  \global\gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax
   \gre@restorepenalties %
   \gre@dimen@temp@one=0pt\relax%
   \gre@dimen@temp@two=0pt\relax%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -136,11 +136,7 @@
 }%
 
 \RequireLuaModule{gregoriotex}%
-\ifcsname greskipheightcomputation\endcsname %
-  \directlua{gregoriotex.init(arg, false)}%
-\else %
-  \directlua{gregoriotex.init(arg, true)}%
-\fi %
+\directlua{gregoriotex.init(arg)}%
 \directlua{gregoriotex.set_debug_string([[\gre@debug]])}%
 
 \xdef\gre@gregoriotexluaversion{\directlua{tex.write(gregoriotex.get_gregoriotexluaversion())}}%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -110,13 +110,10 @@
 
 % Alterations are numbered consecutively starting from 1. If an
 % alteration is set twice, once for measurement and once for printing,
-% they have the same id (unlike glyph ids).
+% they have the same id.
 \newluatexattribute\gre@attr@alteration@id %
 
-% The pitch and type of an alteration. If an alteration has a glyph
-% id, then \gre@attr@alteration@pitch = \gre@attr@glyph@top
-% = \gre@attr@glyph@bottom, but we can't use the latter because we
-% also keep track of custos alterations, which don't have glyph ids.
+% The pitch and type of an alteration.
 \newluatexattribute\gre@attr@alteration@pitch
   \edef\gre@attrid@alteration@pitch{\the\allocationnumber}%
 \newluatexattribute\gre@attr@alteration@type % see \gre@alteration for codes

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -84,6 +84,7 @@
 
 % an attribute to mark various parts of the score
 % 1 = commentary, 2 = stafflines, 3 = initial
+% 4 = lyrics, 5 = translation, 6 = alt, 7 = nabc
 \newluatexattribute\gre@attr@part%
   \edef\gre@attrid@part{\the\allocationnumber}
 
@@ -282,17 +283,6 @@
   \fi %
   %%
   \GreResetEolCustos\relax %
-  \gre@trace@end%
-}%
-
-\def\gre@mark@translation{%
-  \gre@trace{gre@mark@translation}%
-  \directlua{gregoriotex.mark_translation()}%
-  \gre@trace@end%
-}%
-\def\gre@mark@abovelinestext{%
-  \gre@trace{gre@mark@abovelinestext}%
-  \directlua{gregoriotex.mark_abovelinestext()}%
   \gre@trace@end%
 }%
 
@@ -731,8 +721,10 @@
   \endgre@style@abovelinestext%
   \ifnum#2=0\relax%
     \gre@dimen@temp@five=\gre@dimen@additionaltopspacealt\relax%
+    \gre@attr@part=6\relax
   \else%
     \gre@dimen@temp@five=\gre@dimen@additionaltopspacenabc\relax%
+    \gre@attr@part=7\relax
   \fi%
   \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
     + \gre@dimen@interstafflinespace %
@@ -742,9 +734,9 @@
     + \gre@dimen@additionalbottomspace %
     + \gre@dimen@temp@five %
     + \gre@space@dimen@abovelinestextraise)\relax%
-  \gre@mark@abovelinestext %
   \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
-    \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\gre@style@abovelinestext#1\endgre@style@abovelinestext\hss}%
+  \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\gre@style@abovelinestext#1\endgre@style@abovelinestext\hss}%
+  \gre@attr@part=-"7FFFFFFF\relax % nil
   \relax %
   \gre@trace@end%
 }%
@@ -926,13 +918,11 @@
     \ifgre@translationcentering %
       \setbox\gre@box@temp@width=\hbox{#1}%
       \gre@dimen@temp@five=\dimexpr((\wd\gre@box@syllabletext - \wd\gre@box@temp@width) / 2)\relax%
-      \gre@mark@translation %
       \kern\gre@dimen@temp@five %
-      \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
+      \raise\gre@space@dimen@spacebeneathtext\hbox attr \gre@attrid@part=5 to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
       \kern-\gre@dimen@temp@five %
     \else %
-      \gre@mark@translation %
-      \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
+      \raise\gre@space@dimen@spacebeneathtext\hbox attr \gre@attrid@part=5 to 0pt{\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}}%
     \fi %
   \fi%
 }%
@@ -943,8 +933,7 @@
       \GreBeginNLBArea{0}{1}%
     \fi %
     \gre@attr@center=1\relax %
-    \gre@mark@translation %
-    \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{\kern 0pt\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}\kern 0pt}%
+    \raise\gre@space@dimen@spacebeneathtext\hbox attr \gre@attrid@part=5 to 0pt{\kern 0pt\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}\kern 0pt}%
     \unsetluatexattribute{\gre@attr@center}%
     \relax %
   \fi%
@@ -992,13 +981,17 @@
 }%
 
 % make this a count so that it can be read more easily in Lua
-\newcount\gre@variableheightexpansion\gre@variableheightexpansion=1\relax %
+\newcount\gre@variableheightexpansion\gre@variableheightexpansion=3\relax %
 \def\gresetlineheightexpansion#1{%
   \IfStrEqCase{#1}{%
-    {uniform}%
+    {olduniform}%
       {\gre@variableheightexpansion=0\relax }%
-    {variable}%
+    {oldvariable}%
       {\gre@variableheightexpansion=1\relax }%
+    {uniform}%
+      {\gre@variableheightexpansion=2\relax }%
+    {variable}%
+      {\gre@variableheightexpansion=3\relax }%
     }[% all other cases
       \gre@error{Unrecognized option "#1" for \protect\gresetlineheightexpansion\MessageBreak Possible options are: 'uniform' and 'variable'}%
     ]%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1067,10 +1067,10 @@
 
 %macro called at the beginning of a score
 % #1 is the gabc score id
-% #2 is the high height (currently ignored)
-% #3 is the low height (currently ignored)
-% #4 is 1 if there is a translation somewhere (currently ignored)
-% #5 is if 1 if we have space above the staff (currently ignored)
+% #2 is the high height (DEPRECATED)
+% #3 is the low height (DEPRECATED)
+% #4 is 1 if there is a translation somewhere (DEPRECATED)
+% #5 is if 1 if we have space above the staff (DEPRECATED)
 % #6 is the point-and-click filename
 % #7 is the number of staff lines
 % #8 is to set the initial clef position

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1101,9 +1101,7 @@
   \noindent%
   \gre@calculate@additionalspaces
   #8%
-  \directlua{
-    gregoriotex.at_score_beginning([[#1]], "\luatexluaescapestring{\gre@gregoriofontname}")
-  }%
+  \directlua{gregoriotex.at_score_beginning([[#1]])}%
   %TODO do something like LaTeX's AtBeginDocument
   \ifdefined\optgabcAtScoreBeginning %
     \optgabcAtScoreBeginning %

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1083,8 +1083,6 @@
   \gre@resetledgerlineheuristics%
   \global\setluatexattribute\gre@attr@syllable@id{0}%
   \global\setluatexattribute\gre@attr@alteration@id{0}%
-  \let\gre@pitch@cleftop\gre@pitch@dummy %
-  \let\gre@pitch@clefbottom\gre@pitch@dummy %
   \xdef\gre@gabcname{#6}%
   \gre@setstafflines{#7}%
   \ifgre@justifylastline%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -207,7 +207,6 @@
 \def\gre@pitch@n{16}%
 \def\gre@pitch@p{17}%
 
-\def\gre@pitch@adjust@bottom{\the\numexpr(\gre@space@count@noteadditionalspacelinestextthreshold + \gre@pitch@a)\relax} %
 \let\gre@pitch@belowstaff\gre@pitch@c %
 \let\gre@pitch@ledger@below\gre@pitch@b %
 \let\gre@pitch@barvepisema\gre@pitch@c %
@@ -992,7 +991,6 @@
   \or % 1
     \gre@error{Invalid number of staff lines}%
   \or % 2
-    \let\gre@pitch@adjust@top\gre@pitch@f %
     \let\gre@pitch@abovestaff\gre@pitch@g %
     \let\gre@pitch@ledger@above\gre@pitch@h %
     \let\gre@pitch@raresign\gre@pitch@g %
@@ -1012,7 +1010,6 @@
     \let\gre@char@bar@divisiomaiordotted\GreCPDivisioMaiorDottedTwo %
     \let\gre@char@bar@divisiomaiordottedbacking\GreCPDivisioMaiorDottedBackingTwo %
   \or % 3
-    \let\gre@pitch@adjust@top\gre@pitch@h %
     \let\gre@pitch@abovestaff\gre@pitch@i %
     \let\gre@pitch@ledger@above\gre@pitch@j %
     \let\gre@pitch@raresign\gre@pitch@i %
@@ -1032,7 +1029,6 @@
     \let\gre@char@bar@divisiomaiordotted\GreCPDivisioMaiorDottedThree %
     \let\gre@char@bar@divisiomaiordottedbacking\GreCPDivisioMaiorDottedBackingThree %
   \or % 4
-    \let\gre@pitch@adjust@top\gre@pitch@j %
     \let\gre@pitch@abovestaff\gre@pitch@k %
     \let\gre@pitch@ledger@above\gre@pitch@l %
     \let\gre@pitch@raresign\gre@pitch@k %
@@ -1052,7 +1048,6 @@
     \let\gre@char@bar@divisiomaiordotted\GreCPDivisioMaiorDottedFour %
     \let\gre@char@bar@divisiomaiordottedbacking\GreCPDivisioMaiorDottedBackingFour %
   \or % 5
-    \let\gre@pitch@adjust@top\gre@pitch@l %
     \let\gre@pitch@abovestaff\gre@pitch@m %
     \let\gre@pitch@ledger@above\gre@pitch@n %
     \let\gre@pitch@raresign\gre@pitch@m %

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -100,7 +100,6 @@
 \newluatexattribute\GreScoreId %
 
 % attributes for tracking glyph heights
-\newluatexattribute\gre@attr@glyph@id %
 \newluatexattribute\gre@attr@glyph@top %
 \newluatexattribute\gre@attr@glyph@bottom %
 
@@ -667,24 +666,6 @@
 %% macro for putting text above lines for annotations and the like
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% set space above the text lines - almost the same as for the translation
-\def\gre@addspaceabove{%
-  \gre@trace{gre@addspaceabove}%
-  \gre@style@abovelinestext%
-  \global\gre@dimen@currentabovelinestextheight=\gre@space@dimen@abovelinestextheight\relax%
-  \endgre@style@abovelinestext%
-  \relax %
-  \gre@trace@end%
-}%
-
-% we don't need space above any more
-\def\gre@removespaceabove{%
-  \gre@trace{gre@removespaceabove}%
-  \global\gre@dimen@currentabovelinestextheight=0 sp%
-  \relax %
-  \gre@trace@end%
-}%
-
 % the code is a bit strange here: we always execute \gre@space@skip@spaceabovelines at the beginning of a glyph. This will:
 % - typeset the text above the lines if relevant, and making sure we execute it only once
 % - not do anything else
@@ -980,17 +961,13 @@
 }%
 
 % make this a count so that it can be read more easily in Lua
-\newcount\gre@variableheightexpansion\gre@variableheightexpansion=3\relax %
+\newcount\gre@variableheightexpansion\gre@variableheightexpansion=1\relax %
 \def\gresetlineheightexpansion#1{%
   \IfStrEqCase{#1}{%
-    {olduniform}%
-      {\gre@variableheightexpansion=0\relax }%
-    {oldvariable}%
-      {\gre@variableheightexpansion=1\relax }%
     {uniform}%
-      {\gre@variableheightexpansion=2\relax }%
+      {\gre@variableheightexpansion=0\relax }%
     {variable}%
-      {\gre@variableheightexpansion=3\relax }%
+      {\gre@variableheightexpansion=1\relax }%
     }[% all other cases
       \gre@error{Unrecognized option "#1" for \protect\gresetlineheightexpansion\MessageBreak Possible options are: 'uniform' and 'variable'}%
     ]%
@@ -1109,10 +1086,10 @@
 
 %macro called at the beginning of a score
 % #1 is the gabc score id
-% #2 is the high height
-% #3 is the low height
-% #4 is 1 if there is a translation somewhere
-% #5 is if 1 if we have space above the staff
+% #2 is the high height (currently ignored)
+% #3 is the low height (currently ignored)
+% #4 is 1 if there is a translation somewhere (currently ignored)
+% #5 is if 1 if we have space above the staff (currently ignored)
 % #6 is the point-and-click filename
 % #7 is the number of staff lines
 % #8 is to set the initial clef position
@@ -1123,7 +1100,6 @@
   \global\gre@dimen@morawidth=0pt\relax %
   \GreResetEolCustos%
   \gre@resetledgerlineheuristics%
-  \global\setluatexattribute\gre@attr@glyph@id{0}%
   \global\setluatexattribute\gre@attr@syllable@id{0}%
   \global\setluatexattribute\gre@attr@alteration@id{0}%
   \let\gre@pitch@cleftop\gre@pitch@dummy %
@@ -1142,13 +1118,10 @@
   \gre@attr@dash=0\relax %
   \gre@generatelines %
   \noindent%
-  \gre@calculate@additionalspaces{#2}{#3}{#4}{#5}%
+  \gre@calculate@additionalspaces
   #8%
   \directlua{
-    gregoriotex.at_score_beginning([[#1]], #2, #3, #4, #5,
-        \gre@pitch@adjust@top, \gre@pitch@adjust@bottom,
-        "\luatexluaescapestring{\gre@gregoriofontname}")
-    gregoriotex.adjust_line_height(1)
+    gregoriotex.at_score_beginning([[#1]], "\luatexluaescapestring{\gre@gregoriofontname}")
   }%
   %TODO do something like LaTeX's AtBeginDocument
   \ifdefined\optgabcAtScoreBeginning %
@@ -1179,9 +1152,9 @@
   % with some versions of LuaTeX, the \localrightbox and \localleftbox must be set empty in an environment with the good attributes set
   \gre@localleftbox{}%
   \gre@localrightbox{}%
-  \gre@calculate@additionalspaces{\gre@pitch@dummy}{\gre@pitch@dummy}{0}{0}%
-  \global\gre@dimen@currentabovelinestextheight=0 sp%
-  \gre@removetranslationspace %
+  \global\gre@dimen@currentabovelinestextheight=0pt\relax
+  \global\gre@dimen@currenttranslationheight=0pt\relax
+  \global\gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax
   \gre@restorepenalties %
   \gre@dimen@temp@one=0pt\relax%
   \gre@dimen@temp@two=0pt\relax%
@@ -1195,7 +1168,6 @@
   \setbox\gre@box@annotation=\box\voidb@x%
   \setbox\gre@box@commentary=\box\voidb@x%
   \directlua{gregoriotex.at_score_end()}%
-  \unsetluatexattribute{\gre@attr@glyph@id}%
   \unsetluatexattribute{\gre@attr@glyph@top}%
   \unsetluatexattribute{\gre@attr@glyph@bottom}%
   \unsetluatexattribute{\gre@attr@dash}%
@@ -1203,7 +1175,6 @@
   \ifgre@justifylastline%
     \parfillskip=\gre@saved@parfillskip\relax%
   \fi %
-  \global\setluatexattribute\gre@attr@glyph@id{0}%
   \relax%
 }%
 

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -736,8 +736,7 @@
     + \gre@space@dimen@abovelinestextraise)\relax%
   \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
   \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\gre@style@abovelinestext#1\endgre@style@abovelinestext\hss}%
-  \gre@attr@part=-"7FFFFFFF\relax % nil
-  \relax %
+  \unsetluatexattribute{\gre@attr@part}%
   \gre@trace@end%
 }%
 

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -300,13 +300,8 @@
   \gre@trace@end%
 }%
 
-\def\GreInitialClefPosition#1#2{%
-  \gre@trace{GreInitialClefPosition{#1}{#2}}%
-  \ifgre@showclef %
-    \gre@save@clefextrema{#1}{#2}%
-  \fi %
-  \gre@trace@end%
-}%
+% DEPRECATED
+\def\GreInitialClefPosition#1#2{}%
 
 % macro that typesets the clef
 % arguments are :

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -576,9 +576,7 @@
   \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
     + \gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext %
-    + \gre@dimen@interstafflinespace %
-    + \gre@dimen@additionalbottomspace %
-    + \gre@dimen@currenttranslationheight)\relax %
+    + \gre@dimen@interstafflinespace)\relax %
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
     \gre@style@additionalstafflines %
@@ -597,8 +595,6 @@
   \gre@trace{gre@additionalbottomcustoslineend}%
   \gre@dimen@temp@five=\dimexpr(\gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext %
-    + \gre@dimen@additionalbottomspace %
-    + \gre@dimen@currenttranslationheight %
     - \gre@dimen@interstafflinespace %
     - \gre@dimen@stafflineheight)\relax %
   \raise\gre@dimen@temp@five %
@@ -622,9 +618,7 @@
   \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
     + \gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext %
-    + \gre@dimen@interstafflinespace %
-    + \gre@dimen@additionalbottomspace %
-    + \gre@dimen@currenttranslationheight)\relax%
+    + \gre@dimen@interstafflinespace)\relax%
   \raise\gre@dimen@temp@five %
   \hbox to 0pt{%
     \gre@style@additionalstafflines %
@@ -643,8 +637,6 @@
   \gre@trace{gre@additionalbottomcustoslinemiddle}%
   \gre@dimen@temp@five=\dimexpr(\gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext %
-    + \gre@dimen@additionalbottomspace %
-    + \gre@dimen@currenttranslationheight %
     - \gre@dimen@interstafflinespace %
     - \gre@dimen@stafflineheight)\relax%
   \raise\gre@dimen@temp@five %
@@ -1629,18 +1621,14 @@
     + \gre@dimen@temp@four)\relax %
   \ifcase#1 % 0
     \gre@dimen@glyphraisevalue=%
-      \dimexpr(\gre@dimen@additionalbottomspace %
-      + \gre@space@dimen@spacebeneathtext %
+      \dimexpr(\gre@space@dimen@spacebeneathtext %
       + \gre@space@dimen@spacelinestext %
-      + \gre@dimen@currenttranslationheight %
       + \gre@count@stafflines\gre@dimen@interstafflinespace %
       + \gre@count@stafflines\gre@dimen@stafflineheight)\relax%
   \or % 1
     \gre@dimen@glyphraisevalue=%
-      \dimexpr(\gre@dimen@additionalbottomspace %
-      + \gre@space@dimen@spacebeneathtext %
+      \dimexpr(\gre@space@dimen@spacebeneathtext %
       + \gre@space@dimen@spacelinestext %
-      + \gre@dimen@currenttranslationheight %
       - \gre@dimen@interstafflinespace %
       - \gre@dimen@stafflineheight)\relax%
   \fi %
@@ -2567,10 +2555,8 @@
   \else %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\gre@char@bar@divisiomaior}%
     % we calculate the raise of the bar
-    \gre@dimen@temp@five=\dimexpr(\gre@dimen@additionalbottomspace %
-      + \gre@space@dimen@spacebeneathtext %
-      + \gre@space@dimen@spacelinestext %
-      + \gre@dimen@currenttranslationheight)\relax%
+    \gre@dimen@temp@five=\dimexpr(\gre@space@dimen@spacebeneathtext %
+      + \gre@space@dimen@spacelinestext)\relax%
     % we calculate the height of the bar
     \raise\gre@dimen@temp@five\hbox{\vrule height \gre@dimen@staffheight width \wd\gre@box@temp@width}%
   \fi %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -324,6 +324,7 @@
 \def\gre@typeclef#1#2#3#4#5#6#7#8{%
   \gre@trace{gre@typeclef{#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}}%
   \gre@save@clefextrema{#2}{#7}%
+  \GreGlyphHeights{\gre@pitch@cleftop}{\gre@pitch@clefbottom}%
   \gre@boxclef{#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}%
   \ifcase#3%
     \gre@update@clefwidth@current{\wd\gre@box@temp@width}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -668,7 +668,9 @@
 \def\gre@custosalteration#1#2{%
   \gre@trace{gre@custosalteration{#1}{#2}}%
   \ifgre@usecustosalteration %
-    \IfStrEq{#2}{}{}{\csname Gre#2\endcsname{#1}{0}{}{}{}}%
+    \IfStrEq{#2}{}{}{%
+      \GreGlyphHeights{#1}{#1}%
+      \csname Gre#2\endcsname{#1}{0}{}{}{}}%
   \fi %
   \gre@trace@end%
 }%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -107,9 +107,6 @@
 %   - 0: clef change
 \def\GreDiscretionary#1#2#3{%
   \gre@trace{GreDiscretionary{#1}{#2}{#3}}%
-  \gre@save@additionalspaces %
-  \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary, true)}%
-  \gre@restore@additionalspaces %
   \global\let\gre@hskip\kern %
   \global\let\gre@penalty\gre@falsepenalty %
   \global\xdef\gre@insidediscretionary{\number 1}%
@@ -505,7 +502,6 @@
     \kern\gre@skip@bar@lastskip %
     \GreNoBreak %
   \fi %
-  \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \relax %
   \gre@in@custosfalse %
   \gre@trace@end%
@@ -691,7 +687,6 @@
   % set attributes to adjust the line height for the pitch of the custos
   \ifcase#2% 0
   \or % 1
-    \global\advance\gre@attr@glyph@id by 1\relax %
     \GreGlyphHeights{#1}{#1}%
   \or % 2
     \ifgre@eolshiftsenabled %
@@ -2560,7 +2555,6 @@
   \gre@debugmsg{spacing}{Width of bar just printed: \the\wd\gre@box@temp@width}%
   \gre@debugmsg{spacing}{Last bar space: \the\gre@skip@temp@four}%
   \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %
-  \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \global\gre@firstglyphfalse %
   \relax%
   \gre@trace@end%
@@ -2836,7 +2830,6 @@
       \gre@hskip\gre@skip@temp@four %
     \fi %
     \GreNoBreak %
-    \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \fi %
   \relax %
   \gre@trace@end%
@@ -3038,7 +3031,6 @@
     \fi %
     \GreNoBreak% no break after left bracket
   \fi %
-  \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \gre@endofglyphcommon %
   \relax%
   \gre@trace@end%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1590,6 +1590,9 @@
 % #1 : line number
 % #2-#4 : same as #1-#3 of \grechangedim
 \def\grechangenextscorelinedim#1#2#3#4{%
+  \IfStrEqCase{#2}{{abovelinestextheight}{}{noteadditionalspacelinestext}{}{spaceabovelines}{}{abovelinestextraise}{}{spacelinestext}{}{spacebeneathtext}{}{translationheight}{}}[%
+    \gre@error{Unrecognized option "#2" for \protect\grechangenextscorelinedim\MessageBreak Possible options are: 'abovelinestextraise', 'noteadditionalspacelinestext', 'spaceabovelines', 'spacebeneathtext', 'spacelinestext', 'translationheight'}%
+  ]%
   {\grechangedim{#2}{#3}{#4}%
    \gre@rubberpermit{#2}%
    \ifgre@rubber%
@@ -1610,6 +1613,9 @@
 % #1 : line number
 % #2-#3 : same as #1-#2 of \grechangecount
 \def\grechangenextscorelinecount#1#2#3{%
+  \IfStrEqCase{#2}{{additionaltopspacethreshold}{}{additionaltopspacealtthreshold}{}{additionaltopspacenabcthreshold}{}{noteadditionalspacelinestextthreshold}{}}[%
+    \gre@error{Unrecognized option "#2" for \protect\grechangenextscorelinecount\MessageBreak Possible options are: 'additionaltopspacethreshold', 'additionaltopspacealtthreshold', 'additionaltopspacenabcthreshold', 'noteadditionalspacelinestextthreshold'}%
+  ]%
   \directlua{%
     gregoriotex.change_next_score_line_count(%
       "\luatexluaescapestring{#1}",%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1027,13 +1027,13 @@
 %This function sets the true raises of the commentary (it has to be called just as the boxes are placed in order to make sure that the values are all correct)
 \def\gre@calculate@commentarytrueraise{%
   \gre@trace{gre@calculate@commentarytrueraise}%
-  \gre@style@commentary%
   \gre@debugmsg{commentary}{Calculating the raise.}%
   \global\advance\gre@dimen@commentarytrueraise by %
     \dimexpr(\gre@dimen@staffheight %
     + \gre@space@dimen@spacebeneathtext %
-    + \gre@space@dimen@spacelinestext %
-    + \gre@space@dimen@commentaryraise)\relax%
+    + \gre@space@dimen@spacelinestext)\relax
+  \gre@style@commentary
+  \global\advance\gre@dimen@commentarytrueraise by \gre@space@dimen@commentaryraise
   \endgre@style@commentary%
   \gre@trace@end%
 }%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -899,25 +899,6 @@
 \newcount\gre@space@count@noteadditionalspacelinestextthreshold\relax%
 \gre@space@count@noteadditionalspacelinestextthreshold=2
 
-\def\gre@num@min#1#2{%
-  \gre@trace{gre@num@min{#1}{#2}}%
-  \ifnum#1 < #2\relax %
-    \gre@count@temp@one=#1\relax %
-  \else %
-    \gre@count@temp@one=#2\relax %
-  \fi %
-  \gre@trace@end%
-}%
-\def\gre@num@max#1#2{%
-  \gre@trace{gre@num@max{#1}{#2}}%
-  \ifnum#1 > #2\relax %
-    \gre@count@temp@one=#1\relax %
-  \else %
-    \gre@count@temp@one=#2\relax %
-  \fi %
-  \gre@trace@end%
-}%
-
 \let\gre@pitch@cleftop\gre@pitch@dummy %
 \let\gre@pitch@clefbottom\gre@pitch@dummy %
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -138,15 +138,6 @@
 %% Global distances
 %%%%%%%%%%%%%%%%%
 
-% textlower is the height of the separation between the bottom line (which is invisible : for the notes which are very low) and the bottom of the text
-\newdimen\gre@dimen@textlower\relax%
-\def\gre@calculate@textlower{%
-  \gre@trace{gre@calculate@textlower}%
-  \gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax%
-  %\advance\gre@dimen@textlower by \translationheight
-  \gre@trace@end%
-}%
-
 % stafflinewidth is the width of a line of staff, this can vary, for example at the first line
 \newdimen\gre@dimen@stafflinewidth\relax%
 \def\gre@calculate@stafflinewidth{%
@@ -212,14 +203,12 @@
 \def\gre@calculate@constantglyphraise{%
   \gre@trace{gre@calculate@constantglyphraise}%
   \global\gre@dimen@constantglyphraise = \dimexpr((\gre@dimen@glyphraisebase * \gre@factor) %
-    + \gre@dimen@additionalbottomspace %
     + \gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext %
     + \gre@dimen@interstafflinespace %
     + \gre@dimen@interstafflinespace %
     + \gre@dimen@stafflineheight %
     + \gre@dimen@stafflineheight %
-    + \gre@dimen@currenttranslationheight %
     % an adjustment in the case of big lines
     + \gre@dimen@stafflinediff)\relax%
   \relax %
@@ -241,17 +230,15 @@
 % A routine that simply aggregates the above global space calculating routines so we can easily update all when needed.
 %% Note: It used to be that some distance calculating functions called others.  Since this can create problems with circularity if one is not careful, this is no longer the case.  Now all distance calculating functions simply calculate their respective distance.  This means that dependent distances are not necessarily recalculated when an individual distance is recalculated.  This function updates all global calculated distances and in the order needed for the dependencies.
 %% Dependencies:
-%% textlower: spacebeneathtext
 %% linewidth: hsize
 %% stafflinewidth: linewidth
 %% stafflineheight: stafflinefactor & gre@factor
 %% interstafflinespace: stafflineheight & gre@factor
 %% stafflinediff: stafflineheight & gre@factor
 %% staffheight: stafflineheight & interstafflinespace
-%% constantglyphraise: gre@factor, additionalbottomspace, spacebeneathtext, spacelinestext, interstafflinespace, stafflineheight, currenttranslationheight, stafflinediff
+%% constantglyphraise: gre@factor, spacebeneathtext, spacelinestext, interstafflinespace, stafflineheight, stafflinediff
 \def\gre@computespaces{%
   \gre@trace{gre@computespaces}%
-  \gre@calculate@textlower%
   \gre@calculate@linewidth%
   \gre@calculate@stafflinewidth%
   \gre@calculate@stafflineheight%
@@ -900,15 +887,6 @@
   \gre@trace@end%
 }%
 
-% two dimensions for the additionalspaces
-\newdimen\gre@dimen@additionalbottomspace\relax%
-% the one taken into account to adjust space between lines
-\newdimen\gre@dimen@additionaltopspace\relax%
-% the one taken into account for above lines text height
-\newdimen\gre@dimen@additionaltopspacealt\relax%
-% the one taken into account for above lines nabc height
-\newdimen\gre@dimen@additionaltopspacenabc\relax%
-
 \newcount\gre@space@count@additionaltopspacethreshold\relax%
 \gre@space@count@additionaltopspacethreshold=2
 
@@ -945,13 +923,6 @@
 
 \def\gre@calculate@additionalspaces{%
   \gre@trace{gre@calculate@additionalspaces}%
-  \global\gre@dimen@currentabovelinestextheight=0pt\relax
-  \global\gre@dimen@additionaltopspace=0pt\relax
-  \global\gre@dimen@additionaltopspacealt=0pt\relax
-  \global\gre@dimen@additionaltopspacenabc=0pt\relax
-  \global\gre@dimen@additionalbottomspace=0pt\relax
-  \global\gre@dimen@currenttranslationheight=0pt\relax
-  \global\gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax
   % Pass in dimensions and counts that are macros
   \gre@luasavedim{abovelinestextheight}%
   % \ifgre@noteadditionalspacelinestext is not accessible in Lua, so handle it here
@@ -1021,9 +992,6 @@
   \gre@trace@end%
 }%
 
-% temporary value for space for the translation, beneath the text
-\newdimen\gre@dimen@currenttranslationheight\relax%
-
 %nextbegindifference is the begindifference of the next syllable
 \newskip\gre@skip@nextbegindifference\relax%
 
@@ -1064,9 +1032,7 @@
   \global\advance\gre@dimen@annotationtrueraise by %
     \dimexpr(\gre@dimen@staffheight %
     + \gre@space@dimen@spacebeneathtext %
-    + \gre@dimen@currenttranslationheight %
-    + \gre@space@dimen@spacelinestext %
-    + \gre@dimen@additionalbottomspace)\relax%
+    + \gre@space@dimen@spacelinestext)\relax%
   \gre@style@annotation%
   \global\advance\gre@dimen@annotationtrueraise by \gre@space@dimen@annotationraise\relax%
   \gre@debugmsg{annotation}{Added user raise.}%
@@ -1085,9 +1051,7 @@
   \global\advance\gre@dimen@commentarytrueraise by %
     \dimexpr(\gre@dimen@staffheight %
     + \gre@space@dimen@spacebeneathtext %
-    + \gre@dimen@currenttranslationheight %
     + \gre@space@dimen@spacelinestext %
-    + \gre@dimen@additionalbottomspace %
     + \gre@space@dimen@commentaryraise)\relax%
   \endgre@style@commentary%
   \gre@trace@end%
@@ -1451,9 +1415,6 @@
 % the calculated width of the initial (may be actual width of letter or be forced wider under certain conditions)
 \newdimen\gre@dimen@initialwidth\relax%
 \gre@dimen@initialwidth= 0 pt\relax%
-
-\newdimen\gre@dimen@currentabovelinestextheight\relax%
-\gre@dimen@currentabovelinestextheight = 0pt\relax%
 
 %% TODO: perhaps create a pair of functions which “reserve” and “release” the temporary registers in order to keep track of which ones are in use when.  There would also need to be a list of the registers currently in use.  The reserve function would then check the list to make sure the requested register isn’t already in use, throwing an error if it is and adding its name to the list if it isn’t.  It might also provide for an alias (via \let).  The release function would simply remove the register from the list of those in use.
 % Register allocation is an inherently global process in TeX.  Below are the registers used within calculations on a temporary basis.

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -980,11 +980,6 @@
 \let\gre@pitch@cleftop\gre@pitch@dummy %
 \let\gre@pitch@clefbottom\gre@pitch@dummy %
 
-% \gre@space@dimen@abovelinestextheight and \gre@space@dimen@translationheight are macros, but Lua code can only read dimens
-\newdimen\gre@dimen@maybe@abovelinestextheight
-\newdimen\gre@dimen@maybe@translationheight
-\newdimen\gre@dimen@maybe@noteadditionalspacelinestext
-
 % #1 is the high height
 % #2 is the low height
 % #3 is 1 if there is a translation somewhere
@@ -992,19 +987,26 @@
 \def\gre@calculate@additionalspaces#1#2#3#4{%
   \gre@trace{gre@calculate@additionalspaces{#1}{#2}{#3}{#4}}%
   \ifnum\gre@variableheightexpansion>1\relax
-    \global\gre@dimen@maybe@abovelinestextheight=\gre@space@dimen@abovelinestextheight\relax
+    \gre@removespaceabove
     \global\gre@dimen@additionaltopspace=0pt\relax
     \global\gre@dimen@additionaltopspacealt=0pt\relax
     \global\gre@dimen@additionaltopspacenabc=0pt\relax
-    \ifgre@noteadditionalspacelinestext
-      \global\gre@dimen@maybe@noteadditionalspacelinestext=\gre@space@dimen@noteadditionalspacelinestext
-    \else
-      \global\gre@dimen@maybe@noteadditionalspacelinestext=\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)/2 * \gre@factor\relax
-    \fi
     \global\gre@dimen@additionalbottomspace=0pt\relax
-    \global\gre@dimen@maybe@translationheight=\gre@space@dimen@translationheight\relax
     \gre@removetranslationspace
-    \gre@removespaceabove
+    % Pass in dimensions and counts that are macros
+    \gre@luasavedim{abovelinestextheight}%
+    % \ifgre@noteadditionalspacelinestext is not accessible in Lua, so handle it here
+    \ifgre@noteadditionalspacelinestext
+      \gre@luasavedim{noteadditionalspacelinestext}%
+    \else
+      {\grechangedim{noteadditionalspacelinestext}{\the\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)/2 * \gre@factor\relax}{fixed}%
+       \gre@luasavedim{noteadditionalspacelinestext}}%
+    \fi
+    \gre@luasavedim{spaceabovelines}%
+    \gre@luasavedim{abovelinestextraise}%
+    \gre@luasavedim{spacelinestext}%
+    \gre@luasavedim{spacebeneathtext}%
+    \gre@luasavedim{translationheight}%
   \else
   \gre@num@max{#1}{\gre@pitch@cleftop}%
   \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacethreshold)\relax %
@@ -1757,16 +1759,42 @@
   \gre@trace@end%
 }%
 
+% Make a dim accessible in Lua code. Any scaling or inheriting is done
+% at the time of the expansion of \gre@luasavedim, not when the dim is
+% used in Lua.
+% #1: name of dim
+\def\gre@luasavedim#1{%
+  \gre@rubberpermit{#1}%
+  \ifgre@rubber%
+    \def\gre@prefix{skip}%
+  \else%
+    \def\gre@prefix{dimen}%
+  \fi%
+  \directlua{%
+    gregoriotex.save_dim(%
+      "\luatexluaescapestring{#1}",%
+      "\luatexluaescapestring{\csname gre@space@\gre@prefix @#1\endcsname}"%
+    )%
+  }%
+}%
+
 % #1 : line number
 % #2-#4 : same as #1-#3 of \grechangedim
 \def\grechangenextscorelinedim#1#2#3#4{%
-  \directlua{%
-    gregoriotex.change_next_score_line_dim(%
-      "\luatexluaescapestring{#1}",%
-      "\luatexluaescapestring{#2}",%
-      "\luatexluaescapestring{#3}",%
-      "\luatexluaescapestring{#4}"%
-    )%
+  {\grechangedim{#2}{#3}{#4}%
+   \gre@rubberpermit{#2}%
+   \ifgre@rubber%
+     \def\gre@prefix{skip}%
+   \else%
+     \def\gre@prefix{dimen}%
+   \fi%
+   \directlua{%
+     gregoriotex.change_next_score_line_dim(%
+       "\luatexluaescapestring{#1}",%
+       "\luatexluaescapestring{#2}",%
+       "\luatexluaescapestring{\csname gre@space@\gre@prefix @#2\endcsname}"%
+     )%
+   }%
   }%
 }%
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -899,9 +899,6 @@
 \newcount\gre@space@count@noteadditionalspacelinestextthreshold\relax%
 \gre@space@count@noteadditionalspacelinestextthreshold=2
 
-\let\gre@pitch@cleftop\gre@pitch@dummy %
-\let\gre@pitch@clefbottom\gre@pitch@dummy %
-
 \def\gre@calculate@additionalspaces{%
   \gre@trace{gre@calculate@additionalspaces}%
   % Pass in dimensions and counts that are macros

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -940,120 +940,34 @@
   \gre@trace@end%
 }%
 
-% some backup demensions for use around discretionaries
-\newdimen\gre@saved@prediscretionary@dimen@additionalbottomspace\relax%
-\newdimen\gre@saved@prediscretionary@dimen@additionaltopspace\relax%
-\newdimen\gre@saved@prediscretionary@dimen@additionaltopspacealt\relax%
-\newdimen\gre@saved@prediscretionary@dimen@additionaltopspacenabc\relax%
-\newdimen\gre@saved@prediscretionary@dimen@currenttranslationheight\relax%
-\newdimen\gre@saved@prediscretionary@dimen@textlower\relax%
-\newdimen\gre@saved@prediscretionary@dimen@currentabovelinestextheight\relax%
-\newdimen\gre@saved@prediscretionary@dimen@constantglyphraise\relax%
-
-
-\def\gre@save@additionalspaces{%
-  \gre@trace{gre@save@additionalspaces}%
-  \global\gre@saved@prediscretionary@dimen@additionalbottomspace=\gre@dimen@additionalbottomspace\relax%
-  \global\gre@saved@prediscretionary@dimen@additionaltopspace=\gre@dimen@additionaltopspace\relax%
-  \global\gre@saved@prediscretionary@dimen@additionaltopspacealt=\gre@dimen@additionaltopspacealt\relax%
-  \global\gre@saved@prediscretionary@dimen@additionaltopspacenabc=\gre@dimen@additionaltopspacenabc\relax%
-  \global\gre@saved@prediscretionary@dimen@currenttranslationheight=\gre@dimen@currenttranslationheight\relax%
-  \global\gre@saved@prediscretionary@dimen@textlower=\gre@dimen@textlower\relax%
-  \global\gre@saved@prediscretionary@dimen@currentabovelinestextheight=\gre@dimen@currentabovelinestextheight\relax%
-  \global\gre@saved@prediscretionary@dimen@constantglyphraise=\gre@dimen@constantglyphraise\relax%
-  \gre@trace@end%
-}%
-
-\def\gre@restore@additionalspaces{%
-  \gre@trace{gre@restore@additionalspaces}%
-  \global\gre@dimen@additionalbottomspace=\gre@saved@prediscretionary@dimen@additionalbottomspace\relax%
-  \global\gre@dimen@additionaltopspace=\gre@saved@prediscretionary@dimen@additionaltopspace\relax%
-  \global\gre@dimen@additionaltopspacealt=\gre@saved@prediscretionary@dimen@additionaltopspacealt\relax%
-  \global\gre@dimen@additionaltopspacenabc=\gre@saved@prediscretionary@dimen@additionaltopspacenabc\relax%
-  \global\gre@dimen@currenttranslationheight=\gre@saved@prediscretionary@dimen@currenttranslationheight\relax%
-  \global\gre@dimen@textlower=\gre@saved@prediscretionary@dimen@textlower\relax%
-  \global\gre@dimen@currentabovelinestextheight=\gre@saved@prediscretionary@dimen@currentabovelinestextheight\relax%
-  \global\gre@dimen@constantglyphraise=\gre@saved@prediscretionary@dimen@constantglyphraise\relax%
-  \gre@trace@end%
-}%
-
 \let\gre@pitch@cleftop\gre@pitch@dummy %
 \let\gre@pitch@clefbottom\gre@pitch@dummy %
 
-% #1 is the high height
-% #2 is the low height
-% #3 is 1 if there is a translation somewhere
-% #4 is if 1 if we have space above the staff
-\def\gre@calculate@additionalspaces#1#2#3#4{%
-  \gre@trace{gre@calculate@additionalspaces{#1}{#2}{#3}{#4}}%
-  \ifnum\gre@variableheightexpansion>1\relax
-    \gre@removespaceabove
-    \global\gre@dimen@additionaltopspace=0pt\relax
-    \global\gre@dimen@additionaltopspacealt=0pt\relax
-    \global\gre@dimen@additionaltopspacenabc=0pt\relax
-    \global\gre@dimen@additionalbottomspace=0pt\relax
-    \gre@removetranslationspace
-    % Pass in dimensions and counts that are macros
-    \gre@luasavedim{abovelinestextheight}%
-    % \ifgre@noteadditionalspacelinestext is not accessible in Lua, so handle it here
-    \ifgre@noteadditionalspacelinestext
-      \gre@luasavedim{noteadditionalspacelinestext}%
-    \else
-      {\grechangedim{noteadditionalspacelinestext}{\the\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)/2 * \gre@factor\relax}{fixed}%
-       \gre@luasavedim{noteadditionalspacelinestext}}%
-    \fi
-    \gre@luasavedim{spaceabovelines}%
-    \gre@luasavedim{abovelinestextraise}%
-    \gre@luasavedim{spacelinestext}%
-    \gre@luasavedim{spacebeneathtext}%
-    \gre@luasavedim{translationheight}%
+\def\gre@calculate@additionalspaces{%
+  \gre@trace{gre@calculate@additionalspaces}%
+  \global\gre@dimen@currentabovelinestextheight=0pt\relax
+  \global\gre@dimen@additionaltopspace=0pt\relax
+  \global\gre@dimen@additionaltopspacealt=0pt\relax
+  \global\gre@dimen@additionaltopspacenabc=0pt\relax
+  \global\gre@dimen@additionalbottomspace=0pt\relax
+  \global\gre@dimen@currenttranslationheight=0pt\relax
+  \global\gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax
+  % Pass in dimensions and counts that are macros
+  \gre@luasavedim{abovelinestextheight}%
+  % \ifgre@noteadditionalspacelinestext is not accessible in Lua, so handle it here
+  \ifgre@noteadditionalspacelinestext
+    \gre@luasavedim{noteadditionalspacelinestext}%
   \else
-  \gre@num@max{#1}{\gre@pitch@cleftop}%
-  \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacethreshold)\relax %
-  \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionaltopspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
-  \else %
-    \global\gre@dimen@additionaltopspace=0 sp%
-  \fi %
-  \gre@num@max{#1}{\gre@pitch@cleftop}%
-  \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacealtthreshold)\relax %
-  \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionaltopspacealt=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
-  \else %
-    \global\gre@dimen@additionaltopspacealt=0 sp%
-  \fi %
-  \gre@num@max{#1}{\gre@pitch@cleftop}%
-  \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacenabcthreshold)\relax %
-  \ifnum\gre@count@temp@one>0\relax %
-    \global\gre@dimen@additionaltopspacenabc=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@count@temp@one * \gre@factor)\relax %
-  \else %
-    \global\gre@dimen@additionaltopspacenabc=0 sp%
-  \fi %
-  \gre@num@min{#2}{\gre@pitch@clefbottom}%
-  \gre@count@temp@one=\numexpr(\gre@pitch@adjust@bottom - \gre@count@temp@one)\relax %
-  \ifnum\gre@count@temp@one>0\relax %
-    \ifgre@noteadditionalspacelinestext%
-      \global\gre@dimen@additionalbottomspace=\dimexpr(\gre@space@dimen@noteadditionalspacelinestext * \gre@count@temp@one)\relax%
-    \else%
-      \global\gre@dimen@additionalbottomspace=\dimexpr(((\gre@dimen@interstafflinedistancebase + \gre@dimen@stafflinethicknessbase) / 2 ) * \gre@factor * \gre@count@temp@one)\relax%
-    \fi%
-  \else %
-    \global\gre@dimen@additionalbottomspace=0 sp%
-  \fi %
-  \ifnum#3 = 1\relax %
-    \gre@addtranslationspace %
-  \else %
-    \gre@removetranslationspace %
-  \fi %
-  \ifnum#4 = 1\relax %
-    \gre@addspaceabove %
-  \else %
-    \gre@removespaceabove %
-  \fi %
-  \fi % \gre@variableheightexpansion < 2
+    {\grechangedim{noteadditionalspacelinestext}{\the\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)/2 * \gre@factor\relax}{fixed}%
+     \gre@luasavedim{noteadditionalspacelinestext}}%
+  \fi
+  \gre@luasavedim{spaceabovelines}%
+  \gre@luasavedim{abovelinestextraise}%
+  \gre@luasavedim{spacelinestext}%
+  \gre@luasavedim{spacebeneathtext}%
+  \gre@luasavedim{translationheight}%
   \gre@generatelines %
   \gre@calculate@constantglyphraise %
-  \relax %
   \gre@trace@end%
 }%
 
@@ -1109,26 +1023,6 @@
 
 % temporary value for space for the translation, beneath the text
 \newdimen\gre@dimen@currenttranslationheight\relax%
-
-% macro to tell gregorio to set space for the translation
-\def\gre@addtranslationspace{%
-  \gre@trace{gre@addtranslationspace}%
-  \gre@style@translation%
-  \global\gre@dimen@currenttranslationheight=\gre@space@dimen@translationheight\relax%
-  \global\gre@dimen@textlower=\dimexpr(\gre@space@dimen@spacebeneathtext %
-    + \gre@space@dimen@translationheight)\relax%
-  \endgre@style@translation%
-  \relax %
-  \gre@trace@end%
-}%
-
-\def\gre@removetranslationspace{%
-  \gre@trace{gre@removetranslationspace}%
-  \global\gre@dimen@currenttranslationheight=0 sp%
-  \global\gre@dimen@textlower=\gre@space@dimen@spacebeneathtext\relax%
-  \relax %
-  \gre@trace@end%
-}%
 
 %nextbegindifference is the begindifference of the next syllable
 \newskip\gre@skip@nextbegindifference\relax%
@@ -1672,7 +1566,6 @@
       \def\gre@prefixII{dimen}%
     \fi%
     \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{\expandafter\unexpanded{\csname gre@space@\gre@prefixII @#2\endcsname}}%
-    \directlua{gregoriotex.hash_spaces("\luatexluaescapestring{#1}", "\luatexluaescapestring{inherited from #2}")}%
   }{%
     \gre@rubberpermit{#2}%
     \ifgre@rubber%
@@ -1708,7 +1601,6 @@
         \fi%
       }{}%
     \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{#2}%
-    \directlua{gregoriotex.hash_spaces("\luatexluaescapestring{#1}", "\luatexluaescapestring{#2}")}%
     \relax %
   }%
   \gre@trace@end%
@@ -1733,31 +1625,6 @@
     \gre@error{Unrecognized distance "#1" in \protect\grescaledim}%
   \fi%
 }
-
-% same arguments as \grechangedim, but used for setting the dimension for a
-% single line
-\def\gre@changedimforline#1#2#3{%
-  \gre@trace{gre@changedimforline{#1}{#2}{#3}}%
-  \gre@rubberpermit{#1}%
-  \ifgre@rubber%
-    \def\gre@prefix{skip}%
-  \else%
-    \def\gre@prefix{dimen}%
-  \fi%
-  \directlua{%
-    gregoriotex.save_dim(%
-      "\luatexluaescapestring{#1}",%
-      "\luatexluaescapestring{\expandafter\unexpanded%
-        \expandafter\expandafter\expandafter{%
-          \csname gre@space@\gre@prefix @#1\endcsname%
-        }%
-      }",%
-      "\csname ifgre@scale@#1\endcsname scalable\else fixed\fi"%
-    )%
-  }%
-  \grechangedim{#1}{#2}{#3}%
-  \gre@trace@end%
-}%
 
 % Make a dim accessible in Lua code. Any scaling or inheriting is done
 % at the time of the expansion of \gre@luasavedim, not when the dim is
@@ -1796,24 +1663,6 @@
      )%
    }%
   }%
-}%
-
-% same arguments as \grechangecount, but used for setting the dimension for a
-% single line
-\def\gre@changecountforline#1#2{%
-  \gre@trace{gre@changecountforline{#1}{#2}}%
-  \directlua{%
-    gregoriotex.save_count(%
-      "\luatexluaescapestring{#1}",%
-      "\luatexluaescapestring{\expandafter\unexpanded%
-        \expandafter\expandafter\expandafter{%
-          \expandafter\the\csname gre@space@count@#1\endcsname%
-        }%
-      }"%
-    )%
-  }%
-  \grechangecount{#1}{#2}%
-  \gre@trace@end%
 }%
 
 % #1 : line number

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -980,12 +980,32 @@
 \let\gre@pitch@cleftop\gre@pitch@dummy %
 \let\gre@pitch@clefbottom\gre@pitch@dummy %
 
+% \gre@space@dimen@abovelinestextheight and \gre@space@dimen@translationheight are macros, but Lua code can only read dimens
+\newdimen\gre@dimen@maybe@abovelinestextheight
+\newdimen\gre@dimen@maybe@translationheight
+\newdimen\gre@dimen@maybe@noteadditionalspacelinestext
+
 % #1 is the high height
 % #2 is the low height
 % #3 is 1 if there is a translation somewhere
 % #4 is if 1 if we have space above the staff
 \def\gre@calculate@additionalspaces#1#2#3#4{%
   \gre@trace{gre@calculate@additionalspaces{#1}{#2}{#3}{#4}}%
+  \ifnum\gre@variableheightexpansion>1\relax
+    \global\gre@dimen@maybe@abovelinestextheight=\gre@space@dimen@abovelinestextheight\relax
+    \global\gre@dimen@additionaltopspace=0pt\relax
+    \global\gre@dimen@additionaltopspacealt=0pt\relax
+    \global\gre@dimen@additionaltopspacenabc=0pt\relax
+    \ifgre@noteadditionalspacelinestext
+      \global\gre@dimen@maybe@noteadditionalspacelinestext=\gre@space@dimen@noteadditionalspacelinestext
+    \else
+      \global\gre@dimen@maybe@noteadditionalspacelinestext=\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)/2 * \gre@factor\relax
+    \fi
+    \global\gre@dimen@additionalbottomspace=0pt\relax
+    \global\gre@dimen@maybe@translationheight=\gre@space@dimen@translationheight\relax
+    \gre@removetranslationspace
+    \gre@removespaceabove
+  \else
   \gre@num@max{#1}{\gre@pitch@cleftop}%
   \gre@count@temp@one=\numexpr(\gre@count@temp@one - \gre@pitch@adjust@top - \gre@space@count@additionaltopspacethreshold)\relax %
   \ifnum\gre@count@temp@one>0\relax %
@@ -1028,6 +1048,7 @@
   \else %
     \gre@removespaceabove %
   \fi %
+  \fi % \gre@variableheightexpansion < 2
   \gre@generatelines %
   \gre@calculate@constantglyphraise %
   \relax %

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -90,7 +90,6 @@
 
 \def\gre@newglyphcommon{%
   \gre@trace{gre@newglyphcommon}%
-  \global\advance\gre@attr@glyph@id by 1\relax %
   % first there is something we must do: setting \gre@lastoflinecount to 0 if its value is 2. The reason of this is that in ab(abzcd), we cannot let \grelastoflinecount set to 2 after the end of line... the only way I found to achieve it is to reset \grelastoflinecount to 0 after each glyph or bar.
   \ifnum\gre@lastoflinecount=2\relax %
     \global\gre@lastoflinecount=0\relax %
@@ -177,7 +176,6 @@
     \global\gre@firstglyphfalse%
   \fi%
   #6\relax %
-  \directlua{gregoriotex.adjust_line_height(\gre@insidediscretionary)}%
   \gre@endofglyphcommon %
   \relax%
 }%
@@ -877,7 +875,6 @@
   % So, at beginning of lines, we will have shifted left, and in middle of lines
   % we will have shifted right and left, thus cancelling... Very easy trick, but
   % took me years to find it!
-  \gre@debugmsg{bolshift}{Current glyph: \the\gre@attr@glyph@id}%
   % we only want to execute these shifts if the clef is being shown
   % if no clef is being shown, then there is no space under the clef for the
   % lyrics to invade

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -114,6 +114,8 @@
 
 \def\gre@endofglyphcommon{%
   \gre@trace{gre@endofglyphcommon}%
+  \global\unsetluatexattribute{\gre@attr@glyph@top}%
+  \global\unsetluatexattribute{\gre@attr@glyph@bottom}%
   \ifgre@endofscore %
     \gre@penalty{\the\gre@space@count@finalpenalty}%
     \gre@localleftbox{}%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -1049,8 +1049,8 @@
     \kern\gre@skip@temp@one %
   \fi%
   #8\relax %
-  \raise\gre@dimen@textlower%
-  \copy\gre@box@syllabletext %
+  \raise\gre@dimen@textlower
+  \hbox attr \gre@attrid@part=4 {\unhcopy\gre@box@syllabletext}%
   \ifgre@mustdotranslationcenterend%
     % case of end of translation centering, we do it after the typesetting of the text
     \gre@dotranslationcenterend %
@@ -1324,7 +1324,8 @@
     #8%
     \GreNoBreak %
     %print the text, the raise is in case of a translation
-    \raise\gre@dimen@textlower \copy\gre@box@syllabletext%
+    \raise\gre@dimen@textlower
+    \hbox attr \gre@attrid@part=4 {\unhcopy\gre@box@syllabletext}%
     %and the code which handles translation centering
     \ifgre@mustdotranslationcenterend%
       % case of end of translation centering, we do it after the typesetting of the text

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -1046,7 +1046,7 @@
     \kern\gre@skip@temp@one %
   \fi%
   #8\relax %
-  \raise\gre@dimen@textlower
+  \raise\gre@space@dimen@spacebeneathtext
   \hbox attr \gre@attrid@part=4 {\unhcopy\gre@box@syllabletext}%
   \ifgre@mustdotranslationcenterend%
     % case of end of translation centering, we do it after the typesetting of the text
@@ -1321,7 +1321,7 @@
     #8%
     \GreNoBreak %
     %print the text, the raise is in case of a translation
-    \raise\gre@dimen@textlower
+    \raise\gre@space@dimen@spacebeneathtext
     \hbox attr \gre@attrid@part=4 {\unhcopy\gre@box@syllabletext}%
     %and the code which handles translation centering
     \ifgre@mustdotranslationcenterend%
@@ -1516,7 +1516,7 @@
     % then the most simple : the case where there is something to write under the bar. We just need to adjust the spaces.
     \else %ifdim\wd\gre@box@syllabletext = 0 pt
       #8\relax %
-      \raise\gre@dimen@textlower \copy\gre@box@syllabletext %
+      \raise\gre@space@dimen@spacebeneathtext \copy\gre@box@syllabletext %
       \ifgre@mustdotranslationcenterend%
         % case of end of translation centering, we do it after the typesetting of the text
         \gre@dotranslationcenterend %

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -124,7 +124,6 @@ local capture_header_macro = {}
 local per_line_dims = {}
 local per_line_counts = {}
 local saved_dims = {}
-local saved_counts = {}
 
 local catcode_at_letter = luatexbase.catcodetables['gre@atletter']
 
@@ -1105,10 +1104,9 @@ local function at_score_end()
   per_line_dims = {}
   per_line_counts = {}
   saved_dims = {}
-  saved_counts = {}
 end
 
---- Toggle the state of GretorioTeX callbacks.
+--- Toggle the state of GregorioTeX callbacks.
 -- Our callbacks can affect fancyhdr's ability to create multi-line headers/footers
 -- By adding this function to fancyhdr's before and after hooks, our callbacks are removed
 -- while processing headers/footers and then reinstated for the rest of the score.
@@ -1633,13 +1631,7 @@ local function save_dim(name, value)
   saved_dims[name] = tex.sp(value)
 end
 
-local function save_count(name, value)
-  debugmessage('save_count', 'count %s value %s', name, value)
-  saved_counts[name] = value
-end
-
 local function change_next_score_line_dim(line_expr, name, value)
-  local linenum_str
   for linenum_str in string.gmatch(line_expr, "%s*([^,]+)%s*") do
     local linenum = tonumber(linenum_str)
     local line_dims = per_line_dims[linenum]
@@ -1653,7 +1645,6 @@ local function change_next_score_line_dim(line_expr, name, value)
 end
 
 local function change_next_score_line_count(line_expr, name, value)
-  local linenum_str
   for linenum_str in string.gmatch(line_expr, "%s*([^,]+)%s*") do
     local linenum = tonumber(linenum_str)
     local line_counts = per_line_counts[linenum]
@@ -1904,7 +1895,6 @@ gregoriotex.set_debug_string             = set_debug_string
 gregoriotex.late_save_position           = late_save_position
 gregoriotex.is_last_syllable_on_line     = is_last_syllable_on_line
 gregoriotex.save_dim                     = save_dim
-gregoriotex.save_count                   = save_count
 gregoriotex.change_next_score_line_dim   = change_next_score_line_dim
 gregoriotex.change_next_score_line_count = change_next_score_line_count
 gregoriotex.set_base_output_dir          = set_base_output_dir

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -107,9 +107,6 @@ local function set_base_output_dir(new_dirname)
   base_output_dir = lfs.normalize(new_dirname)
 end
 
-local space_below_staff = 5
-local space_above_staff = 13
-
 local score_fonts = {}
 local symbol_fonts = {}
 local loaded_font_sizes = {}
@@ -124,7 +121,6 @@ local number_to_letter = {
 
 local capture_header_macro = {}
 
-local dims = {}
 local per_line_dims = {}
 local per_line_counts = {}
 local saved_dims = {}
@@ -422,7 +418,11 @@ end
 local function dump_nodes_helper(head, indent)
   local dots = string.rep('..', indent)
   for n in traverse(head) do
-    local ids = nil
+    local ids = format("g=%s,%s,a=%s,%s",
+                       has_attribute(n, glyph_top_attr),
+                       has_attribute(n, glyph_bottom_attr),
+                       has_attribute(n, alteration_pitch_attr),
+                       has_attribute(n, alteration_id_attr))
     if n.id == hlist or n.id == vlist then
       log(dots .. "%s [%s] width=%.2fpt height=%.2fpt depth=%.2fpt shift=%.2fpt {%s}", node.type(n.id), n.subtype, n.width/2^16, n.height/2^16, n.depth/2^16, n.shift/2^16, ids)
     elseif n.id == rule then
@@ -680,8 +680,8 @@ local function compute_line_statistics(line, info)
     info = {
       has_translation = false,
       has_abovelinestext = false,
-      line_top = 7, -- e = \gre@pitch@dummy
-      line_bottom = 7 -- e = \gre@pitch@dummy
+      glyph_top = 7, -- e = \gre@pitch@dummy
+      glyph_bottom = 7 -- e = \gre@pitch@dummy
     }
   end
   for n in traverse(line.head) do
@@ -850,11 +850,6 @@ local function post_linebreak(h, groupcode, glyphes)
   -- TODO: to be changed according to the font
   local lastseennode            = nil
   local centerstartnode         = nil
-  local line_id                 = nil
-  local line_top                = nil
-  local line_bottom             = nil
-  local line_has_translation    = false
-  local line_has_abovelinestext = false
   local linenum                 = 0
   local syl_id                  = nil
   
@@ -876,11 +871,6 @@ local function post_linebreak(h, groupcode, glyphes)
         linenum = linenum + 1
         debugmessage('linesglues', 'line %d: %s factor %.0f%%', linenum, glue_sign_name[line.glue_sign], line.glue_set*100)
         centerstartnode = nil
-        line_id = nil
-        line_top = nil
-        line_bottom = nil
-        line_has_translation = false
-        line_has_abovelinestext = false
 
         for n in traverse_id(hlist, line.head) do
           syl_id = has_attribute(n, syllable_id_attr) or syl_id

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -526,6 +526,7 @@ local function adjust_fullwidth (line)
         debugmessage("adjust_fullwidth", "commentary width %spt -> %spt", child.width/2^16, line_width/2^16)
         child.width = line_width
         local new = node.hpack(child.head, line_width, 'exactly')
+        new.shift = child.shift
         cur.head = node.insert_before(cur.head, child, new)
         cur.head = node.remove(cur.head, child)
       elseif has_attribute(child, part_attr, part_stafflines) then
@@ -755,6 +756,7 @@ local function adjust_additional_spaces(line, info, linenum)
   local extra_space_beneath_text = get_space('spacebeneathtext') - saved_dims['spacebeneathtext']
 
   -- how much to raise/lower each part
+  local commentary_raise = additional_top_space_alt
   local alt_raise = additional_top_space_alt + extra_above_lines_text_raise
   local nabc_raise = additional_top_space_nabc + extra_above_lines_text_raise
   local height_increase = abovelinestext_height + extra_space_above_lines + additional_top_space
@@ -773,7 +775,11 @@ local function adjust_additional_spaces(line, info, linenum)
     end
     for child in traverse(children) do
       local child_part_attr = has_attribute(child, part_attr)
-      if child_part_attr == part_alt then
+      if child_part_attr == part_commentary then
+        debugmessage('adjust_additional_spaces', 'shift commentary up by %spt', commentary_raise/2^16)
+        child.shift = child.shift - commentary_raise
+        changed = true
+      elseif child_part_attr == part_alt then
         debugmessage('adjust_additional_spaces', 'shift abovelinestext up by %spt', alt_raise/2^16)
         child.shift = child.shift - alt_raise
         changed = true
@@ -839,6 +845,7 @@ end
 -- in each function we check if we really are inside a score,
 -- which we can see with the dash_attr being set or not
 local function post_linebreak(h, groupcode, glyphes)
+  --dump_nodes(h)
   -- TODO: to be changed according to the font
   local lastseennode            = nil
   local centerstartnode         = nil

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -326,7 +326,7 @@ local function write_greaux()
   end
 end
 
-local function init(arg, enable_height_computation)
+local function init(arg)
   -- is there a better way to get the output directory?
   local outputdir = nil
   for k,v in pairs(arg) do
@@ -369,29 +369,22 @@ local function init(arg, enable_height_computation)
     first_alterations = {}
   end
 
-  if enable_height_computation then
-    new_last_syllables = {}
-    new_state_hashes = {}
+  new_last_syllables = {}
+  new_state_hashes = {}
 
-    local mcb_version = luatexbase.get_module_version and
-        luatexbase.get_module_version('luatexbase-mcb') or 9999
-    if mcb_version and mcb_version > 0.6 then
-      luatexbase.add_to_callback('finish_pdffile', write_greaux,
-          'gregoriotex.write_greaux')
-    else
-      -- The version of luatexbase in TeX Live 2014 does not support it, and
-      -- luatexbase prevents a direct call to callback.register.  Because of
-      -- this, we lose the LuaTeX statistics and "output written to" messages,
-      -- but I know of no other workaround.
-
-      luatexbase.add_to_callback('stop_run', write_greaux,
-          'gregoriotex.write_greaux')
-    end
+  local mcb_version = luatexbase.get_module_version and
+      luatexbase.get_module_version('luatexbase-mcb') or 9999
+  if mcb_version and mcb_version > 0.6 then
+    luatexbase.add_to_callback('finish_pdffile', write_greaux,
+        'gregoriotex.write_greaux')
   else
-    warn('Height computation has been skipped.  Gregorio will use '..
-        'previously computed values if available but will not recompute '..
-        'line heights.  Remove or undefine \\greskipheightcomputation to '..
-        'resume height computation.')
+    -- The version of luatexbase in TeX Live 2014 does not support it, and
+    -- luatexbase prevents a direct call to callback.register.  Because of
+    -- this, we lose the LuaTeX statistics and "output written to" messages,
+    -- but I know of no other workaround.
+
+    luatexbase.add_to_callback('stop_run', write_greaux,
+        'gregoriotex.write_greaux')
   end
   saved_positions = {}
   new_saved_lengths = {}

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -1066,8 +1066,7 @@ local inside_score = false
 --- Start a score
 -- Prepare all variables for processing a new score and add our callbacks
 -- @param score_id score identifier
--- @param score_font_name which font does this score use for the neumes
-local function at_score_beginning(score_id, score_font_name)
+local function at_score_beginning(score_id)
   first_line_prevdepth = tex.prevdepth -- used in adjust_glue
   inside_score = true
   local inclusion = score_inclusion[score_id] or 1


### PR DESCRIPTION
In #1488 the question came up of whether variable line spacing could be done in a single pass. This (sorry, rather large) patch does that. The score lines are printed in TeX with possible collisions, but with different parts of the score distinguished by different attributes, so that they can be put into the proper place in Lua. The advantages of this I see are:

- With two passes, the user might forget to run a second time, or be confused by large changes between the first and second pass.
- The two-pass computation was complicated, with control passing from TeX to Lua to TeX to Lua. It was difficult to inject the `\grechangedim`s at exactly the end of a line, which led to bugs.

The disadvantages are:

- `\grechangenextscorelinedim` and `\grechangenextscorelinecount` now only work for the distances and counts used for line spacing. I guess a helpful error should be printed if the user tries to change something else.
- It might seem conceptually strange to print a bad-looking score at first (which no one would see). In particular, the translation is printed right on top of the lyrics.

All tests pass except for:
gabc-output/glyphs/clef_change.gabc : this is #1633 I think
gabc-output/glyphs/nabc-edge-cases.gabc : this is #1634
gabc-output/bugs/fix-569.gabc : this is #1633
gabc-output/lines/3-lines.gabc : this is #1636
gabc-output/lines/2-lines.gabc : #1636 again
gabc-output/lines/5-lines.gabc : #1636 again
tex-output/dominican-flats/dominican-flats.tex : this one fails for me even in `ctan`, and the "correct" output looks wrong; I must have messed it up somehow
tex-output/bar-spacing/bar-spacing-new.tex : the difference is only in the lines used for debugging, and the new lines look more consistent to me?

Supersedes #1639.
Closes #1633, #1634, #1636.