### PR TITLE
Fix bug causing an error on scores with two line breaks in a row

### DIFF
--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -505,9 +505,6 @@ Macro holding the current secondary clef line (or 0 for no secondary clef).
 \macroname{\textbackslash gre@cleftwoflatheight}{}{gregoriotex-signs.tex}
 Macro to hold the height of the current flat for the secondary clef (\texttt{3} if no flat).
 
-\macroname{\textbackslash gre@updatelinesclef}{}{gregoriotex-signs.tex}
-Macro redrawing a key from \verb=\gre@clefnum=, useful for vertical space changes.
-
 \macroname{\textbackslash gre@currenttextabovelines}{}{gregoriotex-main.tex}
 Macro for storing the text which needs to be placed above the lines.
 
@@ -778,9 +775,6 @@ Macro which typesets a single clef.
   & \texttt{1} & we must use small clef characters (inside a line)\\
   \#4 & integer & if \texttt{3}, it means that we must not put a flat after the clef, otherwise it’s the height of the flat\\
 \end{argtable}
-
-\macroname{\textbackslash gre@updateleftbox}{}{gregoriotex-main.tex}
-Macro to update the box printed a the left end of every line (the one which holds the staff lines).
 
 \macroname{\textbackslash gre@useautoeolcustos}{}{gregoriotex-main.tex}
 Macro which enables automatic custos at the end of lines.

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -277,6 +277,7 @@
     \else
       \ifnum#1=1\relax
         \GreNoBreak
+        \null% prevent the \hfill from getting eaten in case of empty line
         \hfill
       \fi
       \gre@penalty{-10001}%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -264,9 +264,6 @@
         \kern -\gre@dimen@eolshift\relax%
       \fi%
     \fi %
-    \ifnum\gre@insidediscretionary=0\relax %
-      \gre@updateleftbox %
-    \fi %
     % If this is the last element, just end the paragraph here, ignoring #1
     % and letting \gre@count@lastline determine justification of the last line.
     \ifgre@endofscore
@@ -346,12 +343,6 @@
   ]%
 }%
 \gresetinitialanchor{baseline}%
-
-\def\gre@updateleftbox{%
-  \gre@trace{gre@updateleftbox}%
-  \gre@updatelinesclef %
-  \gre@trace@end%
-}%
 
 \def\greillumination#1{%
   \setbox\gre@box@initial=\hbox{#1}%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -196,14 +196,6 @@
   \gre@trace@end%
 }%
 
-%% macro redrawing a key from clefnum, useful for vertical space changes
-\def\gre@updatelinesclef{%
-  \gre@trace{gre@updatelinesclef}%
-  \GreSetLinesClef{\gre@clef}{\gre@clefheight}{1}{\gre@clefflatheight}%
-  {\gre@cleftwo}{\gre@cleftwoheight}{\gre@cleftwoflatheight}\relax %
-  \gre@trace@end%
-}%
-
 \newbox\gre@box@temp@clef%
 \newbox\gre@box@temp@cleftwo%
 


### PR DESCRIPTION
Fixes issue #1652.

The root of the problem seems to be a bug in LuaTeX. The following MWE illustrates the bug:
```
\localrightbox{xyz}%
\hfill\break
\localleftbox{abc}%
\bye
```

This produces the errors
```
warning  (nodes): attempt to copy free hlist node 399, ignored

warning  (nodes): attempt to copy free hlist node 369, ignored
```
and the `\localleftbox` is not updated.

Here, the bug was happening when the `\localleftbox` was updated on an empty line. The simplest fix is just to not update the `\localleftbox` (it appears not to be needed after #1641).