### PR TITLE
Fix overfull \hbox warning in ledger lines

### DIFF
--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1633,6 +1633,7 @@
     \kern-\gre@dimen@temp@five %
     \vrule height \gre@dimen@stafflineheight %
            width \gre@dimen@temp@two %
+    \hss
   }%
   \gre@trace@end%
 }


### PR DESCRIPTION
Should be an extremely easy one! Closes #1643.