### PR TITLE
Some fixes to the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ This is the primary development branch for significant changes to the package.  
 
 We also reserve short-term branch names of the patterns `release-vx.y` and `hotfix-vx.y.z`.  Names of this sort are reserved for preparing releases.  Only PRs for blocking bugs should be submitted against these branches.
 
-Individual bugfixes and features should be developed on their own branch and then a PR submitted in the main repository against the appropriate branch.  New contributors should fork the repository on GitHub under your own username and use branches created there to create PRs against the main repository.  If you don't have a GitHub account (they are free) and don't want to create one, you can submit a patch file to the developers' mailing list: gregorio-devel@googlegroups.com.
+Individual bugfixes and features should be developed on their own branch and then a PR submitted in the main repository against the appropriate branch.  New contributors should fork the repository on GitHub under your own username and use branches created there to create PRs against the main repository.  If you don't have a GitHub account (they are free) and don't want to create one, you can submit a patch file to the developers' mailing list: [gregorio-devel@googlegroups.com](mailto:gregorio-devel@googlegroups.com).
 
 ### Make a pull request
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -303,7 +303,7 @@ Macro to turn on or off scaling with the staff size for a particular distance.
 \textbf{Nota bene:} This macro also can be used to change whether or not the staff line thickness scales with the staff size by specifying \texttt{stafflinefactor} for the first argument.
 
 \macroname{\textbackslash grechangecount}{\{\#1\}\{\#2\}}{gregoriotex-spaces.tex}
-Macro to change one of Gregorio\TeX’s counts or penalities (numeric values).
+Macro to change one of Gregorio\TeX’s counts or penalties (numeric values).
 
 \begin{argtable}
   \#1 & string & The name of the count to be changed.  See \nameref{counts} and \nameref{penalties} below.\\
@@ -2137,7 +2137,7 @@ The value of the last ditch stretch for overfull boxes.  This should be set usin
 Default: \verb=\emergencystretch=
 
 \begin{gcount}{endafterbarpenalty}
-The end after bar penalty.
+The end after bar penalty.  Inserted by Gregorio\TeX after a bar.
 \end{gcount}
 
 \begin{gcount}{endafterbaraltpenalty}{}{gregoriotex-gsp-default.tex}
@@ -2145,19 +2145,19 @@ The alternate end after bar penalty (used when there is no text under the bar).
 \end{gcount}
 
 \begin{gcount}{endofelementpenalty}{}{gregoriotex-gsp-default.tex}
-The end of element penalty.
+The end of element penalty.  Inserted by Gregorio\TeX\ after each element in a score.
 \end{gcount}
 
 \begin{gcount}{endofsyllablepenalty}{}{gregoriotex-gsp-default.tex}
-The end of element penalty.
+The end of syllable penalty.  Inserted by Gregorio\TeX\ after each syllable in a score.
 \end{gcount}
 
 \begin{gcount}{endofwordpenalty}{}{gregoriotex-gsp-default.tex}
-The end of element penalty.
+The end of word penalty.  Inserted by Gregorio\TeX\ after each word in a score.
 \end{gcount}
 
 \begin{gcount}{hyphenpenalty}{}{gregoriotex-gsp-default.tex}
-The hyphen penalty.
+The penalty inserted with a hyphen by \TeX.  \texbf{Note:} \TeX\ does not insert hyphens into the score in most places because Gregorio\TeX\ makes its own decisions on inserting hyphens after syllables in lyrics.  This penalty would only be used when there is a block of text long enough to trigger a line break within a syllable or similarly sized unit.
 \end{gcount}
 
 \begin{gcount}{nobreakpenalty}{}{gregoriotex-gsp-default.tex}


### PR DESCRIPTION
I noticed some typos and unclear documentation while answering a question on the mailing list.  Here's a quick fix.