### PR TITLE
Speed up \gre@createdim

### DIFF
--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1169,18 +1169,17 @@ Macro to generate the point-and-click links.
   \#2 & link target & line:char:column for the link\\
 \end{argtable}
 
+\macroname{\textbackslash gre@getprefix}{}{gregoriotet-spaces.tex}
+If the given distance allows glue, expands to \texttt{skip}; otherwise, expands to \texttt{dimen}.
+\begin{argtable}
+  \#1 & name of distance
+\end{argtable}
+
 \macroname{\textbackslash gre@prefix}{}{gregoriotex-spaces.tex}
 Either \texttt{skip} or \texttt{dimen} according to the distance being set or changed at the given moment.
 
 \macroname{\textbackslash gre@prefixII}{}{gregoriotex-spaces.tex}
 Same as \verb=\gre@prefix=.  Used when we were dealing with two distances simultaneously.
-
-\macroname{\textbackslash gre@rubberpermit}{\#1}{gregoriotex-spaces.tex}
-Determines whether the given distance is allowed to take a rubber length.
-
-\begin{argtable}
-  \#1 & string & the name of the distance to check\\
-\end{argtable}
 
 \macroname{\textbackslash gre@setgregoriofont}{[\#1]\#2}{gregoriotex-main.tex}
 Workhorse function behind \verb=\gresetgregoriofont=.
@@ -1382,17 +1381,6 @@ Runs a command for each string in a comma-separated list of strings.
 
 \macroname{\textbackslash gre@parsecommas@options}{}{gregoriotex-common.tex}
 Internal to \verb|\gre@parsecommas|.
-
-\macroname{\textbackslash gre@makeparshape}{}{gregoriotex-main.tex}
-Sets the shape of the paragraph shape using \verb|\parshape|.
-
-\begin{argtable}
-  \#1 & integer & How many lines are indented \\
-  \#2 & dimen & The amount of the indentation \\
-\end{argtable}  
-
-\macroname{\textbackslash gre@parshape@dims}{}{gregoriotex-main.tex}
-Used inside \verb|\gre@makeparshape| to hold the \verb=\parshape= information needed to shape the score around the initial.
 
 \subsection{Auxiliary File}
 Gregorio\TeX\ creates its own auxiliary file (extension \texttt{gaux}) which it uses to store information between successive typesetting runs.  This allows for such features as the dynamic interline spacing.  The following functions are used to interact with that auxiliary file.
@@ -1652,9 +1640,6 @@ Boolean used to indicate if hyphens should be forced between all syllables in a 
 
 \macroname{\textbackslash ifgre@checklength}{}{gregoriotex-spaces.tex}
 Boolean used in \verb=\gresetdim= to indicate if we are attempting to set a rubber length.
-
-\macroname{\textbackslash ifgre@rubber}{}{gregoriotex-spaces.tex}
-Boolean used in \verb=\gre@changeonedimenfactor= to indicate if we are dealing with one of the distances which can accept a rubber length.
 
 \macroname{\textbackslash ifgre@stretch}{}{gregoriotex-spaces.tex}
 Boolean used in \verb=\gre@changeonedimenfactor= as we test for the presence of a stretch.
@@ -2034,13 +2019,15 @@ Macros that store the protrusion factors created by
 
 \subsection{Distances}
 
-\macroname{\textbackslash gre@createdim}{\{\#1\}\{\#2\}\{\#3\}}{gregoriotex-spaces.tex}
+\macroname{\textbackslash gre@createdim}{\{\#1\}\{\#2\}\{\#3\}\{\#4\}}{gregoriotex-spaces.tex}
 Macro to create one of Gregorio\TeX’s distances.  Used to initialize distances in \textit{gregoriotex-gsp-default.tex}.
 
 \begin{argtable}
-  \#1 & string & The name of the distance to be changed.  See \nameref{distances} below.\\
-  \#2 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
-  \#3 & \texttt{fixed} & Distance will not scale when staff size is changed.\\
+  \#1 & \texttt{dimen} & Distance does not allow stretch (\texttt{plus}) or shrink (\texttt{minus}).\\
+      & \texttt{skip} & Distance does allow stretch (\texttt{plus}) or shrink (\texttt{minus}).\\
+  \#2 & string & The name of the distance to be created.  See \nameref{distances} below.\\
+  \#3 & string & The distance in string format.  \textbf{Note:} You cannot use a length register for this argument.  You \emph{must} use a string because of the way that Gregorio\TeX\ handles spaces.\\
+  \#4 & \texttt{fixed} & Distance will not scale when staff size is changed.\\
   & \texttt{scalable} & Distance will scale when staff size is changed.\\
   & \texttt{inherited} & Distance will inherit its value from another distance.  When this argument is used, then \#2 should be the name of another Gregorio\TeX\ distance.
 \end{argtable}
@@ -2069,10 +2056,6 @@ Width of the clef used to compute bolshift.
 
 \macroname{\textbackslash gre@dimen@constantglyphraise}{}{gregoriotex-spaces.tex}
 Dimension representing the space between the 0 of the gregorian fonts and the effective 0 of the TeX score.
-
-\macroname{\textbackslash gre@dimen@stafflinewidth}{}{gregoriotex-spaces.tex}
-Dimension representing the width of a line of staff.  Can vary, for
-example, at the first line.
 
 \macroname{\textbackslash gre@dimen@linewidth}{}{gregoriotex-spaces.tex}
 Dimension representing the width of the score (including initial).

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -140,13 +140,8 @@
 
 \makeatletter%
 \NewDocumentEnvironment{gdimension}{m}{\macroname{#1}{}{gregoriotex-gsp-default.tex}}{%
-
-  \gre@rubberpermit{#1}%
-  \ifgre@rubber%
-    Default: \directlua{GregorioRef.emit_dimension("\luaescapestring{\csname gre@space@skip@#1\endcsname}")}
-  \else%
-    Default: \directlua{GregorioRef.emit_dimension("\luaescapestring{\csname gre@space@dimen@#1\endcsname}")}
-  \fi%
+  \par
+  Default: \directlua{GregorioRef.emit_dimension("\luaescapestring{\csname gre@space@\gre@getprefix{#1}@#1\endcsname}")}
 }
 
 \NewDocumentEnvironment{gcount}{m}{\macroname{#1}{}{gregoriotex-gsp-default.tex}}{%

--- a/doc_check.sh
+++ b/doc_check.sh
@@ -71,7 +71,7 @@ sed -i.temp 's:.*gre@space@count@\([a-z@]*\).*:\1:' $CODEFILE
 
 #distances
 grep -h '\\gre@createdim{.*' gregoriotex-gsp-default.tex >> $CODEFILE
-sed -i.temp 's:\\gre@createdim{\([a-z@]*\)}.*:\1:' $CODEFILE
+sed -i.temp 's:\\gre@createdim{[a-z]*}{\([a-z@]*\)}.*:\1:' $CODEFILE
 sed -i.temp 's:.*gre@space@.*::' $CODEFILE
 
 #styles

--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -61,7 +61,7 @@
 \else %
   \grechangecount{pretolerance}{\the\pretolerance}%
 \fi %
-\gre@createdim{emergencystretch}{\the\emergencystretch}{scalable}%
+\gre@createdim{skip}{emergencystretch}{\the\emergencystretch}{scalable}%
 % By default, we don't care if a line of score is alone on the page,
 % if you think it is bad, you can modify the two following values. Assigning
 % 10000 to them will prevent all orphaned lines (this will certainly improve
@@ -98,118 +98,118 @@
 \grechangestafflinethickness{17}%
 
 % the additional width of the additional lines (compared to the width of the glyph they're associated with)
-\gre@createdim{additionallineswidth}{0.14584 cm}{scalable}%
+\gre@createdim{dimen}{additionallineswidth}{0.14584 cm}{scalable}%
 % width of the additional lines, used only for the custos (maybe should depend on the width of the custos...)
 % the width is the one for the custos at end of lines, the line for custos in the middle of a score is the same
 % multiplied by 2.
-\gre@createdim{additionalcustoslineswidth}{0.09114 cm}{scalable}%
+\gre@createdim{dimen}{additionalcustoslineswidth}{0.09114 cm}{scalable}%
 % null space
-\gre@createdim{zerowidthspace}{0 cm}{scalable}%
+\gre@createdim{dimen}{zerowidthspace}{0 cm}{scalable}%
 % space between glyphs in the same element
-\gre@createdim{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{interglyphspace}{0.06927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between an alteration (flat or natural) and the next glyph
-\gre@createdim{alterationspace}{0.07747 cm}{scalable}%
+\gre@createdim{dimen}{alterationspace}{0.07747 cm}{scalable}%
 % space between a clef and a flat (for clefs with flat)
-\gre@createdim{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
+\gre@createdim{skip}{clefflatspace}{0.05469 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
 % space before a choral sign
-\gre@createdim{beforelowchoralsignspace}{0.04556 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
+\gre@createdim{skip}{beforelowchoralsignspace}{0.04556 cm plus 0.00638 cm minus 0.00638 cm}{scalable}%
 % when bolshifts are enabled, minimal space between a clef at the beginning of the line and a leading alteration glyph (should be larger than clefflatspace so that a flatted clef can be distinguished from a flat which is part of the first glyph on a line, but also smaller than spaceafterlineclef, the distance from the clef to the first notes)
-\gre@createdim{beforealterationspace}{0.1 cm}{scalable}%
+\gre@createdim{dimen}{beforealterationspace}{0.1 cm}{scalable}%
 % half-space between elements
-\gre@createdim{halfspace}{0.03463 cm plus 0.00091 cm minus 0.00182 cm}{scalable}%
+\gre@createdim{skip}{halfspace}{0.03463 cm plus 0.00091 cm minus 0.00182 cm}{scalable}%
 % space between elements
-\gre@createdim{interelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{interelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scalable}%
 % larger space between elements
-\gre@createdim{largerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
+\gre@createdim{skip}{largerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
 % space between elements in ancient notation
-\gre@createdim{nabcinterelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{nabcinterelementspace}{0.06927 cm plus 0.00182 cm minus 0.00363 cm}{scalable}%
 % larger space between elements in ancient notation
-\gre@createdim{nabclargerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
+\gre@createdim{skip}{nabclargerspace}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
 % space between elements which has the size of a note
-\gre@createdim{glyphspace}{0.21877 cm plus 0.01822 cm minus 0.01822 cm}{scalable}%
+\gre@createdim{skip}{glyphspace}{0.21877 cm plus 0.01822 cm minus 0.01822 cm}{scalable}%
 % space before in-line custos
-\gre@createdim{spacebeforeinlinecustos}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
+\gre@createdim{skip}{spacebeforeinlinecustos}{0.10938 cm plus 0.01822 cm minus 0.00911 cm}{scalable}%
 % space before end-of-line custos
-\gre@createdim{spacebeforeeolcustos}{0.23 cm plus 0 cm minus 0 cm}{scalable}%
+\gre@createdim{skip}{spacebeforeeolcustos}{0.23 cm plus 0 cm minus 0 cm}{scalable}%
 % space before punctum mora and augmentum duplex
-\gre@createdim{spacebeforesigns}{0.050 cm plus 0.004 cm minus 0.004 cm}{scalable}%
+\gre@createdim{skip}{spacebeforesigns}{0.050 cm plus 0.004 cm minus 0.004 cm}{scalable}%
 % when a syllable is shifted left because of a preceding punctum mora, moraadjustmentbar is
 % also added. Use it to make the syllable a bit further from the punctum mora if you want.
 % This version is the general case.
-\gre@createdim{moraadjustment}{0.050 cm}{scalable}%
+\gre@createdim{skip}{moraadjustment}{0.050 cm}{scalable}%
 % This version is for when punctum mora is before a bar.
-\gre@createdim{moraadjustmentbar}{0.050 cm}{scalable}%
+\gre@createdim{skip}{moraadjustmentbar}{0.050 cm}{scalable}%
 % space after punctum mora and augmentum duplex
-\gre@createdim{spaceaftersigns}{0.08203 cm plus 0.0082 cm minus 0.0082 cm}{scalable}%
+\gre@createdim{skip}{spaceaftersigns}{0.08203 cm plus 0.0082 cm minus 0.0082 cm}{scalable}%
 % space after a clef at the beginning of a line
-\gre@createdim{spaceafterlineclef}{0.23 cm plus 0 cm minus 0.01367 cm}{scalable}%
+\gre@createdim{skip}{spaceafterlineclef}{0.23 cm plus 0 cm minus 0.01367 cm}{scalable}%
 % space after a clef at the beginning of a line, when the clef and first note are vertically distant
-\gre@createdim{shortspaceafterlineclef}{0.18 cm plus 0 cm minus 0.01367 cm}{scalable}%
+\gre@createdim{skip}{shortspaceafterlineclef}{0.18 cm plus 0 cm minus 0.01367 cm}{scalable}%
 % minimal space between notes of different words
-\gre@createdim{interwordspacenotes}{0.29 cm plus 0.05 cm minus 0.05 cm}{scalable}%
+\gre@createdim{skip}{interwordspacenotes}{0.29 cm plus 0.05 cm minus 0.05 cm}{scalable}%
 % minimal space between notes of the same syllable.
-\gre@createdim{intersyllablespacenotes}{0.24 cm}{scalable}%
+\gre@createdim{dimen}{intersyllablespacenotes}{0.24 cm}{scalable}%
 % stretching added in the case where the text of two syllables of the same word are
 % separated with an automatic hyphen
-\gre@createdim{intersyllablespacestretchhyphen}{0cm plus 0.05cm}{scalable}%
+\gre@createdim{skip}{intersyllablespacestretchhyphen}{0cm plus 0.05cm}{scalable}%
 % minimal space between letters of different words.
-\gre@createdim{interwordspacetext}{0.17 cm plus 0.05 cm minus 0.05 cm}{scalable}%
+\gre@createdim{skip}{interwordspacetext}{0.17 cm plus 0.05 cm minus 0.05 cm}{scalable}%
 % Versions of interword spaces for euouae blocks
-\gre@createdim{interwordspacenotes@euouae}{0.23 cm plus 0.1 cm minus 0.05 cm}{scalable}%
-\gre@createdim{interwordspacetext@euouae}{0.21 cm plus 0.1 cm minus 0.05 cm}{scalable}%
+\gre@createdim{skip}{interwordspacenotes@euouae}{0.23 cm plus 0.1 cm minus 0.05 cm}{scalable}%
+\gre@createdim{skip}{interwordspacetext@euouae}{0.21 cm plus 0.1 cm minus 0.05 cm}{scalable}%
 % versions of note spaces when the first note of the second syllable is an alteration
 % those are used in euouae blocks
-\gre@createdim{interwordspacenotes@alteration}{0.1 cm plus 0.07 cm minus 0.01 cm}{scalable}%
-\gre@createdim{intersyllablespacenotes@alteration}{0.1 cm}{scalable}%
+\gre@createdim{skip}{interwordspacenotes@alteration}{0.1 cm plus 0.07 cm minus 0.01 cm}{scalable}%
+\gre@createdim{dimen}{intersyllablespacenotes@alteration}{0.1 cm}{scalable}%
 % space between notes of a bivirga or trivirga
-\gre@createdim{bitrivirspace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scalable}%
+\gre@createdim{skip}{bitrivirspace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scalable}%
 % space between notes of a bistropha or tristrophae
-\gre@createdim{bitristrospace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scalable}%
+\gre@createdim{skip}{bitristrospace}{0.06927 cm plus 0.00182 cm minus 0.00546 cm}{scalable}%
 %
 %%%%%%%%%%%%%%%%%%%%
 % puncta inclinata %
 %%%%%%%%%%%%%%%%%%%%
 %
 % space between two descending punctum inclinatum
-\gre@createdim{punctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{punctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between two descending or ascending punctum inclinatum at the unison
-\gre@createdim{punctuminclinatumunisonshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
+\gre@createdim{skip}{punctuminclinatumunisonshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 % space before descending puncta inclinata
-\gre@createdim{beforepunctainclinatashift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
+\gre@createdim{skip}{beforepunctainclinatashift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 % space between a descending punctum inclinatum and a punctum inclinatum deminutus
-\gre@createdim{punctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{punctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between two punctum inclinatum deminutus
-\gre@createdim{punctuminclinatumdebilisshift}{-0.00728 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{punctuminclinatumdebilisshift}{-0.00728 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between descending puncta inclinata, larger ambitus (range=3rd)
-\gre@createdim{punctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{punctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between descending puncta inclinata, larger ambitus (range=4th or 5th)
-\gre@createdim{punctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{punctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between two ascending punctum inclinatum
-\gre@createdim{ascendingpunctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{ascendingpunctuminclinatumshift}{-0.03918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between a punctum inclinatum and a punctum inclinatum deminutus, ascending
-\gre@createdim{ascendingpunctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{ascendingpunctuminclinatumanddebilisshift}{-0.02278 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between ascending puncta inclinata, larger ambitus (range=3rd)
-\gre@createdim{ascendingpunctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{ascendingpunctuminclinatumbigshift}{0.07565 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between ascending puncta inclinata, larger ambitus (range=4th or 5th)
-\gre@createdim{ascendingpunctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{ascendingpunctuminclinatummaxshift}{0.17865 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between a punctum inclinatum and a no-bar glyph one pitch below
-\gre@createdim{descendinginclinatumtonobarshift}{-0.00073 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{descendinginclinatumtonobarshift}{-0.00073 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between a punctum inclinatum and a no-bar glyph two pitches below
-\gre@createdim{descendinginclinatumtonobarbigshift}{0.10927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{descendinginclinatumtonobarbigshift}{0.10927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between a punctum inclinatum and a no-bar glyph three or four pitches below
-\gre@createdim{descendinginclinatumtonobarmaxshift}{0.23927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{descendinginclinatumtonobarmaxshift}{0.23927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between a punctum inclinatum and a no-bar glyph one pitch above
-\gre@createdim{ascendinginclinatumtonobarshift}{-0.02473 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{ascendinginclinatumtonobarshift}{-0.02473 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between a punctum inclinatum and a no-bar glyph two pitches above
-\gre@createdim{ascendinginclinatumtonobarbigshift}{0.04427 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{ascendinginclinatumtonobarbigshift}{0.04427 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between a punctum inclinatum and a no-bar glyph three or four pitches above
-\gre@createdim{ascendinginclinatumtonobarmaxshift}{0.12927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
+\gre@createdim{skip}{ascendinginclinatumtonobarmaxshift}{0.12927 cm plus 0.00363 cm minus 0.00363 cm}{scalable}%
 % space between two descending punctum inclinatum glyphs in an ascent
-\gre@createdim{descendingpunctuminclinatumascendingshift}{-0.07918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{descendingpunctuminclinatumascendingshift}{-0.07918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between two ascending punctum inclinatum glyphs in an descent
-\gre@createdim{ascendingpunctuminclinatumdescendingshift}{-0.07918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{ascendingpunctuminclinatumdescendingshift}{-0.07918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between two unison punctum inclinatum glyphs (at the unison)
-\gre@createdim{uprightpunctuminclinatumshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
+\gre@createdim{skip}{uprightpunctuminclinatumshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 
 %
 %%%%%%%%
@@ -219,129 +219,129 @@
 % bars inside syllables
 %
 % short versions are when the notes are very low (virgula, minima, and minimis only)
-\gre@createdim{bar@virgula}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@virgula@short}{0.13 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@virgulaparen}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@virgulaparen@short}{0.13 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@minimis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@minimis@short}{0.12 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@minima}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@minima@short}{0.12 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@minimaparen}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@minimaparen@short}{0.12 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@minor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@virgula}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@virgula@short}{0.13 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@virgulaparen}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@virgulaparen@short}{0.13 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@minimis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@minimis@short}{0.12 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@minima}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@minima@short}{0.12 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@minimaparen}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@minimaparen@short}{0.12 cm plus 0.05 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@minor}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 % dominican bars
-\gre@createdim{bar@dominican}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@maior}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
-\gre@createdim{bar@finalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@dominican}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@maior}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
+\gre@createdim{skip}{bar@finalis}{0.1823 cm plus 0.22787 cm minus 0.00469 cm}{scalable}%
 % space added before the final divisio finalis (old bar spacing algorithm only)
-\gre@createdim{bar@finalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{scalable}%
+\gre@createdim{skip}{bar@finalfinalis}{0.29169 cm plus 0.07292 cm minus 0.27345 cm}{scalable}%
 %
 % bars having their own syllable, with text associated (new bar spacing algorithm only)
 % plus or minus here will trigger some problems
 %
-\gre@createdim{bar@virgula@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@virgula@standalone@text@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@minimis@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@minimis@standalone@text@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@virgulaparen@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@virgulaparen@standalone@text@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@minima@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@minima@standalone@text@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@minor@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@dominican@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@maior@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@finalis@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@minimaparen@standalone@text}{0.2323 cm}{scalable}%
-\gre@createdim{bar@minimaparen@standalone@text@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@virgula@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@virgula@standalone@text@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@minimis@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@minimis@standalone@text@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@virgulaparen@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@virgulaparen@standalone@text@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@minima@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@minima@standalone@text@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@minor@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@dominican@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@maior@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@finalis@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@minimaparen@standalone@text}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@minimaparen@standalone@text@short}{0.19 cm}{scalable}%
 % actual space before divisio finalis, not additional one
-\gre@createdim{bar@finalfinalis@standalone@text}{0.29169 cm}{scalable}%
+\gre@createdim{skip}{bar@finalfinalis@standalone@text}{0.29169 cm}{scalable}%
 %
 % bars having their own syllable, with no text associated (new bar spacing algorithm only)
 %
-\gre@createdim{bar@virgula@standalone@notext}{0.2 cm}{scalable}%
-\gre@createdim{bar@virgula@standalone@notext@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@minimis@standalone@notext}{0.2 cm}{scalable}%
-\gre@createdim{bar@minimis@standalone@notext@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@virgulaparen@standalone@notext}{0.2 cm}{scalable}%
-\gre@createdim{bar@virgulaparen@standalone@notext@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@minima@standalone@notext}{0.2 cm}{scalable}%
-\gre@createdim{bar@minima@standalone@notext@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@minor@standalone@notext}{0.2323 cm}{scalable}%
-\gre@createdim{bar@dominican@standalone@notext}{0.2323 cm}{scalable}%
-\gre@createdim{bar@maior@standalone@notext}{0.2323 cm}{scalable}%
-\gre@createdim{bar@finalis@standalone@notext}{0.2323 cm}{scalable}%
-\gre@createdim{bar@minimaparen@standalone@notext}{0.2 cm}{scalable}%
-\gre@createdim{bar@minimaparen@standalone@notext@short}{0.19 cm}{scalable}%
-\gre@createdim{bar@finalfinalis@standalone@notext}{0.29169 cm}{scalable}%
+\gre@createdim{skip}{bar@virgula@standalone@notext}{0.2 cm}{scalable}%
+\gre@createdim{skip}{bar@virgula@standalone@notext@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@minimis@standalone@notext}{0.2 cm}{scalable}%
+\gre@createdim{skip}{bar@minimis@standalone@notext@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@virgulaparen@standalone@notext}{0.2 cm}{scalable}%
+\gre@createdim{skip}{bar@virgulaparen@standalone@notext@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@minima@standalone@notext}{0.2 cm}{scalable}%
+\gre@createdim{skip}{bar@minima@standalone@notext@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@minor@standalone@notext}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@dominican@standalone@notext}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@maior@standalone@notext}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@finalis@standalone@notext}{0.2323 cm}{scalable}%
+\gre@createdim{skip}{bar@minimaparen@standalone@notext}{0.2 cm}{scalable}%
+\gre@createdim{skip}{bar@minimaparen@standalone@notext@short}{0.19 cm}{scalable}%
+\gre@createdim{skip}{bar@finalfinalis@standalone@notext}{0.29169 cm}{scalable}%
 %
 % minimal space between letters of different syllable texts for text around bars
 % (new bar spacing algorithm only)
-\gre@createdim{interwordspacetext@bars}{0.18 cm}{scalable}%
+\gre@createdim{dimen}{interwordspacetext@bars}{0.18 cm}{scalable}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\gre@createdim{interwordspacetext@bars@euouae}{0.18 cm}{scalable}%
-\gre@createdim{interwordspacetext@bars@notext}{0.19 cm}{scalable}%
+\gre@createdim{dimen}{interwordspacetext@bars@euouae}{0.18 cm}{scalable}%
+\gre@createdim{dimen}{interwordspacetext@bars@notext}{0.19 cm}{scalable}%
 % minimal space between letters of different syllable texts for text around bars,
 % euouae context
-\gre@createdim{interwordspacetext@bars@notext@euouae}{0.18 cm}{scalable}%
+\gre@createdim{dimen}{interwordspacetext@bars@notext@euouae}{0.18 cm}{scalable}%
 % rubber length that will be added around bars in new bar spacing algorithm
-\gre@createdim{bar@rubber}{0 cm plus 0.025 cm minus 0.025 cm}{scalable}%
+\gre@createdim{skip}{bar@rubber}{0 cm plus 0.025 cm minus 0.025 cm}{scalable}%
 % in the case of an alteration after a bar, the alteration will "protrude" left of this value
 % think of it as some kind of moraadjustmentbar
-\gre@createdim{alterationadjustmentbar}{0.07 cm}{scalable}%
+\gre@createdim{dimen}{alterationadjustmentbar}{0.07 cm}{scalable}%
 % additional space that will appear around bars that are preceded by a custos and followed by a key.
-\gre@createdim{spacearoundclefbars}{0.03645 cm plus 0.00455 cm minus 0.0009 cm}{scalable}%
+\gre@createdim{skip}{spacearoundclefbars}{0.03645 cm plus 0.00455 cm minus 0.0009 cm}{scalable}%
 % space between the text of previous syllable and text associated with a bar (old bar spacing algorithm only)
-\gre@createdim{textbartextspace}{0.24611 cm plus 0.13672 cm minus 0.04921 cm}{scalable}%
+\gre@createdim{skip}{textbartextspace}{0.24611 cm plus 0.13672 cm minus 0.04921 cm}{scalable}%
 % minimal space between a note and a bar (old algorithm only)
-\gre@createdim{notebarspace}{0.31903 cm plus 0.27345 cm minus 0.02824 cm}{scalable}%
+\gre@createdim{skip}{notebarspace}{0.31903 cm plus 0.27345 cm minus 0.02824 cm}{scalable}%
 % Maximum offset between a bar and its associated text when the text goes left of the bar (new bar spacing algorithm only)
-\gre@createdim{maxbaroffsettextleft}{0.3 cm}{scalable}%
+\gre@createdim{dimen}{maxbaroffsettextleft}{0.3 cm}{scalable}%
 % Same as maxbaroffsettextleft when text goes right of the bar
-\gre@createdim{maxbaroffsettextright}{0.15 cm}{scalable}%
+\gre@createdim{dimen}{maxbaroffsettextright}{0.15 cm}{scalable}%
 % Maximum offset between a no-bar (i.e. something like `text()` in gabc) and its associated text when the text goes left of the no-bar (new bar spacing algorithm only)
-\gre@createdim{maxbaroffsettextleft@nobar}{12 cm}{scalable}%
+\gre@createdim{dimen}{maxbaroffsettextleft@nobar}{12 cm}{scalable}%
 % Same as maxbaroffsettextleft@nobar when text goes right of the no-bar
-\gre@createdim{maxbaroffsettextright@nobar}{12 cm}{scalable}%
+\gre@createdim{dimen}{maxbaroffsettextright@nobar}{12 cm}{scalable}%
 % Space between the two bars of a divisio finalis
 % Maximum offset between a bar and its associated text when the text goes left of the bar and the bar terminates a line (i.e. something line `text(::z)` in gabc) (new bar spacing algorithm only)
-\gre@createdim{maxbaroffsettextleft@eol}{0.0 cm}{scalable}%
+\gre@createdim{dimen}{maxbaroffsettextleft@eol}{0.0 cm}{scalable}%
 % Same as maxbaroffsettextleft@eol when text goes right of the bar
-\gre@createdim{maxbaroffsettextright@eol}{0 cm}{scalable}%
-\gre@createdim{divisiofinalissep}{0.1094 cm}{scalable}%
+\gre@createdim{dimen}{maxbaroffsettextright@eol}{0 cm}{scalable}%
+\gre@createdim{dimen}{divisiofinalissep}{0.1094 cm}{scalable}%
 %
 %
 % maximal space between two syllables for which we consider a dash is not needed
-\gre@createdim{maximumspacewithoutdash}{0 cm}{scalable}%
+\gre@createdim{dimen}{maximumspacewithoutdash}{0 cm}{scalable}%
 % an extensible space for the beginning of lines
-\gre@createdim{afterclefnospace}{0 cm plus 0.27345 cm minus 0 cm}{scalable}%
+\gre@createdim{skip}{afterclefnospace}{0 cm plus 0.27345 cm minus 0 cm}{scalable}%
 % space between the initial and the beginning of the score
-\gre@createdim{afterinitialshift}{0.2 cm}{scalable}%
+\gre@createdim{dimen}{afterinitialshift}{0.2 cm}{scalable}%
 % space before the initial
-\gre@createdim{beforeinitialshift}{0.2 cm}{scalable}%
+\gre@createdim{dimen}{beforeinitialshift}{0.2 cm}{scalable}%
 % when bolshifts are enabled, minimum space between beginning of line and first syllable text
-\gre@createdim{minimalspaceatlinebeginning}{0.05 cm}{scalable}%
+\gre@createdim{dimen}{minimalspaceatlinebeginning}{0.05 cm}{scalable}%
 % space to force the initial width to.  Ignored when 0.
-\gre@createdim{manualinitialwidth}{0 cm}{scalable}%
+\gre@createdim{dimen}{manualinitialwidth}{0 cm}{scalable}%
 % minimum width of the initial.  Ignored when manualinitialwidth is non-zero.
-\gre@createdim{minimalinitialwidth}{0 cm}{scalable}%
+\gre@createdim{dimen}{minimalinitialwidth}{0 cm}{scalable}%
 % distance to move the initial up by
-\gre@createdim{initialraise}{0 cm}{scalable}%
+\gre@createdim{dimen}{initialraise}{0 cm}{scalable}%
 % Space between lines in the annotation
-\gre@createdim{annotationseparation}{0.05 cm}{scalable}%
+\gre@createdim{dimen}{annotationseparation}{0.05 cm}{scalable}%
 % Amount to raise (positive) or lower (negative) the annotations from the default position
-\gre@createdim{annotationraise}{-0.2 cm}{scalable}%
+\gre@createdim{dimen}{annotationraise}{-0.2 cm}{scalable}%
 % Space between lines in the commentary
-\gre@createdim{commentaryseparation}{0.05 cm}{scalable}%
+\gre@createdim{dimen}{commentaryseparation}{0.05 cm}{scalable}%
 % Amount to raise (positive) or lower (negative) the commentary from the default position (base line of bottom commentary aligned with top line of staff)
-\gre@createdim{commentaryraise}{0.17351 cm}{scalable}%
+\gre@createdim{dimen}{commentaryraise}{0.17351 cm}{scalable}%
 % space at the beginning of the lines if there is no clef
-\gre@createdim{noclefspace}{0.1 cm}{scalable}%
+\gre@createdim{dimen}{noclefspace}{0.1 cm}{scalable}%
 % space around a clef change
-\gre@createdim{clefchangespace}{0.27345 cm plus 0.14584 cm minus 0.01367 cm}{scalable}%
+\gre@createdim{skip}{clefchangespace}{0.27345 cm plus 0.14584 cm minus 0.01367 cm}{scalable}%
 % When \gre@clivisalignment is 2, this distance is the maximum length of the consonants after vowels for which the clivis will be aligned on its center.
-\gre@createdim{clivisalignmentmin}{0.3 cm}{scalable}%
+\gre@createdim{dimen}{clivisalignmentmin}{0.3 cm}{scalable}%
 
 %%%%%%%%%%%%%%%%%%
 % vertical spaces
@@ -352,15 +352,15 @@
 %     it's on a line or in a space
 % (b) high choral signs and low choral signs that are lower than the note which
 %     are in a space
-\gre@createdim{choralsigndownshift}{0.00911 cm}{scalable}%
+\gre@createdim{dimen}{choralsigndownshift}{0.00911 cm}{scalable}%
 % the amount to shift up:
 % (a) high choral signs and low choral signs that are lower than the note which
 %     are on a line
-\gre@createdim{choralsignupshift}{0.04556 cm}{scalable}%
+\gre@createdim{dimen}{choralsignupshift}{0.04556 cm}{scalable}%
 % the space for the translation
-\gre@createdim{translationheight}{0.5 cm}{scalable}%
+\gre@createdim{dimen}{translationheight}{0.5 cm}{scalable}%
 %the space above the lines
-\gre@createdim{spaceabovelines}{0 cm}{scalable}%
+\gre@createdim{skip}{spaceabovelines}{0 cm}{scalable}%
 % this counter is the threshold above which we start accounting notes above
 % lines for additional space above lines. For instance with a threshold of
 % 2 and a staff of 4 lines, notes with a pitch of k and l will not interfere
@@ -371,64 +371,64 @@
 % same, for notes taken into account for nabc vertical position
 \grechangecount{additionaltopspacenabcthreshold}{4}%
 %the space between the lines and the bottom of the text
-\gre@createdim{spacelinestext}{3.48471ex}{fixed}%
+\gre@createdim{dimen}{spacelinestext}{3.48471ex}{fixed}%
 %the per-note additional space between lines and the bottom of the text
-\gre@createdim{noteadditionalspacelinestext}{0.14413 cm}{scalable}%
+\gre@createdim{dimen}{noteadditionalspacelinestext}{0.14413 cm}{scalable}%
 % this counter is the number of low notes which will add on the
 % noteadditionalspacelinestext.  For instance, with a threshold of 2, every
 % note below c will add noteadditionalspacelinestext space for each pitch needed
 % below c, accounting for the various signs.
 \grechangecount{noteadditionalspacelinestextthreshold}{2}%
 %the space beneath the text
-\gre@createdim{spacebeneathtext}{0 cm}{scalable}%
+\gre@createdim{dimen}{spacebeneathtext}{0 cm}{scalable}%
 % height of the text above the note line
-\gre@createdim{abovelinestextraise}{0.17351 cm}{scalable}%
+\gre@createdim{dimen}{abovelinestextraise}{0.17351 cm}{scalable}%
 % height that is added at the top of the lines if there is text above the lines (it must be bigger than the text for it to be taken into consideration)
-\gre@createdim{abovelinestextheight}{0.3 cm}{scalable}%
+\gre@createdim{dimen}{abovelinestextheight}{0.3 cm}{scalable}%
 % an additional shift you can give to the brace above the bars if you don't like it
-\gre@createdim{braceshift}{0 cm}{scalable}%
+\gre@createdim{dimen}{braceshift}{0 cm}{scalable}%
 % a shift you can give to the accentus above the curly brace
-\gre@createdim{curlybraceaccentusshift}{-0.05 cm}{scalable}%
+\gre@createdim{dimen}{curlybraceaccentusshift}{-0.05 cm}{scalable}%
 % the amount to shift the over slur up
-\gre@createdim{overslurshift}{0.05000 cm}{scalable}%
+\gre@createdim{dimen}{overslurshift}{0.05000 cm}{scalable}%
 % the amount to shift the under slur up
-\gre@createdim{underslurshift}{0.01000 cm}{scalable}%
+\gre@createdim{dimen}{underslurshift}{0.01000 cm}{scalable}%
 % shift for a horizontal episema over a note in a low position in the space
-\gre@createdim{overhepisemalowshift}{0.02287 cm}{scalable}%
+\gre@createdim{dimen}{overhepisemalowshift}{0.02287 cm}{scalable}%
 % shift for a horizontal episema over a note in a high position in the space
-\gre@createdim{overhepisemahighshift}{0.10066 cm}{scalable}%
+\gre@createdim{dimen}{overhepisemahighshift}{0.10066 cm}{scalable}%
 % shift for a horizontal episema under a note in a low position in the space
-\gre@createdim{underhepisemalowshift}{0.02763 cm}{scalable}%
+\gre@createdim{dimen}{underhepisemalowshift}{0.02763 cm}{scalable}%
 % shift for a horizontal episema under a note in a high position in the space
-\gre@createdim{underhepisemahighshift}{0.10981 cm}{scalable}%
+\gre@createdim{dimen}{underhepisemahighshift}{0.10981 cm}{scalable}%
 % shift for a horizontal episema in the middle of a space
-\gre@createdim{hepisemamiddleshift}{0.07206 cm}{scalable}%
+\gre@createdim{dimen}{hepisemamiddleshift}{0.07206 cm}{scalable}%
 % shift for a vertical episema in a low position in the space
-\gre@createdim{vepisemalowshift}{-0.01262 cm}{scalable}%
+\gre@createdim{dimen}{vepisemalowshift}{-0.01262 cm}{scalable}%
 % shift for a vertical episema in a high position in the space
-\gre@createdim{vepisemahighshift}{0.06634 cm}{scalable}%
+\gre@createdim{dimen}{vepisemahighshift}{0.06634 cm}{scalable}%
 % shift for a punctum mora for a note on a line
-\gre@createdim{linepunctummorashift}{-0.06314 cm}{scalable}%
+\gre@createdim{dimen}{linepunctummorashift}{-0.06314 cm}{scalable}%
 % shift for a punctum mora for a note in a space
-\gre@createdim{spacepunctummorashift}{-0.02013 cm}{scalable}%
+\gre@createdim{dimen}{spacepunctummorashift}{-0.02013 cm}{scalable}%
 % shift for a punctum mora for the second note (in a space) of a pes with ambitus one
-\gre@createdim{spaceamonepespunctummorashift}{0.00183 cm}{scalable}%
+\gre@createdim{dimen}{spaceamonepespunctummorashift}{0.00183 cm}{scalable}%
 % shift for a punctum mora for the second note in a porrectus, on a line
-\gre@createdim{lineporrectuspunctummorashift}{0.04575 cm}{scalable}%
+\gre@createdim{dimen}{lineporrectuspunctummorashift}{0.04575 cm}{scalable}%
 % shift for a punctum mora for the second note in a porrectus, in a space
-\gre@createdim{spaceporrectuspunctummorashift}{0.00000 cm}{scalable}%
+\gre@createdim{dimen}{spaceporrectuspunctummorashift}{0.00000 cm}{scalable}%
 % shift for a rare sign
-\gre@createdim{raresignshift}{0.18302 cm}{scalable}%
+\gre@createdim{dimen}{raresignshift}{0.18302 cm}{scalable}%
 % up-shift for a bracket
-\gre@createdim{bracketupshift}{0.03000 cm}{scalable}%
+\gre@createdim{dimen}{bracketupshift}{0.03000 cm}{scalable}%
 % down-shift for a bracket
-\gre@createdim{bracketdownshift}{0.04000 cm}{scalable}%
+\gre@createdim{dimen}{bracketdownshift}{0.04000 cm}{scalable}%
 %
 
 %%%%%%%%%%
 %% Line spacings
 %%%%%%%%%%
-\gre@createdim{parskip}{1pt plus 1pt}{scalable}%
-\gre@createdim{lineskip}{0pt plus 1pt}{scalable}%
-\gre@createdim{baselineskip}{55pt plus 5pt minus 5pt}{scalable}%
-\gre@createdim{lineskiplimit}{0pt}{scalable}%
+\gre@createdim{skip}{parskip}{1pt plus 1pt}{scalable}%
+\gre@createdim{skip}{lineskip}{0pt plus 1pt}{scalable}%
+\gre@createdim{skip}{baselineskip}{55pt plus 5pt minus 5pt}{scalable}%
+\gre@createdim{skip}{lineskiplimit}{0pt}{scalable}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1448,7 +1448,7 @@
   \fi
 }
 
-% a macro for changing a dimension.  Unlike \grecreatedim, this function won’t create a new distance, just change an existing one.
+% a macro for changing a dimension.  Unlike \gre@createdim, this function won’t create a new distance, just change an existing one.
 \def\grechangedim#1#2#3{%
   \edef\gre@prefix{\gre@getprefix{#1}}%
   \ifcsname gre@space@\gre@prefix @#1\endcsname%
@@ -1494,7 +1494,7 @@
   ]% DEPRECATED
 }
 
-% The common internals for \grecreatedim and \grechangedim.
+% The common internals for \gre@createdim and \grechangedim.
 \newif\ifgre@checklength%
 \def\gre@dimension#1#2#3#4{%
   \gre@trace{gre@dimension{#1}{#2}{#3}{#4}}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1404,38 +1404,54 @@
 %% dimension changing macros
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% This macro creates one dim (#1), setting its value to #2 and sets whether it should scale when the \gre@factor changes (#3, scalable or fixed).  Checks that #1 can accept the kind of distance given in #2.
-%% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
-\newif\ifgre@checklength%
-\def\gre@createdim#1#2#3{%
-  \csname newif\expandafter\endcsname\csname ifgre@scale@#1\endcsname%
-  \IfStrEqCase{#3}{%
+% \gre@createdim#1#2#3#4
+% Create a new dim.
+%
+% #1: 'dimen' (no glue allowed) or 'skip' (glue allowed)
+% #2: name of the new dim
+% #3: initial value of the new dim
+% #4: whether it should scale when the \gre@factor changes ('scalable') or not ('fixed') or inherits its value from another dim ('inherited').
+% Checks that #1 can accept the kind of distance given in #2.
+% Note: the distances created by this function are stored as strings, not skip or dimension registers.  This allows the user to specify a distance in em or ex units even though the font parameters may not be the same at the time the distance is specified and the time the distance is used.
+\def\gre@createdim#1#2#3#4{%
+  \IfStrEqCase{#1}{%
+    {dimen}{}%
+    {skip}{}%
+  }[% all other cases
+      \gre@error{Unrecognized option "#1" for \protect\gre@createdim\MessageBreak Possible options are: 'dimen' or 'skip'}%
+  ]%
+  \csname newif\expandafter\endcsname\csname ifgre@scale@#2\endcsname%
+  \IfStrEqCase{#4}{%
     {scalable}%
-      {\grescaledim{#1}{true}}%
+      {\grescaledim{#2}{true}}%
     {fixed}%
-      {\grescaledim{#1}{false}}%
+      {\grescaledim{#2}{false}}%
     {inherited}%
-      {\grescaledim{#1}{false}}%
+      {\grescaledim{#2}{false}}%
     }[% all other cases
-      \gre@error{Unrecognized option "#3" for \protect\gre@createdim\MessageBreak Possible options are: 'scalable' and 'fixed' and 'inherited'}%
+      \gre@error{Unrecognized option "#4" for \protect\gre@createdim\MessageBreak Possible options are: 'scalable' and 'fixed' and 'inherited'}%
     ]%
-  \gre@dimension{#1}{#2}{#3}%
+  \gre@dimension{#1}{#2}{#3}{#4}%
 }%
 
+% \gre@getprefix#1
+% If dim #1 allows glue, expands to 'skip'; otherwise, expands to 'dimen'.
+\def\gre@getprefix#1{%
+  \ifcsname gre@space@dimen@#1\endcsname
+    dimen%
+  \else
+    \ifcsname gre@space@skip@#1\endcsname
+      skip%
+    \else
+      ERROR%
+    \fi
+  \fi
+}
 
 % a macro for changing a dimension.  Unlike \grecreatedim, this function won’t create a new distance, just change an existing one.
 \def\grechangedim#1#2#3{%
-  \gre@rubberpermit{#1}%
-  % figure out our prefix
-  \ifgre@rubber%
-    \gre@debugmsg{spacing}{Changing a skip.}%
-    \def\gre@prefix{skip}%
-  \else%
-    \gre@debugmsg{spacing}{Changing a dimen.}%
-    \def\gre@prefix{dimen}%
-  \fi%
+  \edef\gre@prefix{\gre@getprefix{#1}}%
   \ifcsname gre@space@\gre@prefix @#1\endcsname%
-    \gre@debugmsg{spacing}{It does exist.}%
     \IfStrEqCase{#3}{%
       {scalable}%
         {\grescaledim{#1}{true}}%
@@ -1443,12 +1459,7 @@
         {\grescaledim{#1}{false}}%
       {inherited}%
         {%
-          \gre@rubberpermit{#2}%
-          \ifgre@rubber%
-            \def\gre@prefixII{skip}%
-          \else%
-            \def\gre@prefixII{dimen}%
-          \fi%
+          \edef\gre@prefixII{\gre@getprefix{#2}}%
           \ifcsname gre@space@\gre@prefixII @#2\endcsname%
             \grescaledim{#1}{false}%
           \else%
@@ -1457,7 +1468,7 @@
         }%
       % all other cases
       }[\gre@error{Unrecognized option "#3" for \protect\grechangedim\MessageBreak Possible options are: 'scalable', 'fixed', and 'inherited'}]%
-    \gre@dimension{#1}{#2}{#3}%
+    \gre@dimension{\gre@prefix}{#1}{#2}{#3}%
     %If we are calling grechangedim from a space configuration file (greconffactor is not 0)
     % and the space configuration file is designed for a \gre@factor other than the current
     % one, then we need to rescale the distance being changed.
@@ -1467,7 +1478,7 @@
       \fi%
     \fi%
   \else%
-    \gre@error{#1 is not a recognized distance.}%
+    \gre@error{"#1" is not a recognized distance.}%
   \fi%
 }%
 
@@ -1484,58 +1495,33 @@
 }
 
 % The common internals for \grecreatedim and \grechangedim.
-\def\gre@dimension#1#2#3{%
-  \gre@trace{gre@dimension{#1}{#2}{#3}}%
-  \IfStrEq{#3}{inherited}{%
+\newif\ifgre@checklength%
+\def\gre@dimension#1#2#3#4{%
+  \gre@trace{gre@dimension{#1}{#2}{#3}{#4}}%
+  \edef\gre@prefix{#1}%
+  \IfStrEq{#4}{inherited}{%
     \gre@debugmsg{spacing}{setting inherited distance}%
-    \gre@rubberpermit{#1}%
-    \ifgre@rubber%
-      \def\gre@prefix{skip}%
-    \else%
-      \def\gre@prefix{dimen}%
-    \fi%
-    \gre@rubberpermit{#2}%
-    \ifgre@rubber%
-      \def\gre@prefixII{skip}%
-    \else%
-      \def\gre@prefixII{dimen}%
-    \fi%
-    \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{\expandafter\unexpanded{\csname gre@space@\gre@prefixII @#2\endcsname}}%
+    \edef\gre@prefixII{\gre@getprefix{#3}}%
+    \expandafter\edef\csname gre@space@\gre@prefix @#2\endcsname{\expandafter\unexpanded{\csname gre@space@\gre@prefixII @#3\endcsname}}%
   }{%
-    \gre@rubberpermit{#2}%
-    \ifgre@rubber%
-      \def\gre@prefixII{skip}%
-    \else%
-      \def\gre@prefixII{dimen}%
-    \fi%
-    \ifcsname gre@space@\gre@prefixII @#2\endcsname%
-      \gre@error{'#1' cannot be '#3' and depend on '#2' at the same time\MessageBreak Either use 'inherited' in the third argument\MessageBreak or give an actual distance in the second}%
+    \edef\gre@prefixII{\gre@getprefix{#3}}%
+    \ifcsname gre@space@\gre@prefixII @#3\endcsname%
+      \gre@error{'#2' cannot be '#4' and depend on '#3' at the same time\MessageBreak Either use 'inherited' in the fourth argument\MessageBreak or give an actual distance in the third}%
     \fi%
     \gre@checklengthfalse%
-    %check if #2 is a rubber length (contains plus and/or minus)
-    \IfSubStr{#2}{plus}{\gre@checklengthtrue}{\relax}%
-    \IfSubStr{#2}{minus}{\gre@checklengthtrue}{\relax}%
-    %if #1 is one of the distances which cannot be rubber.
-    \gre@rubberpermit{#1}%
-    % do we try to assign a rubber to one where it's not permitted?
-    \ifgre@rubber%
-      \def\gre@prefix{skip}%
-    \else%
-      \ifgre@checklength%
-        \gre@error{#1 cannot be a rubber length.}%
-      \else%
-        \def\gre@prefix{dimen}%
-      \fi%
-    \fi%
+    %check if #3 is a rubber length (contains plus and/or minus)
+    \IfSubStr{#3}{plus}{\gre@checklengthtrue}{\relax}%
+    \IfSubStr{#3}{minus}{\gre@checklengthtrue}{\relax}%
+    %if #2 is one of the distances which cannot be rubber.
     % special check for bar@rubber
-    \IfStrEq*{#1}{bar@rubber}%
+    \IfStrEq*{#2}{bar@rubber}%
       {%
-        \gre@skip@temp@one = #2\relax%
+        \gre@skip@temp@one = #3\relax%
         \ifdim\gre@skip@temp@one=0pt\relax\else%
           \gre@error{bar@rubber cannot have a non-zero base}%
         \fi%
       }{}%
-    \expandafter\edef\csname gre@space@\gre@prefix @#1\endcsname{#2}%
+    \expandafter\edef\csname gre@space@\gre@prefix @#2\endcsname{#3}%
     \relax %
   }%
   \gre@trace@end%
@@ -1566,12 +1552,7 @@
 % used in Lua.
 % #1: name of dim
 \def\gre@luasavedim#1{%
-  \gre@rubberpermit{#1}%
-  \ifgre@rubber%
-    \def\gre@prefix{skip}%
-  \else%
-    \def\gre@prefix{dimen}%
-  \fi%
+  \edef\gre@prefix{\gre@getprefix{#1}}%
   \directlua{%
     gregoriotex.save_dim(%
       "\luatexluaescapestring{#1}",%
@@ -1587,12 +1568,7 @@
     \gre@error{Unrecognized option "#2" for \protect\grechangenextscorelinedim\MessageBreak Possible options are: 'abovelinestextheight', 'abovelinestextraise', 'spaceabovelines', 'spacelinestext', 'noteadditionalspacelinestext', 'translationheight', 'spacebeneathtext'}%
   ]%
   {\grechangedim{#2}{#3}{#4}%
-   \gre@rubberpermit{#2}%
-   \ifgre@rubber%
-     \def\gre@prefix{skip}%
-   \else%
-     \def\gre@prefix{dimen}%
-   \fi%
+   \edef\gre@prefix{\gre@getprefix{#2}}%
    \directlua{%
      gregoriotex.change_next_score_line_dim(%
        "\luatexluaescapestring{#1}",%
@@ -1670,96 +1646,26 @@
 %% Rescaling dimensions (for when \gre@factor changes)
 %%%%%%%%%%%%%%
 
-% This function checks to see if the length is one of the ones which cannot be a rubber length.  The assumption is that any length not listed here is allowed to be rubber.
-\newif\ifgre@rubber%
-\def\gre@rubberpermit#1{%
-  \gre@trace{gre@rubberpermit{#1}}%
-  % is length one that cannot be rubber?
-  \IfStrEqCase*{#1}{%
-    {additionallineswidth}{\gre@rubberfalse}%
-    {additionalcustoslineswidth}{\gre@rubberfalse}%
-    {zerowidthspace}{\gre@rubberfalse}%
-    {maximumspacewithoutdash}{\gre@rubberfalse}%
-    {afterinitialshift}{\gre@rubberfalse}%
-    {beforeinitialshift}{\gre@rubberfalse}%
-    {minimalspaceatlinebeginning}{\gre@rubberfalse}%
-    {manualinitialwidth}{\gre@rubberfalse}%
-    {minimalinitialwidth}{\gre@rubberfalse}%
-    {annotationseparation}{\gre@rubberfalse}%
-    {intersyllablespacenotes}{\gre@rubberfalse}%
-    {intersyllablespacenotes@alteration}{\gre@rubberfalse}%
-    {annotationraise}{\gre@rubberfalse}%
-    {commentaryseparation}{\gre@rubberfalse}%
-    {commentaryraise}{\gre@rubberfalse}%
-    {noclefspace}{\gre@rubberfalse}%
-    {clivisalignmentmin}{\gre@rubberfalse}%
-    {choralsigndownshift}{\gre@rubberfalse}%
-    {choralsignupshift}{\gre@rubberfalse}%
-    {translationheight}{\gre@rubberfalse}%
-    {spacelinestext}{\gre@rubberfalse}%
-    {spacebeneathtext}{\gre@rubberfalse}%
-    {abovelinestextraise}{\gre@rubberfalse}%
-    {abovelinestextheight}{\gre@rubberfalse}%
-    {braceshift}{\gre@rubberfalse}%
-    {curlybraceaccentusshift}{\gre@rubberfalse}%
-    {initialraise}{\gre@rubberfalse}%
-    {beforealterationspace}{\gre@rubberfalse}%
-    {alterationspace}{\gre@rubberfalse}%
-    {overslurshift}{\gre@rubberfalse}%
-    {underslurshift}{\gre@rubberfalse}%
-    {maxbaroffsettextleft}{\gre@rubberfalse}%
-    {maxbaroffsettextright}{\gre@rubberfalse}%
-    {maxbaroffsettextleft@nobar}{\gre@rubberfalse}%
-    {maxbaroffsettextright@nobar}{\gre@rubberfalse}%
-    {maxbaroffsettextleft@eol}{\gre@rubberfalse}%
-    {maxbaroffsettextright@eol}{\gre@rubberfalse}%
-    {interwordspacetext@bars@euouae}{\gre@rubberfalse}%
-    {interwordspacetext@bars}{\gre@rubberfalse}%
-    {interwordspacetext@bars@notext@euouae}{\gre@rubberfalse}%
-    {interwordspacetext@bars@notext}{\gre@rubberfalse}%
-    {overhepisemalowshift}{\gre@rubberfalse}%
-    {overhepisemahighshift}{\gre@rubberfalse}%
-    {underhepisemalowshift}{\gre@rubberfalse}%
-    {underhepisemahighshift}{\gre@rubberfalse}%
-    {hepisemamiddleshift}{\gre@rubberfalse}%
-    {vepisemalowshift}{\gre@rubberfalse}%
-    {vepisemahighshift}{\gre@rubberfalse}%
-    {linepunctummorashift}{\gre@rubberfalse}%
-    {spacepunctummorashift}{\gre@rubberfalse}%
-    {spaceamonepespunctummorashift}{\gre@rubberfalse}%
-    {lineporrectuspunctummorashift}{\gre@rubberfalse}%
-    {spaceporrectuspunctummorashift}{\gre@rubberfalse}%
-    {raresignshift}{\gre@rubberfalse}%
-    {divisiofinalissep}{\gre@rubberfalse}%
-    {alterationadjustmentbar}{\gre@rubberfalse}%
-    {bracketupshift}{\gre@rubberfalse}%
-    {bracketdownshift}{\gre@rubberfalse}%
-    {noteadditionalspacelinestext}{\gre@rubberfalse}%
-  }[\gre@rubbertrue]%
-  \gre@trace@end%
-}%
-
 %% an aux function adapting the value #1 from the factor #2 to the factor #3
 \def\gre@changeonedimenfactor#1#2#3{%
   \gre@trace{gre@changeonedimenfactor{#1}{#2}{#3}}%
+  \edef\gre@prefix{\gre@getprefix{#1}}%
   % Math
-  \gre@rubberpermit{#1}%
-  \ifgre@rubber%
+  \IfStrEq{\gre@prefix}{skip}{%
     \gre@debugmsg{gsp}{scaling a rubber}%
     % if we have a rubber allowed length we create a temporary skip
     \let\gre@scaledist\gre@skip@temp@one%
     \edef\gre@convert{\csname gre@space@skip@#1\endcsname}%
     \gre@scaledist=\glueexpr(\gre@convert * \number#3 / \number#2)\relax %
-  \else%
+  }{%
     \gre@debugmsg{gsp}{scaling a fixed distance}%
     % otherwise we create a temporary dimen
     \let\gre@scaledist\gre@dimen@temp@one%
     \edef\gre@convert{\csname gre@space@dimen@#1\endcsname}%
     \gre@scaledist=\dimexpr(\gre@convert * \number#3 / \number#2)\relax %
-  \fi%
+  }%
   \gre@consistentunits{\gre@convert}{\gre@scaledist}%
-  \gre@dimension{#1}{\gre@stringdist}%
-  \relax %
+  \gre@dimension{\gre@prefix}{#1}{\gre@stringdist}{}%
   \gre@trace@end%
 }%
 


### PR DESCRIPTION
Previously, `\gre@createdim` would determine whether a dim should allow glue (i.e., whether it would be a skip or a dimen) by looking it up in a table, so in some sense it was creating something that already existed. The more practical problem was that this table lookup caused loading to take O(n^2) time in the number of dims. This PR makes the skip/dimen choice into a new argument to `\gre@createdim` and reduces the time to run tests by about 10%.
