### PR TITLE
Clarify vertical spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.
 - Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the appearance of the last line would sometimes depend on `Z` versus `z` and sometimes depend on `\gresetlastline{ragged}` versus `\gresetlastline{justified}`. Now, the appearance of the last line always depends on `\gresetlastline`.
+- The meanings of the distances `spaceabovelines` and `abovelinestextheight` were changed to be (hopefully) easier to use and closer to their descriptions in the documentation.
+- All lengths related to vertical spacing are documented in greater detail in a dedicated section in GregorioRef.pdf.
 
 ### Deprecated
 - The count `grefinalpenalty` no longer has any effect and will be removed in a future release.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,10 @@ The count `grefinalpenalty` no longer has any effect and will be removed in a fu
 
 Forced line breaks (`Z` or `z`) at the very end of a score are discouraged. Please use `\gresetlastline{ragged}` or `\gresetlastline{justified}` instead to set the appearance of the last line.
 
+### `spaceabovelines` and `abovelinestextheight`
+
+The meanings of these distances were changed to be (hopefully) easier to use and closer to their descriptions in the documentation. Please see the section "Vertical spacing" in GregorioRef.pdf for more information. Scores that use the default settings and have above-lines text (`<alt>`) will now have slightly more whitespace above the above-lines text. Scores that set either of these two distances explicitly may experience larger changes in whitespace between staves, and should be checked.
+
 ## 6.1
 
 ### Multiline initials

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1776,7 +1776,7 @@ The space beneath the text.
 \end{gdimension}
 
 \begin{gdimension}{abovelinestextraise}
-Height of the text above the note line.
+Distance from the top staff line to the baseline of the above-lines text.
 \end{gdimension}
 
 \begin{gdimension}{abovelinestextheight}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1896,6 +1896,10 @@ Space after a clef at the beginning of a line, when the clef and first note are 
 \newcommand{\lab}[1]{\scalebox{0.5}{\tt\small #1}}%
 
 \gresetinitiallines{0}
+\gresetlyriccentering{firstletter}
+\gresetlastline{justified}
+\grechangestyle{abovelinestext}{\rmfamily\itshape}
+\grechangestyle{translation}{\rmfamily\itshape}
 
 A staff has text (lyrics) below it, and optionally another line of translation below the text. Above the staff, there can also be a line of text (called the above-lines text) or NABC neumes. The vertical position and height of all these parts are shown in Figure~\ref{fig:vertical-spacing-within-staff} (with \texttt{spaceabovelines} and \texttt{spacebeneathtext} set to 0.2 cm for clarity). The staff together with all the text and neumes above and below it form one box, whose topline and baseline are drawn in red.
 
@@ -1990,6 +1994,7 @@ Note that if there are high notes, increasing \texttt{spaceabovelines} may not a
 
 \begin{center}
 \rowcolors{1}{white}{white}%
+\ttfamily
 \begin{tabular}{ccccc}
   \lines{\gabcsnippet{i[0 steps](i)}} &
   \lines{\gabcsnippet{j[0 steps](j)}} &
@@ -2004,6 +2009,7 @@ Note that if there are high notes, increasing \texttt{spaceabovelines} may not a
 High notes also cause the above-lines text, if any, to be raised. The above-lines text has its own threshold, \texttt{additionaltopspacealtthreshold} (default 0):
 \begin{center}
 \rowcolors{1}{white}{white}%
+\ttfamily
 \begin{tabular}{ccccc}
   \lines{\gabcsnippet{<alt>alt</alt>i[0 steps](i)}} &
   \lines{\gabcsnippet{<alt>alt</alt>j[0 steps](j)}} &
@@ -2021,6 +2027,7 @@ Because the above-lines text and the topline have different thresholds, they may
   
 \begin{center}
 \rowcolors{1}{white}{white}%
+\ttfamily
 \begin{tabular}{ccccc}
   \lines{\gabcsnippet{<alt>alt</alt>i(i)}} &
   \lines{\gabcsnippet{<alt>alt</alt>j(j)}} &
@@ -2037,14 +2044,14 @@ NABC neumes use a different threshold, \texttt{additionaltopspacenabcthreshold}.
 \verb|\grechangedim{abovelinestextheight}{0.1cm}{scalable}| \\
 \grechangedim{abovelinestextraise}{0.8cm}{scalable}%
 \verb|\grechangedim{abovelinestextraise}{0.8cm}{scalable}|%
-\gresetlyriccentering{syllable}%
 \begin{center}
 \rowcolors{1}{white}{white}%
+\ttfamily
 \begin{tabular}{ccccc}
   \lines{\nabcsnippet{m|vi[0 steps](m|vi)}} &
   \lines{\nabcsnippet{m_1|vi[0 steps](m_1|vi)}} &
-  \lines{\nabcsnippet{m'1|vi[1 step](m'1|vi)}} &
-  \lines{\nabcsnippet{m_1'1|vi[2 steps](m_1'1|vi)}}
+  \lines{\nabcsnippet{m<v>\textquotesingle</v>1|vi[1 step](m'1|vi)}} &
+  \lines{\nabcsnippet{m_1<v>\textquotesingle</v>1|vi[2 steps](m_1'1|vi)}}
 \end{tabular}
 \end{center}
 \end{quote}
@@ -2057,6 +2064,7 @@ The minimum value of \texttt{noteadditionalspacelinestextthreshold} is currently
 
 \begin{center}
 \rowcolors{1}{white}{white}%
+\ttfamily
 \begin{tabular}{ccccc}
   \lines{\gabcsnippet{e[0 steps](e)}} &
   \lines{\gabcsnippet{d[0 steps](d)}} &
@@ -2127,12 +2135,12 @@ These settings are illustrated in Figure~\ref{fig:vertical-spacing-between-stave
         label.lft(btex \lab{parskip} etex, (x0, (y2+y3)/2));
       endfig;
     \end{mplibcode}%
-    \llap{\begin{minipage}[b]{1.5cm}\hrule\gabcsnippet{text(gZ) text(g)}\end{minipage}}%
+    \llap{\begin{minipage}[b]{1.5cm}\gabcsnippet{text(gZ) text(g)}\end{minipage}}%
   }%
   \hspace*{1cm}%
   \scalebox{2}{%
     \getdims
-    \rlap{\begin{minipage}[b]{1.5cm}\hrule\gabcsnippet{text(gZ) <alt>alt</alt>text[trans](g)}\end{minipage}}%
+    \rlap{\begin{minipage}[b]{1.5cm}\gabcsnippet{text(gZ) <alt>alt</alt>text[trans](g)}\end{minipage}}%
     \begin{mplibcode}
       beginfig(0);
         pickup pencircle scaled 0.4bp;

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1862,7 +1862,7 @@ Space after a clef at the beginning of a line, when the clef and first note are 
 \end{gdimension}
 
 {
-\subsubsection{Vertical spacing within staves}
+\subsubsection{Vertical spacing}
 \label{sec:vertical-spacing}
 
 \newcommand{\lines}[1]{
@@ -1897,10 +1897,10 @@ Space after a clef at the beginning of a line, when the clef and first note are 
 
 \gresetinitiallines{0}
 
-A staff has text (lyrics) below it, and optionally another line of translation below the text. Above the staff, there can also be a line of text (called the above-lines text) or NABC neumes. The vertical position and height of all these parts are shown below (with \texttt{spaceabovelines} and \texttt{spacebeneathtext} set to 0.2 cm for clarity). The staff together with all the text and neumes above and below it form one box, whose topline and baseline are drawn in red.
+A staff has text (lyrics) below it, and optionally another line of translation below the text. Above the staff, there can also be a line of text (called the above-lines text) or NABC neumes. The vertical position and height of all these parts are shown in Figure~\ref{fig:vertical-spacing-within-staff} (with \texttt{spaceabovelines} and \texttt{spacebeneathtext} set to 0.2 cm for clarity). The staff together with all the text and neumes above and below it form one box, whose topline and baseline are drawn in red.
 
-
-{\grechangedim{spaceabovelines}{0.2cm}{scalable}
+\begin{figure}
+\grechangedim{spaceabovelines}{0.2cm}{scalable}
 \grechangedim{spacebeneathtext}{0.2cm}{scalable}
 \begin{center}
   \scalebox{2}{%
@@ -1940,20 +1940,23 @@ A staff has text (lyrics) below it, and optionally another line of translation b
     \lines{\nabcsnippet{text[trans](g|vi)}}%
   }
 \end{center}
-}
+\caption{The vertical position and height of the various parts above and below the staff. The distances \texttt{spaceabovelines} and \texttt{spacebeneathtext} are set to 0.2 cm for clarity. The staff together with all the text and neumes above and below it form one box, whose topline and baseline are drawn in red.}
+\label{fig:vertical-spacing-within-staff}
+\end{figure}
   
 The height of the staff lines is determined by the commands \verb|\grechangefactor| and \verb|\grechangestafflinethickness|.
+The other distances are listed below and can be changed using \verb|\grechangedim|.
 
 \begin{gdimension}{spaceabovelines}
 The space above the staff lines (and above-lines text or NABC neumes, if any).
 \end{gdimension}
 
 \begin{gdimension}{abovelinestextheight}
-Minimum height of the above-lines text. (It must be bigger than the text for it to be taken into consideration.)
+The height of the above-lines text is this or the the text's natural height, whichever is bigger.
 \end{gdimension}
 
 \begin{gdimension}{abovelinestextraise}
-Distance from the top staff line to the baseline of the above-lines text.
+The distance from the top staff line to the baseline of the above-lines text.
 \end{gdimension}
 
 \begin{gdimension}{spacelinestext}
@@ -1972,8 +1975,12 @@ The space beneath the text (and translation, if any).
 
 The space between the top staff line and the topline is normally $\texttt{spaceabovelines}$, but if there are notes above the staff, additional space may automatically be added.
 
+\goodbreak % prevents a weird page break between translationheight and spacebeneathtext
+
 The count \texttt{additionaltopspacethreshold} sets a threshold relative to the top line of the staff, so on a four-line staff, $0$ is pitch \texttt{j}, $1$ is pitch \texttt{k}, and so on. By default, $\texttt{additionaltopspacethreshold} = 2$, which is pitch \texttt{l}.
 Then, if the highest note is $n$ steps above this threshold, then $n$ steps of additional space are added (where a step is half the distance between staff lines). For example, again assuming the default of $\texttt{additionaltopspacethreshold} = 2$ on a four-line staff, if the highest note is \texttt{m}, then one step of additional space is added.
+
+The minimum value of \texttt{additionaltopspacethreshold} is $-1$ (additional top space for anything above the top staff line) and the maximum value is currently $6$ (no additional top space).
 
 Note that if there are high notes, increasing \texttt{spaceabovelines} may not add any visible space above the notes. To ensure a minimum space above the notes, set \texttt{spaceabovelines} to a length greater than $(1+\texttt{additionaltopspacethreshold})$. That is, with all other settings at their defaults, \texttt{spaceabovelines} should be greater than $3~\textrm{steps} \approx 0.41~\textrm{cm}$.
 
@@ -1993,6 +2000,7 @@ Note that if there are high notes, increasing \texttt{spaceabovelines} may not a
 \end{center}
 \end{quote}
 
+\begin{minipage}{\linewidth}
 High notes also cause the above-lines text, if any, to be raised. The above-lines text has its own threshold, \texttt{additionaltopspacealtthreshold} (default 0):
 \begin{center}
 \rowcolors{1}{white}{white}%
@@ -2004,6 +2012,7 @@ High notes also cause the above-lines text, if any, to be raised. The above-line
   \lines{\gabcsnippet{<alt>alt</alt>m[3 steps](m)}}
 \end{tabular}
 \end{center}
+\end{minipage}
 
 Because the above-lines text and the topline have different thresholds, they may get raised by different amounts. The two preceding examples combine to look like this:
 \begin{quote}
@@ -2044,6 +2053,8 @@ NABC neumes use a different threshold, \texttt{additionaltopspacenabcthreshold}.
 
 Additional space below the staff works in much the same way. The count \texttt{noteadditionalspacelinestextthreshold} sets a threshold relative to pitch \texttt{a}, so $0$ is pitch \texttt{a}, $1$ is pitch \texttt{b}, and so on. Under the default settings, $\texttt{noteadditionalspacelinestextthreshold} = 2$, which is pitch \texttt{c}. Then, if the lowest note is $n$ steps below the threshold, then $n$ steps of additional bottom space are added.
 
+The minimum value of \texttt{noteadditionalspacelinestextthreshold} is currently $-2$ (no additional bottom space) and the maximum value is $4$ (additional bottom space for anything below the bottom staff line).
+
 \begin{center}
 \rowcolors{1}{white}{white}%
 \begin{tabular}{ccccc}
@@ -2063,7 +2074,7 @@ The per-step additional space between lines and the bottom of the text, when usi
 
 \paragraph{Vertical spacing between staves}
 
-The standard rules for paragraph and line spacing apply to scores and staves.
+The standard rules for paragraph and line spacing apply to scores and staves. However, the distances which control those rules are different inside a score from in regular text. The distances listed below will be used inside a score and can be changed with \verb|\grechangedim| without affecting how text outside of a score is typeset.
 
 \begin{gdimension}{parskip}
 The effective \verb=\parskip= inside of a score. This amount of space is added to the top of a score, although this space is removed in some contexts (like the top of a page).
@@ -2074,16 +2085,17 @@ The effective \verb=\baselineskip= inside of a score. This is the minimum distan
 \end{gdimension}
 
 \begin{gdimension}{lineskiplimit}
-The effective \verb=\lineskiplimit= inside of a score. If the distance between one staff's bottomline and the next staff's topline is less than this, then \texttt{lineskip} is added between them.
+The effective \verb=\lineskiplimit= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottomline and the second staff's topline is less than this, then \texttt{lineskip} is added between them.
 \end{gdimension}
 
 \begin{gdimension}{lineskip}
-The effective \verb=\lineskip= inside of a score. If the distance between one staff's bottomline and the next staff's topline is less than \texttt{lineskiplimit}, then this amount of space is added between them.
+The effective \verb=\lineskip= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottomline and the second staff's topline is less than \texttt{lineskiplimit}, then this amount of space is added between them.
 \end{gdimension}
 
-These settings are illustrated below (with \texttt{parskip} and \texttt{lineskip} set to 0.2 cm for clarity).
+These settings are illustrated in Figure~\ref{fig:vertical-spacing-between-staves} (with \texttt{parskip} and \texttt{lineskip} set to 0.2 cm for clarity).
 
-{\grechangedim{parskip}{0.2cm}{scalable}
+\begin{figure}
+\grechangedim{parskip}{0.2cm}{scalable}
 \grechangedim{lineskip}{0.2cm}{scalable}
 \begin{center}
   \scalebox{2}{%
@@ -2150,8 +2162,11 @@ These settings are illustrated below (with \texttt{parskip} and \texttt{lineskip
     \end{mplibcode}%
   }%
 \end{center}
+\caption{Settings controlling the vertical spacing between staves. Distances \texttt{parskip} and \texttt{lineskip} are set to 0.2 cm for clarity.}
+\label{fig:vertical-spacing-between-staves}
+\end{figure}
+
 As shown on the right, under the default settings, a staff with both above-lines text (or NABC) and translations has height greater than the default \texttt{baselineskip}. So if you want to increase \texttt{baselineskip}, you might have to increase it significantly before seeing any effect.
-}% 
 
 \subsubsection{Bar distances}
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -2099,7 +2099,7 @@ The effective \verb=\baselineskip= inside of a score. This is the minimum distan
 \end{gdimension}
 
 \begin{gdimension}{lineskiplimit}
-The effective \verb=\lineskiplimit= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottome and the second staff's top is less than this, then \texttt{lineskip} is added between them.
+The effective \verb=\lineskiplimit= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottom and the second staff's top is less than this, then \texttt{lineskip} is added between them.
 \end{gdimension}
 
 \begin{gdimension}{lineskip}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1873,8 +1873,11 @@ Space after a clef at the beginning of a line, when the clef and first note are 
     \textcolor{red}{\hrule}%
     \setbox0=\vbox{#1}%
     \copy0%
-    \vspace{-\dp0}%
     \textcolor{red}{\hrule}%
+    \ifnum\dp0>0\relax
+      \vspace{-\dp0}%
+      \textcolor{red}{\hrule}%
+    \fi
   \end{minipage}%
 }
 
@@ -1896,12 +1899,13 @@ Space after a clef at the beginning of a line, when the clef and first note are 
 \newcommand{\lab}[1]{\scalebox{0.5}{\tt\small #1}}%
 
 \gresetinitiallines{0}
+\gresetclef{invisible}
 \gresetlyriccentering{firstletter}
 \gresetlastline{justified}
 \grechangestyle{abovelinestext}{\rmfamily\itshape}
 \grechangestyle{translation}{\rmfamily\itshape}
 
-A staff has text (lyrics) below it, and optionally another line of translation below the text. Above the staff, there can also be a line of text (called the above-lines text) or NABC neumes. The vertical position and height of all these parts are shown in Figure~\ref{fig:vertical-spacing-within-staff} (with \texttt{spaceabovelines} and \texttt{spacebeneathtext} set to 0.2 cm for clarity). The staff together with all the text and neumes above and below it form one box, whose topline and baseline are drawn in red.
+A staff has text (lyrics) below it, and optionally another line of translation below the text. Above the staff, there can also be a line of text (called the above-lines text) or NABC neumes. The vertical position and height of all these parts are shown in Figure~\ref{fig:vertical-spacing-within-staff} (with \texttt{spaceabovelines} and \texttt{spacebeneathtext} set to 0.2 cm for clarity). The staff together with all the text and neumes above and below it form one box. In this and following examples, the top, baseline, and bottom of this box are drawn in red, although the baseline and bottom often coincide.
 
 \begin{figure}
 \grechangedim{spaceabovelines}{0.2cm}{scalable}
@@ -1944,7 +1948,7 @@ A staff has text (lyrics) below it, and optionally another line of translation b
     \lines{\nabcsnippet{text[trans](g|vi)}}%
   }
 \end{center}
-\caption{The vertical position and height of the various parts above and below the staff. The distances \texttt{spaceabovelines} and \texttt{spacebeneathtext} are set to 0.2 cm for clarity. The staff together with all the text and neumes above and below it form one box, whose topline and baseline are drawn in red.}
+\caption{The vertical position and height of the various parts above and below the staff. The distances \texttt{spaceabovelines} and \texttt{spacebeneathtext} are set to 0.2 cm for clarity. The staff together with all the text and neumes above and below it form one box, whose top and baseline/bottom are drawn in red.}
 \label{fig:vertical-spacing-within-staff}
 \end{figure}
   
@@ -1952,41 +1956,37 @@ The height of the staff lines is determined by the commands \verb|\grechangefact
 The other distances are listed below and can be changed using \verb|\grechangedim|.
 
 \begin{gdimension}{spaceabovelines}
-The space above the staff lines (and above-lines text or NABC neumes, if any).
+The space above the staff lines (and above the above-lines text or NABC neumes, if any).
 \end{gdimension}
 
 \begin{gdimension}{abovelinestextheight}
-The height of the above-lines text is this or the the text's natural height, whichever is bigger.
+The height of the above-lines text. This space appears only if there actually is above-lines text, and it must be larger than the above-line text's natural height for it to have an effect.
 \end{gdimension}
 
 \begin{gdimension}{abovelinestextraise}
-The distance from the top staff line to the baseline of the above-lines text.
+The distance from the top staff line to the baseline of the above-lines text. This space appears only if there actually is above-lines text.
 \end{gdimension}
 
 \begin{gdimension}{spacelinestext}
-The space between the lines and the bottom of the text.
+The space between the lines and the baseline of the text. This space appears whether or not there is actually text.
 \end{gdimension}
 
 \begin{gdimension}{translationheight}
-The space between the baseline of the text and the baseline of the translation.
+The space between the baseline of the text and the baseline of the translation. This space appears only if there actually is a translation.
 \end{gdimension}
 
 \begin{gdimension}{spacebeneathtext}
-The space beneath the text (and translation, if any).
+The space beneath the text (and beneath the translation, if any). It must be larger than the natural depth of the text (or translation) for it to have an effect.
 \end{gdimension}
 
 \paragraph{Additional top space}
 
-The space between the top staff line and the topline is normally $\texttt{spaceabovelines}$, but if there are notes above the staff, additional space may automatically be added.
+The space between the top staff line and the top line is normally $\texttt{spaceabovelines}$, but if there are notes above the staff, additional space may automatically be added.
 
 \goodbreak % prevents a weird page break between translationheight and spacebeneathtext
 
 The count \texttt{additionaltopspacethreshold} sets a threshold relative to the top line of the staff, so on a four-line staff, $0$ is pitch \texttt{j}, $1$ is pitch \texttt{k}, and so on. By default, $\texttt{additionaltopspacethreshold} = 2$, which is pitch \texttt{l}.
 Then, if the highest note is $n$ steps above this threshold, then $n$ steps of additional space are added (where a step is half the distance between staff lines). For example, again assuming the default of $\texttt{additionaltopspacethreshold} = 2$ on a four-line staff, if the highest note is \texttt{m}, then one step of additional space is added.
-
-The minimum value of \texttt{additionaltopspacethreshold} is $-1$ (additional top space for anything above the top staff line) and the maximum value is currently $6$ (no additional top space).
-
-Note that if there are high notes, increasing \texttt{spaceabovelines} may not add any visible space above the notes. To ensure a minimum space above the notes, set \texttt{spaceabovelines} to a length greater than $(1+\texttt{additionaltopspacethreshold})$. That is, with all other settings at their defaults, \texttt{spaceabovelines} should be greater than $3~\textrm{steps} \approx 0.41~\textrm{cm}$.
 
 \begin{quote}
 \verb|\grechangedim{spaceabovelines}{0.5cm}{scalable}|
@@ -2000,10 +2000,14 @@ Note that if there are high notes, increasing \texttt{spaceabovelines} may not a
   \lines{\gabcsnippet{j[0 steps](j)}} &
   \lines{\gabcsnippet{k[0 steps](k)}} &
   \lines{\gabcsnippet{l[0 steps](l)}} &
-  \lines{\gabcsnippet{m[1 step](m)}}
+  \lines{\gabcsnippet{m[1 step](m) }}
 \end{tabular}
 \end{center}
 \end{quote}
+
+The minimum value of \texttt{additionaltopspacethreshold} is $-1$ (additional top space for anything above the top staff line) and the maximum value is~$6$ (no additional top space).
+
+Note that if there are high notes, increasing \texttt{spaceabovelines} may not add any visible space above the notes. To ensure a minimum space above the notes, set \texttt{spaceabovelines} to a length greater than $(1+\texttt{additionaltopspacethreshold})$. That is, with all other settings at their defaults, \texttt{spaceabovelines} should be greater than $3~\textrm{steps} \approx 0.41~\textrm{cm}$.
 
 \begin{minipage}{\linewidth}
 High notes also cause the above-lines text, if any, to be raised. The above-lines text has its own threshold, \texttt{additionaltopspacealtthreshold} (default 0):
@@ -2020,7 +2024,8 @@ High notes also cause the above-lines text, if any, to be raised. The above-line
 \end{center}
 \end{minipage}
 
-Because the above-lines text and the topline have different thresholds, they may get raised by different amounts. The two preceding examples combine to look like this:
+\begin{minipage}{\linewidth}
+Because the above-lines text and the top line have different thresholds, they may get raised by different amounts. The two preceding examples combine to look like this:
 \begin{quote}
 \verb|\grechangedim{spaceabovelines}{0.5cm}{scalable}|
 \grechangedim{spaceabovelines}{0.5cm}{scalable}
@@ -2037,6 +2042,7 @@ Because the above-lines text and the topline have different thresholds, they may
 \end{tabular}
 \end{center}
 \end{quote}
+\end{minipage}
 
 NABC neumes use a different threshold, \texttt{additionaltopspacenabcthreshold}. This defaults to $4$, meaning that only the very highest notes affect the positioning of NABC neumes.
 \begin{quote}
@@ -2060,8 +2066,6 @@ NABC neumes use a different threshold, \texttt{additionaltopspacenabcthreshold}.
 
 Additional space below the staff works in much the same way. The count \texttt{noteadditionalspacelinestextthreshold} sets a threshold relative to pitch \texttt{a}, so $0$ is pitch \texttt{a}, $1$ is pitch \texttt{b}, and so on. Under the default settings, $\texttt{noteadditionalspacelinestextthreshold} = 2$, which is pitch \texttt{c}. Then, if the lowest note is $n$ steps below the threshold, then $n$ steps of additional bottom space are added.
 
-The minimum value of \texttt{noteadditionalspacelinestextthreshold} is currently $-2$ (no additional bottom space) and the maximum value is $4$ (additional bottom space for anything below the bottom staff line).
-
 \begin{center}
 \rowcolors{1}{white}{white}%
 \ttfamily
@@ -2073,6 +2077,8 @@ The minimum value of \texttt{noteadditionalspacelinestextthreshold} is currently
   \lines{\gabcsnippet{a[2 steps](a)}}
 \end{tabular}
 \end{center}
+
+The minimum value of \texttt{noteadditionalspacelinestextthreshold} is~$-2$ (no additional bottom space) and the maximum value is $4$ (additional bottom space for anything below the bottom staff line).
 
 A legacy option is to change the amount of additional bottom space per step by setting \verb|\gresetnoteadditionalspacelinestext{manual}| and the following:
 
@@ -2093,11 +2099,11 @@ The effective \verb=\baselineskip= inside of a score. This is the minimum distan
 \end{gdimension}
 
 \begin{gdimension}{lineskiplimit}
-The effective \verb=\lineskiplimit= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottomline and the second staff's topline is less than this, then \texttt{lineskip} is added between them.
+The effective \verb=\lineskiplimit= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottome and the second staff's top is less than this, then \texttt{lineskip} is added between them.
 \end{gdimension}
 
 \begin{gdimension}{lineskip}
-The effective \verb=\lineskip= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottomline and the second staff's topline is less than \texttt{lineskiplimit}, then this amount of space is added between them.
+The effective \verb=\lineskip= inside of a score. If two consecutive staves have baselines \texttt{baselineskip} apart and the distance between the first staff's bottom and the second staff's top is less than \texttt{lineskiplimit}, then this amount of space is added between them.
 \end{gdimension}
 
 These settings are illustrated in Figure~\ref{fig:vertical-spacing-between-staves} (with \texttt{parskip} and \texttt{lineskip} set to 0.2 cm for clarity).
@@ -2106,6 +2112,8 @@ These settings are illustrated in Figure~\ref{fig:vertical-spacing-between-stave
 \grechangedim{parskip}{0.2cm}{scalable}
 \grechangedim{lineskip}{0.2cm}{scalable}
 \begin{center}
+  \setbox0\hbox{prima}%
+  \edef\firstdepth{\the\dp0}%
   \scalebox{2}{%
     \getdims
     \begin{mplibcode}
@@ -2113,64 +2121,68 @@ These settings are illustrated in Figure~\ref{fig:vertical-spacing-between-stave
         pickup pencircle scaled 0.4bp;
         wd := 1.5cm;
         y0 := \spacelinestext + \staffheight + \spaceabovelines;
-        y1 := \grebaselineskip;
-        y2 := y1 + \spacelinestext + \staffheight + \spaceabovelines;
-        y3 := y2 + \greparskip;
+        y2 := \grebaselineskip;
+        y1 := y2 - \firstdepth;
+        y3 := y2 + \spacelinestext + \staffheight + \spaceabovelines;
+        y4 := y3 + \greparskip;
         draw (0,0) -- (wd,0) withcolor red;
         draw (0,y0) -- (wd,y0) withcolor red;
         draw (0,y1) -- (wd,y1) withcolor red;
         draw (0,y2) -- (wd,y2) withcolor red;
         draw (0,y3) -- (wd,y3) withcolor red;
+        draw (0,y4) -- (wd,y4) withcolor red;
         pickup pencircle scaled 0.1bp;
         ahangle := 30; ahlength := 2;
         x0 := -0.2cm;
         dx := 0.1cm;
         draw (x0-dx, 0) -- (x0+dx, 0);
-        draw (x0-dx,y1) -- (x0+dx,y1);
         draw (x0-dx,y2) -- (x0+dx,y2);
         draw (x0-dx,y3) -- (x0+dx,y3);
-        drawdblarrow (x0, 0) -- (x0, y1);
-        label.lft(btex \lab{baselineskip} etex, (x0, y1/2));
-        drawdblarrow (x0, y2) -- (x0, y3);
-        label.lft(btex \lab{parskip} etex, (x0, (y2+y3)/2));
+        draw (x0-dx,y4) -- (x0+dx,y4);
+        drawdblarrow (x0, 0) -- (x0, y2);
+        label.lft(btex \lab{baselineskip} etex, (x0, y2/2));
+        drawdblarrow (x0, y3) -- (x0, y4);
+        label.lft(btex \lab{parskip} etex, (x0, (y3+y4)/2));
       endfig;
     \end{mplibcode}%
-    \llap{\begin{minipage}[b]{1.5cm}\gabcsnippet{text(gZ) text(g)}\end{minipage}}%
+    \llap{\begin{minipage}[b]{1.5cm}\gabcsnippet{prima(gZ) secunda(g)}\end{minipage}}%
   }%
   \hspace*{1cm}%
   \scalebox{2}{%
     \getdims
-    \rlap{\begin{minipage}[b]{1.5cm}\gabcsnippet{text(gZ) <alt>alt</alt>text[trans](g)}\end{minipage}}%
+    \rlap{\begin{minipage}[b]{1.5cm}\gabcsnippet{prima(gZ) <alt>alt</alt>secunda[second](g)}\end{minipage}}%
     \begin{mplibcode}
       beginfig(0);
         pickup pencircle scaled 0.4bp;
         wd := 1.5cm;
         y0 := \spacebeneathtext + \translationheight + \spacelinestext + \staffheight + \abovelinestextraise + \abovelinestextheight + \spaceabovelines;
         y1 := y0 + \grelineskip;
-        y2 := y1 + \spacelinestext + \staffheight + \spaceabovelines;
-        y3 := y2 + \greparskip;
+        y2 := y1 + \firstdepth;
+        y3 := y2 + \spacelinestext + \staffheight + \spaceabovelines;
+        y4 := y3 + \greparskip;
         draw (0,0) -- (wd,0) withcolor red;
         draw (0,y0) -- (wd,y0) withcolor red;
         draw (0,y1) -- (wd,y1) withcolor red;
         draw (0,y2) -- (wd,y2) withcolor red;
         draw (0,y3) -- (wd,y3) withcolor red;
+        draw (0,y4) -- (wd,y4) withcolor red;
         pickup pencircle scaled 0.1bp;
         ahangle := 30; ahlength := 2;
         x0 := 2.2cm;
         dx := 0.1cm;
         draw (x0-dx,y0) -- (x0+dx,y0);
         draw (x0-dx,y1) -- (x0+dx,y1);
-        draw (x0-dx,y2) -- (x0+dx,y2);
         draw (x0-dx,y3) -- (x0+dx,y3);
+        draw (x0-dx,y4) -- (x0+dx,y4);
         drawdblarrow (x0, y0) -- (x0, y1);
         label.rt(btex \lab{lineskip} etex, (x0, (y0+y1)/2));
-        drawdblarrow (x0, y2) -- (x0, y3);
-        label.rt(btex \lab{parskip} etex, (x0, (y2+y3)/2));
+        drawdblarrow (x0, y3) -- (x0, y4);
+        label.rt(btex \lab{parskip} etex, (x0, (y3+y4)/2));
       endfig;
     \end{mplibcode}%
   }%
 \end{center}
-\caption{Settings controlling the vertical spacing between staves. Distances \texttt{parskip} and \texttt{lineskip} are set to 0.2 cm for clarity.}
+\caption{Settings controlling the vertical spacing between staves. Distances \texttt{parskip} and \texttt{lineskip} are set to 0.2 cm for clarity. The staff together with all the text and neumes above and below it form one box, whose top, baseline, and bottom are drawn in red.}
 \label{fig:vertical-spacing-between-staves}
 \end{figure}
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -897,7 +897,7 @@ Macro to specify which part of the initial letter is aligned with the setting of
 \begin{argtable}
   \#1 & \texttt{top} & The initial letter is aligned using its top. \\
   & \texttt{baseline} & The initial letter is aligned using its baseline (default). \\
-  & \texttt{bottom} & The initial letter is aligned using its baseline. \\
+  & \texttt{bottom} & The initial letter is aligned using its bottom. \\
 \end{argtable}
 
 \macroname{\textbackslash gresetinitialposition}{\{\#1\}}{gregoriotex-main.tex}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1442,26 +1442,26 @@ Each of the following counts controls some aspect of the configuration of the Gr
 
 \begin{gcount}{additionaltopspacethreshold}
 The threshold above which we start accounting notes above lines for additional
-vertical space. For instance with a threshold of \texttt{2} and four line
+vertical space. For instance, with a threshold of \texttt{2} and four line
 staves, notes with a pitch of \texttt{k} and \texttt{l} will not interfere with
 the space above lines.  Set it to a high value if you don't want high notes to
-interfere with space above lines.
+interfere with space above lines. See \S\ref{sec:vertical-spacing}.
 \end{gcount}
 
 \begin{gcount}{additionaltopspacealtthreshold}
 Same as \texttt{additionaltopspacethreshold} but setting the threshold for
-notes taken into account with above lines text vertical placement.
+notes taken into account with above lines text vertical placement. See \S\ref{sec:vertical-spacing}.
 \end{gcount}
 
 \begin{gcount}{additionaltopspacenabcthreshold}
 Same as \texttt{additionaltopspacethreshold} but setting the threshold for
 notes taken into account with above lines nabc neume vertical placement
-baseline.
+baseline.  See \S\ref{sec:vertical-spacing}.
 \end{gcount}
 
 \begin{gcount}{noteadditionalspacelinestextthreshold}
 The number of low notes which will add space between the lines and the lyrics.  For instance, with a threshold of
-\texttt{2}, every note below \texttt{c} will add space for each pitch needed below \texttt{c}, accounting for the various signs.
+\texttt{2}, every note below \texttt{c} will add space for each pitch needed below \texttt{c}, accounting for the various signs. See \S\ref{sec:vertical-spacing}.
 \end{gcount}
 
 \subsection{Distances}\label{distances}
@@ -1755,34 +1755,6 @@ The distance to shift choral signs up.  The following choral signs are shifted u
 \end{itemize}
 \end{gdimension}
 
-\begin{gdimension}{translationheight}
-The space for the translation.
-\end{gdimension}
-
-\begin{gdimension}{spaceabovelines}
-The space above the staff lines and the above-lines text.
-\end{gdimension}
-
-\begin{gdimension}{spacelinestext}
-The space between the lines and the bottom of the text.
-\end{gdimension}
-
-\begin{gdimension}{noteadditionalspacelinestext}
-The per-note additional space between lines and the bottom of the text.
-\end{gdimension}
-
-\begin{gdimension}{spacebeneathtext}
-The space beneath the text.
-\end{gdimension}
-
-\begin{gdimension}{abovelinestextraise}
-Distance from the top staff line to the baseline of the above-lines text.
-\end{gdimension}
-
-\begin{gdimension}{abovelinestextheight}
-Minimum height of the above-lines text. (It must be bigger than the text for it to be taken into consideration.)
-\end{gdimension}
-
 \begin{gdimension}{braceshift}
 An additional shift you can give to the brace above the staff.
 \end{gdimension}
@@ -1885,25 +1857,301 @@ Distance to shift a bracket down when the lowest note in the brackets is
 neither on a line nor below the staff.
 \end{gdimension}
 
-\begin{gdimension}{parskip}
-The effective \verb=\parskip= inside of a score.
-\end{gdimension}
-
-\begin{gdimension}{lineskip}
-The effective \verb=\lineskip= inside of a score.
-\end{gdimension}
-
-\begin{gdimension}{baselineskip}
-The effective \verb=\baselineskip= inside of a score.
-\end{gdimension}
-
-\begin{gdimension}{lineskiplimit}
-The effective \verb=\lineskiplimit= inside of a score.
-\end{gdimension}
-
 \begin{gdimension}{shortspaceafterlineclef}
 Space after a clef at the beginning of a line, when the clef and first note are vertically distant.
 \end{gdimension}
+
+{
+\subsubsection{Vertical spacing within staves}
+\label{sec:vertical-spacing}
+
+\newcommand{\lines}[1]{
+  \begin{minipage}[b]{1.5cm}
+    \grechangedim{parskip}{0pt}{fixed}%
+    \setlength{\baselineskip}{0pt}%
+    \setlength{\lineskip}{0pt}%
+    \textcolor{red}{\hrule}%
+    \setbox0=\vbox{#1}%
+    \copy0%
+    \vspace{-\dp0}%
+    \textcolor{red}{\hrule}%
+  \end{minipage}%
+}
+
+\makeatletter
+\def\getdims{%
+  \edef\spaceabovelines{\gre@space@skip@spaceabovelines}%
+  \edef\abovelinestextheight{\gre@space@dimen@abovelinestextheight}%
+  \edef\abovelinestextraise{\gre@space@dimen@abovelinestextraise}%
+  \edef\stafflinedistance{\the\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)*\gre@factor/2}%
+  \edef\staffheight{\the\dimexpr(\gre@dimen@interstafflinedistancebase*3+\gre@dimen@stafflinethicknessbase*4)*\gre@factor}%
+  \edef\spacelinestext{\the\dimexpr\gre@space@dimen@spacelinestext}%
+  \edef\translationheight{\gre@space@dimen@translationheight}%
+  \edef\spacebeneathtext{\gre@space@dimen@spacebeneathtext}%
+  \edef\grebaselineskip{\the\dimexpr\glueexpr\gre@space@skip@baselineskip}%
+  \edef\grelineskip{\the\dimexpr\glueexpr\gre@space@skip@lineskip}%
+  \edef\greparskip{\the\dimexpr\glueexpr\gre@space@skip@parskip}%
+}
+\makeatother
+\newcommand{\lab}[1]{\scalebox{0.5}{\tt\small #1}}%
+
+\gresetinitiallines{0}
+
+A staff has text (lyrics) below it, and optionally another line of translation below the text. Above the staff, there can also be a line of text (called the above-lines text) or NABC neumes. The vertical position and height of all these parts are shown below (with \texttt{spaceabovelines} and \texttt{spacebeneathtext} set to 0.2 cm for clarity). The staff together with all the text and neumes above and below it form one box, whose topline and baseline are drawn in red.
+
+
+{\grechangedim{spaceabovelines}{0.2cm}{scalable}
+\grechangedim{spacebeneathtext}{0.2cm}{scalable}
+\begin{center}
+  \scalebox{2}{%
+    \getdims
+    \begin{mplibcode}
+      beginfig(0);
+        pickup pencircle scaled 0.1bp;
+        ahangle := 30; ahlength := 2;
+        y0 := \spacebeneathtext;
+        y1 := y0+\translationheight;
+        y2 := y1+\spacelinestext;
+        y3 := y2+\staffheight;
+        y4 := y3+\abovelinestextraise;
+        y5 := y4+\abovelinestextheight;
+        y6 := y5+\spaceabovelines;
+        x := 0.1cm;
+        draw (-x, 0) -- (x, 0);
+        draw (-x,y0) -- (x,y0);
+        draw (-x,y1) -- (x,y1);
+        draw (-x,y2) -- (x,y2);
+        draw (-x,y3) -- (x,y3);
+        draw (-x,y4) -- (x,y4);
+        draw (-x,y5) -- (x,y5);
+        draw (-x,y6) -- (x,y6);
+        drawdblarrow ( 0, 0) -- (0,y0); label.lft(btex \lab{spacebeneathtext} etex, (0, y0/2));
+        drawdblarrow ( 0,y0) -- (0,y1); label.lft(btex \lab{translationheight} etex, (0, (y0+y1)/2));
+        drawdblarrow ( 0,y1) -- (0,y2); label.lft(btex \lab{spacelinestext} etex, (0, (y1+y2)/2));
+        %drawdblarrow ( 0,y2) -- (0,y3); label.lft(btex \lab{staffheight} etex, (0, (y2+y3)/2));
+        drawdblarrow ( 0,y3) -- (0,y4); label.lft(btex \lab{abovelinestextraise} etex, (0, (y3+y4)/2));
+        drawdblarrow ( 0,y4) -- (0,y5); label.lft(btex \lab{abovelinestextheight} etex, (0, (y4+y5)/2));
+        drawdblarrow ( 0,y5) -- (0,y6); label.lft(btex \lab{spaceabovelines} etex, (0, (y5+y6)/2));
+      endfig;
+    \end{mplibcode}%
+    \hspace{0.2cm}%
+    \lines{\gabcsnippet{<alt>alt</alt>text[trans](g)}}%
+    \hspace{0.5cm}%
+    \lines{\nabcsnippet{text[trans](g|vi)}}%
+  }
+\end{center}
+}
+  
+The height of the staff lines is determined by the commands \verb|\grechangefactor| and \verb|\grechangestafflinethickness|.
+
+\begin{gdimension}{spaceabovelines}
+The space above the staff lines (and above-lines text or NABC neumes, if any).
+\end{gdimension}
+
+\begin{gdimension}{abovelinestextheight}
+Minimum height of the above-lines text. (It must be bigger than the text for it to be taken into consideration.)
+\end{gdimension}
+
+\begin{gdimension}{abovelinestextraise}
+Distance from the top staff line to the baseline of the above-lines text.
+\end{gdimension}
+
+\begin{gdimension}{spacelinestext}
+The space between the lines and the bottom of the text.
+\end{gdimension}
+
+\begin{gdimension}{translationheight}
+The space between the baseline of the text and the baseline of the translation.
+\end{gdimension}
+
+\begin{gdimension}{spacebeneathtext}
+The space beneath the text (and translation, if any).
+\end{gdimension}
+
+\paragraph{Additional top space}
+
+The space between the top staff line and the topline is normally $\texttt{spaceabovelines}$, but if there are notes above the staff, additional space may automatically be added.
+
+The count \texttt{additionaltopspacethreshold} sets a threshold relative to the top line of the staff, so on a four-line staff, $0$ is pitch \texttt{j}, $1$ is pitch \texttt{k}, and so on. By default, $\texttt{additionaltopspacethreshold} = 2$, which is pitch \texttt{l}.
+Then, if the highest note is $n$ steps above this threshold, then $n$ steps of additional space are added (where a step is half the distance between staff lines). For example, again assuming the default of $\texttt{additionaltopspacethreshold} = 2$ on a four-line staff, if the highest note is \texttt{m}, then one step of additional space is added.
+
+Note that if there are high notes, increasing \texttt{spaceabovelines} may not add any visible space above the notes. To ensure a minimum space above the notes, set \texttt{spaceabovelines} to a length greater than $(1+\texttt{additionaltopspacethreshold})$. That is, with all other settings at their defaults, \texttt{spaceabovelines} should be greater than $3~\textrm{steps} \approx 0.41~\textrm{cm}$.
+
+\begin{quote}
+\verb|\grechangedim{spaceabovelines}{0.5cm}{scalable}|
+\grechangedim{spaceabovelines}{0.5cm}{scalable}
+
+\begin{center}
+\rowcolors{1}{white}{white}%
+\begin{tabular}{ccccc}
+  \lines{\gabcsnippet{i[0 steps](i)}} &
+  \lines{\gabcsnippet{j[0 steps](j)}} &
+  \lines{\gabcsnippet{k[0 steps](k)}} &
+  \lines{\gabcsnippet{l[0 steps](l)}} &
+  \lines{\gabcsnippet{m[1 step](m)}}
+\end{tabular}
+\end{center}
+\end{quote}
+
+High notes also cause the above-lines text, if any, to be raised. The above-lines text has its own threshold, \texttt{additionaltopspacealtthreshold} (default 0):
+\begin{center}
+\rowcolors{1}{white}{white}%
+\begin{tabular}{ccccc}
+  \lines{\gabcsnippet{<alt>alt</alt>i[0 steps](i)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>j[0 steps](j)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>k[1 step](k)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>l[2 steps](l)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>m[3 steps](m)}}
+\end{tabular}
+\end{center}
+
+Because the above-lines text and the topline have different thresholds, they may get raised by different amounts. The two preceding examples combine to look like this:
+\begin{quote}
+\verb|\grechangedim{spaceabovelines}{0.5cm}{scalable}|
+\grechangedim{spaceabovelines}{0.5cm}{scalable}
+  
+\begin{center}
+\rowcolors{1}{white}{white}%
+\begin{tabular}{ccccc}
+  \lines{\gabcsnippet{<alt>alt</alt>i(i)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>j(j)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>k(k)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>l(l)}} &
+  \lines{\gabcsnippet{<alt>alt</alt>m(m)}}
+\end{tabular}
+\end{center}
+\end{quote}
+
+NABC neumes use a different threshold, \texttt{additionaltopspacenabcthreshold}. This defaults to $4$, meaning that only the very highest notes affect the positioning of NABC neumes.
+\begin{quote}
+\grechangedim{abovelinestextheight}{0.1cm}{scalable}%
+\verb|\grechangedim{abovelinestextheight}{0.1cm}{scalable}| \\
+\grechangedim{abovelinestextraise}{0.8cm}{scalable}%
+\verb|\grechangedim{abovelinestextraise}{0.8cm}{scalable}|%
+\gresetlyriccentering{syllable}%
+\begin{center}
+\rowcolors{1}{white}{white}%
+\begin{tabular}{ccccc}
+  \lines{\nabcsnippet{m|vi[0 steps](m|vi)}} &
+  \lines{\nabcsnippet{m_1|vi[0 steps](m_1|vi)}} &
+  \lines{\nabcsnippet{m'1|vi[1 step](m'1|vi)}} &
+  \lines{\nabcsnippet{m_1'1|vi[2 steps](m_1'1|vi)}}
+\end{tabular}
+\end{center}
+\end{quote}
+
+\paragraph{Additional bottom space}
+
+Additional space below the staff works in much the same way. The count \texttt{noteadditionalspacelinestextthreshold} sets a threshold relative to pitch \texttt{a}, so $0$ is pitch \texttt{a}, $1$ is pitch \texttt{b}, and so on. Under the default settings, $\texttt{noteadditionalspacelinestextthreshold} = 2$, which is pitch \texttt{c}. Then, if the lowest note is $n$ steps below the threshold, then $n$ steps of additional bottom space are added.
+
+\begin{center}
+\rowcolors{1}{white}{white}%
+\begin{tabular}{ccccc}
+  \lines{\gabcsnippet{e[0 steps](e)}} &
+  \lines{\gabcsnippet{d[0 steps](d)}} &
+  \lines{\gabcsnippet{c[0 steps](c)}} &
+  \lines{\gabcsnippet{b[1 step](b)}} &
+  \lines{\gabcsnippet{a[2 steps](a)}}
+\end{tabular}
+\end{center}
+
+A legacy option is to change the amount of additional bottom space per step by setting \verb|\gresetnoteadditionalspacelinestext{manual}| and the following:
+
+\begin{gdimension}{noteadditionalspacelinestext}
+The per-step additional space between lines and the bottom of the text, when using \verb|\gresetnoteadditionalspacelinestext{manual}|.
+\end{gdimension}
+
+\paragraph{Vertical spacing between staves}
+
+The standard rules for paragraph and line spacing apply to scores and staves.
+
+\begin{gdimension}{parskip}
+The effective \verb=\parskip= inside of a score. This amount of space is added to the top of a score, although this space is removed in some contexts (like the top of a page).
+\end{gdimension}
+
+\begin{gdimension}{baselineskip}
+The effective \verb=\baselineskip= inside of a score. This is the minimum distance between baselines of consecutive staves.
+\end{gdimension}
+
+\begin{gdimension}{lineskiplimit}
+The effective \verb=\lineskiplimit= inside of a score. If the distance between one staff's bottomline and the next staff's topline is less than this, then \texttt{lineskip} is added between them.
+\end{gdimension}
+
+\begin{gdimension}{lineskip}
+The effective \verb=\lineskip= inside of a score. If the distance between one staff's bottomline and the next staff's topline is less than \texttt{lineskiplimit}, then this amount of space is added between them.
+\end{gdimension}
+
+These settings are illustrated below (with \texttt{parskip} and \texttt{lineskip} set to 0.2 cm for clarity).
+
+{\grechangedim{parskip}{0.2cm}{scalable}
+\grechangedim{lineskip}{0.2cm}{scalable}
+\begin{center}
+  \scalebox{2}{%
+    \getdims
+    \begin{mplibcode}
+      beginfig(0);
+        pickup pencircle scaled 0.4bp;
+        wd := 1.5cm;
+        y0 := \spacelinestext + \staffheight + \spaceabovelines;
+        y1 := \grebaselineskip;
+        y2 := y1 + \spacelinestext + \staffheight + \spaceabovelines;
+        y3 := y2 + \greparskip;
+        draw (0,0) -- (wd,0) withcolor red;
+        draw (0,y0) -- (wd,y0) withcolor red;
+        draw (0,y1) -- (wd,y1) withcolor red;
+        draw (0,y2) -- (wd,y2) withcolor red;
+        draw (0,y3) -- (wd,y3) withcolor red;
+        pickup pencircle scaled 0.1bp;
+        ahangle := 30; ahlength := 2;
+        x0 := -0.2cm;
+        dx := 0.1cm;
+        draw (x0-dx, 0) -- (x0+dx, 0);
+        draw (x0-dx,y1) -- (x0+dx,y1);
+        draw (x0-dx,y2) -- (x0+dx,y2);
+        draw (x0-dx,y3) -- (x0+dx,y3);
+        drawdblarrow (x0, 0) -- (x0, y1);
+        label.lft(btex \lab{baselineskip} etex, (x0, y1/2));
+        drawdblarrow (x0, y2) -- (x0, y3);
+        label.lft(btex \lab{parskip} etex, (x0, (y2+y3)/2));
+      endfig;
+    \end{mplibcode}%
+    \llap{\begin{minipage}[b]{1.5cm}\hrule\gabcsnippet{text(gZ) text(g)}\end{minipage}}%
+  }%
+  \hspace*{1cm}%
+  \scalebox{2}{%
+    \getdims
+    \rlap{\begin{minipage}[b]{1.5cm}\hrule\gabcsnippet{text(gZ) <alt>alt</alt>text[trans](g)}\end{minipage}}%
+    \begin{mplibcode}
+      beginfig(0);
+        pickup pencircle scaled 0.4bp;
+        wd := 1.5cm;
+        y0 := \spacebeneathtext + \translationheight + \spacelinestext + \staffheight + \abovelinestextraise + \abovelinestextheight + \spaceabovelines;
+        y1 := y0 + \grelineskip;
+        y2 := y1 + \spacelinestext + \staffheight + \spaceabovelines;
+        y3 := y2 + \greparskip;
+        draw (0,0) -- (wd,0) withcolor red;
+        draw (0,y0) -- (wd,y0) withcolor red;
+        draw (0,y1) -- (wd,y1) withcolor red;
+        draw (0,y2) -- (wd,y2) withcolor red;
+        draw (0,y3) -- (wd,y3) withcolor red;
+        pickup pencircle scaled 0.1bp;
+        ahangle := 30; ahlength := 2;
+        x0 := 2.2cm;
+        dx := 0.1cm;
+        draw (x0-dx,y0) -- (x0+dx,y0);
+        draw (x0-dx,y1) -- (x0+dx,y1);
+        draw (x0-dx,y2) -- (x0+dx,y2);
+        draw (x0-dx,y3) -- (x0+dx,y3);
+        drawdblarrow (x0, y0) -- (x0, y1);
+        label.rt(btex \lab{lineskip} etex, (x0, (y0+y1)/2));
+        drawdblarrow (x0, y2) -- (x0, y3);
+        label.rt(btex \lab{parskip} etex, (x0, (y2+y3)/2));
+      endfig;
+    \end{mplibcode}%
+  }%
+\end{center}
+As shown on the right, under the default settings, a staff with both above-lines text (or NABC) and translations has height greater than the default \texttt{baselineskip}. So if you want to increase \texttt{baselineskip}, you might have to increase it significantly before seeing any effect.
+}% 
 
 \subsubsection{Bar distances}
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -274,7 +274,7 @@ Macro to change one of Gregorio\TeX’s distances.  This function will check to 
 \end{argtable}
 
 \macroname{\textbackslash grechangenextscorelinedim}{\{\#1\}\{\#2\}\{\#3\}\{\#4\}}{gregoriotex-spaces.tex}
-Changes one of Gregorio\TeX’s distances for a given line in the next included score.  This works with \texttt{abovelinestextheight}, \texttt{spaceabovelines}, \texttt{abovelinestextraise}, \texttt{spacelinestext}, \texttt{spacebeneathtext}, and \texttt{translationheight}.
+Changes one of Gregorio\TeX’s distances for a given line in the next included score.  This works with \texttt{abovelinestextheight}, \texttt{abovelinestextraise}, \texttt{spaceabovelines}, \texttt{spacelinestext}, \texttt{spacebeneathtext}, and \texttt{translationheight}.
 
 \begin{argtable}
   \#1 & list of integers & A comma-separated list of line numbers in the next
@@ -1760,7 +1760,7 @@ The space for the translation.
 \end{gdimension}
 
 \begin{gdimension}{spaceabovelines}
-The space above the lines.
+The space above the staff lines and the above-lines text.
 \end{gdimension}
 
 \begin{gdimension}{spacelinestext}
@@ -1780,7 +1780,7 @@ Distance from the top staff line to the baseline of the above-lines text.
 \end{gdimension}
 
 \begin{gdimension}{abovelinestextheight}
-Height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration).
+Minimum height of the above-lines text. (It must be bigger than the text for it to be taken into consideration.)
 \end{gdimension}
 
 \begin{gdimension}{braceshift}

--- a/doc/GregorioRef.lua
+++ b/doc/GregorioRef.lua
@@ -606,8 +606,8 @@ function GregorioRef.emit_extra_glyphs(csname)
 end
 
 function GregorioRef.emit_dimension(value)
-  value = string.gsub(value, '(-?%d+%.%d+)%s*(%a+)', [[\unit[%1]{%2}]])
-  value = string.gsub(value, '(-?%d+%.)%s*(%a+)', [[\unit[%1]{%2}]])
-  value = string.gsub(value, '(-?%.?%d+)%s*(%a+)', [[\unit[%1]{%2}]])
+  value = string.gsub(value, '(-?%d+%.%d+)%s*(%a%a)', [[\unit[%1]{%2} ]])
+  value = string.gsub(value, '(-?%d+%.)%s*(%a%a)', [[\unit[%1]{%2} ]])
+  value = string.gsub(value, '(-?%.?%d+)%s*(%a%a)', [[\unit[%1]{%2} ]])
   tex.sprint(value)
 end

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -172,6 +172,11 @@
 
 \gresetspecial{\string\126\string\126}{\textasciitilde{}}%
 
+\long\def\nabcsnippet#1{%
+  \directlua{gregoriotex.direct_gabc("\luatexluaescapestring{\unexpanded\expandafter{#1}}",
+                                     "nabc-lines:1;", false)}%
+}%
+
 \begin{document}
 
 \begin{titlepage}

--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -382,7 +382,7 @@
 %the space beneath the text
 \gre@createdim{spacebeneathtext}{0 cm}{scalable}%
 % height of the text above the note line
-\gre@createdim{abovelinestextraise}{-0.1 cm}{scalable}%
+\gre@createdim{abovelinestextraise}{0.17351 cm}{scalable}%
 % height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration)
 \gre@createdim{abovelinestextheight}{0.3 cm}{scalable}%
 % an additional shift you can give to the brace above the bars if you don't like it

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -689,7 +689,6 @@
     \gre@attr@part=7\relax
   \fi%
   \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
-    + \gre@dimen@interstafflinespace %
     + \gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext %
     + \gre@space@dimen@abovelinestextraise)\relax%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -891,7 +891,7 @@
 \def\gre@calculate@additionalspaces{%
   \gre@trace{gre@calculate@additionalspaces}%
   % Pass in dimensions and counts that are macros
-  \gre@luasavedim{abovelinestextheight}%
+  \gre@luasavedim{spaceabovelines}%
   % \ifgre@noteadditionalspacelinestext is not accessible in Lua, so handle it here
   \ifgre@noteadditionalspacelinestext
     \gre@luasavedim{noteadditionalspacelinestext}%
@@ -899,11 +899,11 @@
     {\grechangedim{noteadditionalspacelinestext}{\the\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)/2 * \gre@factor\relax}{fixed}%
      \gre@luasavedim{noteadditionalspacelinestext}}%
   \fi
-  \gre@luasavedim{spaceabovelines}%
+  \gre@luasavedim{abovelinestextheight}%
   \gre@luasavedim{abovelinestextraise}%
   \gre@luasavedim{spacelinestext}%
-  \gre@luasavedim{spacebeneathtext}%
   \gre@luasavedim{translationheight}%
+  \gre@luasavedim{spacebeneathtext}%
   \gre@generatelines %
   \gre@calculate@constantglyphraise %
   \gre@trace@end%
@@ -1583,8 +1583,8 @@
 % #1 : line number
 % #2-#4 : same as #1-#3 of \grechangedim
 \def\grechangenextscorelinedim#1#2#3#4{%
-  \IfStrEqCase{#2}{{abovelinestextheight}{}{noteadditionalspacelinestext}{}{spaceabovelines}{}{abovelinestextraise}{}{spacelinestext}{}{spacebeneathtext}{}{translationheight}{}}[%
-    \gre@error{Unrecognized option "#2" for \protect\grechangenextscorelinedim\MessageBreak Possible options are: 'abovelinestextraise', 'noteadditionalspacelinestext', 'spaceabovelines', 'spacebeneathtext', 'spacelinestext', 'translationheight'}%
+  \IfStrEqCase{#2}{{abovelinestextheight}{}{abovelinestextraise}{}{spaceabovelines}{}{spacelinestext}{}{noteadditionalspacelinestext}{}{translationheight}{}{spacebeneathtext}{}}[%
+    \gre@error{Unrecognized option "#2" for \protect\grechangenextscorelinedim\MessageBreak Possible options are: 'abovelinestextheight', 'abovelinestextraise', 'spaceabovelines', 'spacelinestext', 'noteadditionalspacelinestext', 'translationheight', 'spacebeneathtext'}%
   ]%
   {\grechangedim{#2}{#3}{#4}%
    \gre@rubberpermit{#2}%

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -675,7 +675,8 @@ local function compute_line_statistics(line, info)
   if info == nil then
     info = {
       has_translation = false,
-      has_abovelinestext = false,
+      has_alt = false,
+      has_nabc = false,
       glyph_top = 7, -- e = \gre@pitch@dummy
       glyph_bottom = 7 -- e = \gre@pitch@dummy
     }
@@ -683,8 +684,10 @@ local function compute_line_statistics(line, info)
   for n in traverse(line.head) do
     if has_attribute(n, part_attr, part_translation) then
       info.has_translation = true
-    elseif has_attribute(n, part_attr, part_alt) or has_attribute(n, part_attr, part_nabc) then
-      info.has_abovelinestext = true
+    elseif has_attribute(n, part_attr, part_alt) then
+      info.has_alt = true
+    elseif has_attribute(n, part_attr, part_nabc) then
+      info.has_nabc = true
     else
       if has_attribute(n, glyph_top_attr) then
         if info.glyph_top == nil or has_attribute(n, glyph_top_attr) > info.glyph_top then
@@ -698,7 +701,7 @@ local function compute_line_statistics(line, info)
       end
     end
   end
-  debugmessage('compute_line_statistics', 'has_abovelinestext %s has_translation %s glyph_top %s glyph_bottom %s', info.has_abovelinestext, info.has_translation, info.glyph_top, info.glyph_bottom)
+  debugmessage('compute_line_statistics', 'has_alt %s has_nabc %s has_translation %s glyph_top %s glyph_bottom %s', info.has_alt, info.has_nabc, info.has_translation, info.glyph_top, info.glyph_bottom)
   return info
 end
 
@@ -742,18 +745,13 @@ local function adjust_additional_spaces(line, info, linenum)
   local additional_top_space_nabc = math.max(0, info.glyph_top - adjust_top - nabc_threshold) * staffline_distance
   local additional_bottom_space = math.max(0, adjust_bottom - info.glyph_bottom) * note_additional_space_lines_text
 
-  -- abovelinestext and translation heights
-  local abovelinestext_height = 0
-  if info.has_abovelinestext then
-    abovelinestext_height = get_space('abovelinestextheight')
-  end
+  -- translation height
   local translation_height = 0
   if info.has_translation then
     translation_height = get_space('translationheight')
   end
 
   -- per-line changes to other spaces
-  local extra_space_above_lines = get_space('spaceabovelines') - saved_dims['spaceabovelines']
   local extra_above_lines_text_raise = get_space('abovelinestextraise') - saved_dims['abovelinestextraise']
   local extra_space_lines_text = get_space('spacelinestext') - saved_dims['spacelinestext']
   local extra_space_beneath_text = get_space('spacebeneathtext') - saved_dims['spacebeneathtext']
@@ -762,7 +760,15 @@ local function adjust_additional_spaces(line, info, linenum)
   local commentary_raise = additional_top_space_alt
   local alt_raise = additional_top_space_alt + extra_above_lines_text_raise
   local nabc_raise = additional_top_space_nabc + extra_above_lines_text_raise
-  local height_increase = abovelinestext_height + extra_space_above_lines + additional_top_space
+  local height_new = get_space('spaceabovelines') + additional_top_space
+  if info.has_alt then
+    height_new = math.max(height_new, additional_top_space_alt)
+    height_new = height_new + get_space('abovelinestextraise') + get_space('abovelinestextheight')
+  elseif info.has_nabc then
+    height_new = math.max(height_new, additional_top_space_nabc)
+    height_new = height_new + get_space('abovelinestextraise') + get_space('abovelinestextheight')
+  end
+  local height_increase = height_new - saved_dims['spaceabovelines']
   local lyrics_lower = additional_bottom_space + extra_space_lines_text
   local translation_lower = lyrics_lower + translation_height
   local everything_raise = translation_lower + extra_space_beneath_text


### PR DESCRIPTION
This patch addresses #1631 by making two changes to vertical spacing and adding more detailed documentation about vertical spacing. The two changes unfortunately will break some existing scores, but hopefully make spacing less confusing and easier to extend in the future.

A line without above-lines text looks like this. In all these pictures, the following lengths have been changed from their defaults:

```
\grechangedim{spaceabovelines}{0.2cm}{scalable}
\grechangedim{spacebeneathtext}{0.2cm}{scalable}
\grechangedim{abovelinestextraise}{0.2cm}{scalable}
```

<img width="237" alt="image" src="https://github.com/user-attachments/assets/aef89350-77a8-4654-8708-65ba8005be0f" />


But with above-lines text, the picture becomes more complicated:

<img width="386" alt="image" src="https://github.com/user-attachments/assets/60144504-fb5f-4322-ba0e-a14bcf7365ad" />

The total height is the maximum of the two heights shown.

The first problem is that the docs say that `abovelinestextraise` is the "Height of the text above the note line." To me, that sounds like the distance from the top staff line to the baseline of the above-lines text. But there's actually an extra `interstafflinespace` in there, which I'm guessing was an off-by-one error.

The second problem is that the docs say that `abovelinestextheight` "must be bigger than the text for it to be taken into consideration," but in this example, one would have to increase `abovelinestextheight` by quite a bit more than that before seeing any effect. The reason is that the total height computation leaves out `abovelinestextraise`, and I'm guessing this was just an oversight.

Under this patch, the picture becomes:

<img width="255" alt="image" src="https://github.com/user-attachments/assets/68831662-3cea-42d6-964e-e166280915da" />

It makes two changes:

1. `abovelinestextraise` is measured from the top staff line. The default `abovelinestextraise` is changed from -0.1cm to 1.7351cm to produce the same result as before (all tests pass). But any code that sets `abovelinestextraise` explicitly would have to be corrected.

2. `abovelinestextraise` is included in the computation of the total height. Decreasing the default `abovelinestextheight` to compensate (0.12649cm) makes all tests pass, but I think the current default of 0.3 cm is good, and adds a little breathing room above the above-lines text.

The new documentation is on pages 77-82 of GregorioRef.pdf. It goes into more detail about additional space above/below the staff, and about `baselineskip` and `lineskip`.

Closes #1374, #1375, #1631.
