### PR TITLE
Eliminate \gre@luasavedim by using the "new" token library

### DIFF
--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1230,9 +1230,6 @@ Alias for \verb=\resizebox=.
 \macroname{\textbackslash gre@dimension}{}{gregoriotex-spaces.tex}
 Workhorse function for setting distances in \verb=\grecreatedim= and \verb=\grechangedim=.
 
-\macroname{\textbackslash gre@luasavedim}{}{gregoriotex-spaces.tex}
-Makes a distance, which is a macro and therefore only visible in TeX code, also visible in Lua code.
-
 \macroname{\textbackslash gre@setstafflines}{\#1}{gregoriotex-main.tex}
 Sets the number of staff lines.
 
@@ -2235,14 +2232,6 @@ Macro called at the end of the score to restore the text penalties.
 Depending on version of Lua\TeX / \LaTeX, some primitives have different names
 We define the following local aliases to account for this eventuality.
 
-\macroname{\textbackslash gre@localleftbox}{}{gregoriotex-main.tex}
-Current primitive: \verb=\localleftbox=
-Legacy primitive: \verb=\luatexlocalleftbox=
-
-\macroname{\textbackslash gre@localrightbox}{}{gregoriotex-main.tex}
-Current primitive: \verb=\localrightbox=
-Legacy primitive: \verb=\luatexlocalrightbox=
-
 \macroname{\textbackslash gre@startlink}{}{gregoriotex-main.tex}
 Current primitive: \verb=\pdfextension startlink=
 Legacy primitive: \verb=\pdfstartlink=
@@ -2250,18 +2239,6 @@ Legacy primitive: \verb=\pdfstartlink=
 \macroname{\textbackslash gre@endlink}{}{gregoriotex-main.tex}
 Current primitive: \verb=\pdfextension endlink=
 Legacy primitive: \verb=\pdfendlink=
-
-\macroname{\textbackslash gre@savepos}{}{gregoriotex-main.tex}
-Current primitive: \verb=\savepos=
-Legacy primitive: \verb=\pdfsavepos=
-
-\macroname{\textbackslash gre@lastxpos}{}{gregoriotex-main.tex}
-Current primitive: \verb=\lastxpos=
-Legacy primitive: \verb=\pdflastxpos=
-
-\macroname{\textbackslash gre@lastypos}{}{gregoriotex-main.tex}
-Current primitive: \verb=\lastypos=
-Legacy primitive: \verb=\pdflastypos=
 
 
 \subsection{\LaTeX/Plain \TeX\ compatibility}

--- a/doc/GregorioNabcRef.tex
+++ b/doc/GregorioNabcRef.tex
@@ -122,7 +122,7 @@
 
 \def\sneumebody#1{%
     \font\grefontnabc={name:gregall} at 6pt\grefontnabc\begin{gre@style@nabc}%
-    \directlua{tex.sprint(gregoriotex.nabc_font_tables["gregall"]["\luatexluaescapestring{#1}"] or "")}%
+    \directlua{tex.sprint(gregoriotex.nabc_font_tables["gregall"]["\luaescapestring{#1}"] or "")}%
     \end{gre@style@nabc}%
   \endgroup %
 }
@@ -136,7 +136,7 @@
 
 \def\lneumebody#1{%
     \font\grefontnabc={name:grelaon} at 6pt\grefontnabc\begin{gre@style@nabc}%
-    \directlua{tex.sprint(gregoriotex.nabc_font_tables["grelaon"]["\luatexluaescapestring{#1}"] or "")}%
+    \directlua{tex.sprint(gregoriotex.nabc_font_tables["grelaon"]["\luaescapestring{#1}"] or "")}%
     \end{gre@style@nabc}%
   \endgroup %
 }

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -168,7 +168,7 @@
 \gresetspecial{\string\126\string\126}{\textasciitilde{}}%
 
 \long\def\nabcsnippet#1#2{%
-  \directlua{gregoriotex.direct_gabc("\luatexluaescapestring{\unexpanded\expandafter{#2}}",
+  \directlua{gregoriotex.direct_gabc("\luaescapestring{\unexpanded\expandafter{#2}}",
                                      "nabc-lines:#1;", false)}%
 }%
 

--- a/tex/gregoriotex-common.tex
+++ b/tex/gregoriotex-common.tex
@@ -19,8 +19,8 @@
 
 \gre@declarefileversion{gregoriotex-common.tex}{6.1.0}% GREGORIO_VERSION
 
-\ifnum\luatexversion<76%
-  \gre@error{Error: this document must be compiled with LuaTeX (lualatex) 0.76 or later}%
+\ifnum\luatexversion<100%
+  \gre@error{Error: this document must be compiled with LuaTeX 1.0 or later}%
 \fi%
 
 % Run a command for each string in a comma-separated list of strings.

--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -53,14 +53,7 @@
 %% and emergencystretch
 \grechangecount{looseness}{-1}%
 \grechangecount{tolerance}{9000}%
-% Workaround for bug 842 (http://tracker.luatex.org/view.php?id=842)
-% see http://tug.org/pipermail/luatex/2013-July/004516.html
-% The idea is that we use discretionaries (explicit hyphens, though more than hyphens in our case) for clef changes, and we need to give them a special penalty, which is not taken into account if pretolerance is > -1 on LuaTeX < 0.80. For a more detailed explanation see http://tug.org/pipermail/luatex/2013-July/004516.html.
-\ifnum\the\luatexversion < 78\relax %
-  \grechangecount{pretolerance}{-1}%
-\else %
-  \grechangecount{pretolerance}{\the\pretolerance}%
-\fi %
+\grechangecount{pretolerance}{\the\pretolerance}%
 \gre@createdim{skip}{emergencystretch}{\the\emergencystretch}{scalable}%
 % By default, we don't care if a line of score is alone on the page,
 % if you think it is bad, you can modify the two following values. Assigning

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -39,88 +39,50 @@
 
 \def\gre@nothing{}%
 
-%%%%%%%%%%%%%%%
-%% Backwards Compatibility
-%%%%%%%%%%%%%%%
-
-% Depending on version of LuaTeX / LaTeX, some primitives have different names
-% We define local aliases for this eventuality, using \ifdefined to determine which
-% version of the primative is available.  In all cases the 'true' branch should be the
-% more recent version.
-\ifdefined\localleftbox%
-  \let\gre@localleftbox\localleftbox%
-\else%
-  \let\gre@localleftbox\luatexlocalleftbox%
-\fi%
-\ifdefined\localrightbox%
-  \let\gre@localrightbox\localrightbox%
-\else%
-  \let\gre@localrightbox\luatexlocalrightbox%
-\fi%
-\ifdefined\pdfextension%
-  \def\gre@startlink{\pdfextension startlink }%
-  \def\gre@endlink{\pdfextension endlink\relax}%
-\else%
-  \let\gre@startlink\pdfstartlink%
-  \let\gre@endlink\pdfendlink%
-\fi%
-\ifdefined\savepos%
-  \let\gre@savepos\savepos%
-\else%
-  \let\gre@savepos\pdfsavepos%
-\fi%
-\ifdefined\lastxpos%
-  \let\gre@lastxpos\lastxpos%
-\else%
-  \let\gre@lastxpos\pdflastxpos%
-\fi%
-\ifdefined\lastypos%
-  \let\gre@lastypos\lastypos%
-\else%
-  \let\gre@lastypos\pdflastypos%
-\fi%
+\def\gre@startlink{\pdfextension startlink }
+\def\gre@endlink{\pdfextension endlink\relax}
 
 %%%%%%%%%%%%%%%
 
 % an attribute to mark various parts of the score
 % 1 = commentary, 2 = stafflines, 3 = initial
 % 4 = lyrics, 5 = translation, 6 = alt, 7 = nabc, 8 = nabc below
-\newluatexattribute\gre@attr@part%
+\newattribute\gre@attr@part
   \edef\gre@attrid@part{\the\allocationnumber}
 
 % an attribute we put on the text nodes.
 % if it is 1, it means that there may be a dash here if this syllable is at the end of a line
 % if it is 2, it means that it's never useful to typeset a dash
 % if it is 0, it just means that we are in a score...
-\newluatexattribute\gre@attr@dash%
+\newattribute\gre@attr@dash
 
 % an attribute used for translation centering
-\newluatexattribute\gre@attr@center%
+\newattribute\gre@attr@center
 
-\newluatexattribute\GreScoreId %
+\newattribute\GreScoreId
 
 % attributes for tracking glyph heights
-\newluatexattribute\gre@attr@glyph@top %
-\newluatexattribute\gre@attr@glyph@bottom %
+\newattribute\gre@attr@glyph@top
+\newattribute\gre@attr@glyph@bottom
 
 % attribute for syllable tracking
-\newluatexattribute\gre@attr@syllable@id %
+\newattribute\gre@attr@syllable@id
 
 % attributes for soft alterations
 
 % Alterations are numbered consecutively starting from 1. If an
 % alteration is set twice, once for measurement and once for printing,
 % they have the same id.
-\newluatexattribute\gre@attr@alteration@id %
+\newattribute\gre@attr@alteration@id
 
 % The pitch and type of an alteration.
-\newluatexattribute\gre@attr@alteration@pitch
+\newattribute\gre@attr@alteration@pitch
   \edef\gre@attrid@alteration@pitch{\the\allocationnumber}%
-\newluatexattribute\gre@attr@alteration@type % see \gre@alteration for codes
+\newattribute\gre@attr@alteration@type % see \gre@alteration for codes
   \edef\gre@attrid@alteration@type{\the\allocationnumber}%
 
-\newluatexcatcodetable\gre@atletter %
-\setluatexcatcodetable\gre@atletter{%
+\newcatcodetable\gre@atletter
+\setcatcodetable\gre@atletter{%
   \catcode`\@=11 %
 }%
 
@@ -247,7 +209,7 @@
 \def\gre@newlinecommon#1#2{%
   \gre@trace{gre@newlinecommon{#1}{#2}}%
   \ifgre@blockeolcustos\ifnum\gre@insidediscretionary=0\relax %
-     \gre@localrightbox{}%
+     \localrightbox{}%
   \fi\fi %
   \ifgre@boxing\else%
     \global\gre@lastoflinecount=2\relax %
@@ -563,8 +525,8 @@
   \gre@trace{gre@writemode{#1}{#2}{#3}}%
   \greannotation{%
     \gre@style@modeline #1\endgre@style@modeline %
-    \gre@style@modemodifier \directlua{gregoriotex.mode_part("\luatexluaescapestring{#2}")}\endgre@style@modemodifier %
-    \gre@style@modedifferentia \directlua{gregoriotex.mode_part("\luatexluaescapestring{#3}")}\endgre@style@modedifferentia %
+    \gre@style@modemodifier \directlua{gregoriotex.mode_part("\luaescapestring{#2}")}\endgre@style@modemodifier
+    \gre@style@modedifferentia \directlua{gregoriotex.mode_part("\luaescapestring{#3}")}\endgre@style@modedifferentia
     \relax %
   }%
   \relax %
@@ -697,7 +659,7 @@
       #1%
     \fi
     \hss}%
-  \unsetluatexattribute{\gre@attr@part}%
+  \unsetattribute{\gre@attr@part}%
   \gre@trace@end%
 }%
 
@@ -911,7 +873,7 @@
     \fi %
     \gre@attr@center=1\relax %
     \raise\gre@space@dimen@spacebeneathtext\hbox attr \gre@attrid@part=5 to 0pt{\kern 0pt\vbox to 0pt{\vss\hbox to 0pt{\gre@style@translation#1\endgre@style@translation\hss}}\kern 0pt}%
-    \unsetluatexattribute{\gre@attr@center}%
+    \unsetattribute{\gre@attr@center}%
     \relax %
   \fi%
 }%
@@ -933,7 +895,7 @@
   \fi %
   \gre@attr@center=2\relax %
   \raise\gre@space@dimen@spacebeneathtext\hbox to 0pt{}%
-  \unsetluatexattribute{\gre@attr@center}%
+  \unsetattribute{\gre@attr@center}%
   \relax %
   \gre@trace@end%
 }%
@@ -1097,8 +1059,8 @@
   \global\gre@dimen@morawidth=0pt\relax %
   \GreResetEolCustos%
   \gre@resetledgerlineheuristics%
-  \global\setluatexattribute\gre@attr@syllable@id{0}%
-  \global\setluatexattribute\gre@attr@alteration@id{0}%
+  \global\setattribute\gre@attr@syllable@id{0}%
+  \global\setattribute\gre@attr@alteration@id{0}%
   \xdef\gre@gabcname{#6}%
   \gre@setstafflines{#7}%
   \ifnum\gre@count@lastline=0\relax
@@ -1133,17 +1095,17 @@
   \ifnum\gre@nlbstate=0\else %
     \GreEndNLBArea{2}{0}%
   \fi %
-  \gre@localleftbox{}%
+  \localleftbox{}%
   \ifgre@keeprightbox\else %
-    \gre@localrightbox{}%
+    \localrightbox{}%
   \fi %
   \par %
   \ifgre@keeprightbox%
     \global\gre@keeprightboxfalse%
   \fi%
   % with some versions of LuaTeX, the \localrightbox and \localleftbox must be set empty in an environment with the good attributes set
-  \gre@localleftbox{}%
-  \gre@localrightbox{}%
+  \localleftbox{}%
+  \localrightbox{}%
   \gre@restorepenalties %
   \gre@dimen@temp@one=0pt\relax%
   \gre@dimen@temp@two=0pt\relax%
@@ -1157,9 +1119,9 @@
   \setbox\gre@box@annotation=\box\voidb@x%
   \setbox\gre@box@commentary=\box\voidb@x%
   \directlua{gregoriotex.at_score_end()}%
-  \unsetluatexattribute{\gre@attr@glyph@top}%
-  \unsetluatexattribute{\gre@attr@glyph@bottom}%
-  \unsetluatexattribute{\gre@attr@dash}%
+  \unsetattribute{\gre@attr@glyph@top}%
+  \unsetattribute{\gre@attr@glyph@bottom}%
+  \unsetattribute{\gre@attr@dash}%
   \xdef\gre@bolshiftcleftypelocal{\gre@bolshiftcleftypeglobal}%
   \ifnum\gre@count@lastline=0\relax
     \parfillskip=\gre@saved@parfillskip\relax%
@@ -1261,7 +1223,7 @@
 \newif\ifgre@blockeolcustos%
 \def\GreSuppressEolCustos{%
   \gre@blockeolcustostrue%
-  \gre@localrightbox{}%
+  \localrightbox{}%
 }%
 \def\gre@useautoeolcustos{%
   \gre@trace{gre@useautoeolcustos}%
@@ -1874,7 +1836,7 @@
 % Macros for compiling short snippets of GABC directly expressed in TeX
 
 \long\def\gabcsnippet#1{%
-  \directlua{gregoriotex.direct_gabc("\luatexluaescapestring{\unexpanded\expandafter{#1}}", nil, \gre@allowdeprecated@asboolean)}%
+  \directlua{gregoriotex.direct_gabc("\luaescapestring{\unexpanded\expandafter{#1}}", nil, \gre@allowdeprecated@asboolean)}%
 }%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tex/gregoriotex-nabc.tex
+++ b/tex/gregoriotex-nabc.tex
@@ -33,13 +33,13 @@
   \global\font\gre@font@nabc={name:#2} at #3 pt\relax %
   {%
     \csname gre@font@nabcvoice@\romannumeral#1\endcsname
-    \directlua{gregoriotex.init_nabc_font("\luatexluaescapestring{#2}")}%
+    \directlua{gregoriotex.init_nabc_font("\luaescapestring{#2}")}%
   }%
 }
 
 \def\gre@nabccharno#1#2#3{%
   \gre@trace{gre@nabccharno{#1}{#2}{#3}}%
-  {\directlua{gregoriotex.print_nabc(gregoriotex.parse_nabc("#1", "\luatexluaescapestring{#2}", #3))}}%
+  {\directlua{gregoriotex.print_nabc(gregoriotex.parse_nabc("#1", "\luaescapestring{#2}", #3))}}%
   \gre@trace@end%
 }
 

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -158,7 +158,7 @@
 \def\GreSetLinesClef#1#2#3#4#5#6#7{%
   \gre@trace{GreSetLinesClef{#1}{#2}{#3}{#4}{#5}{#6}{#7}}%
   \gre@save@clef{#1}{#2}{#4}{#5}{#6}{#7}%
-  \gre@localleftbox{%
+  \localleftbox{%
     \copy\gre@box@lines% draws the lines
     \unkern %
     \ifgre@showclef%
@@ -539,7 +539,7 @@
         \GreNoBreak%
         \gre@pickcustos{#1}{0}\relax %
       }%
-      \gre@localrightbox{%
+      \localrightbox{%
         \ifgre@showlines %
           \ifnum#1<\gre@pitch@belowstaff\relax %
             \gre@additionalbottomcustoslineend %
@@ -1117,18 +1117,18 @@
   \ifgre@boxing\else %
     \ifcase#2 % 0
       \gre@debugmsg{general}{save case 0}%
-      \gre@savepos %
+      \savepos
     \or % 1
       \setbox\gre@box@temp@sign=\hbox{\gre@fontchar@punctum}%
       \kern-\wd\gre@box@temp@sign %
-      \gre@savepos %
+      \savepos
       \kern\wd\gre@box@temp@sign %
     \or % 2
       \gre@debugmsg{general}{save case 2}%
       \setbox\gre@box@temp@sign=\hbox{\gre@fontchar@punctum}%
       \gre@dimen@temp@five=\wd\gre@box@temp@sign %
       \kern-.5\wd\gre@box@temp@sign %
-      \gre@savepos %
+      \savepos
       \kern.5\wd\gre@box@temp@sign %
     \fi %
     \directlua{gregoriotex.save_length(#1, #3)}%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1541,12 +1541,12 @@
   ]%
   {\grechangedim{#2}{#3}{#4}%
    \edef\gre@prefix{\gre@getprefix{#2}}%
-   \directlua{%
-     gregoriotex.change_next_score_line_dim(%
-       "\luatexluaescapestring{#1}",%
-       "\luatexluaescapestring{#2}",%
-       "\luatexluaescapestring{\csname gre@space@\gre@prefix @#2\endcsname}"%
-     )%
+   \directlua{
+     gregoriotex.change_next_score_line_dim(
+       "\luaescapestring{#1}",
+       "\luaescapestring{#2}",
+       "\luaescapestring{\csname gre@space@\gre@prefix @#2\endcsname}"
+     )
    }%
   }%
 }%
@@ -1557,12 +1557,12 @@
   \IfStrEqCase{#2}{{additionaltopspacethreshold}{}{additionaltopspacealtthreshold}{}{additionaltopspacenabcthreshold}{}{noteadditionalspacelinestextthreshold}{}}[%
     \gre@error{Unrecognized option "#2" for \protect\grechangenextscorelinecount\MessageBreak Possible options are: 'additionaltopspacethreshold', 'additionaltopspacealtthreshold', 'additionaltopspacenabcthreshold', 'noteadditionalspacelinestextthreshold'}%
   ]%
-  \directlua{%
-    gregoriotex.change_next_score_line_count(%
-      "\luatexluaescapestring{#1}",%
-      "\luatexluaescapestring{#2}",%
-      "\luatexluaescapestring{#3}"%
-    )%
+  \directlua{
+    gregoriotex.change_next_score_line_count(
+      "\luaescapestring{#1}",
+      "\luaescapestring{#2}",
+      "\luaescapestring{#3}"
+    )
   }%
 }%
 

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -890,23 +890,6 @@
 
 \def\gre@calculate@additionalspaces{%
   \gre@trace{gre@calculate@additionalspaces}%
-  % Pass in dimensions and counts that are macros
-  \gre@luasavedim{spaceabovelines}%
-  % \ifgre@noteadditionalspacelinestext is not accessible in Lua, so handle it here
-  \ifgre@noteadditionalspacelinestext
-    \gre@luasavedim{noteadditionalspacelinestext}%
-  \else
-    {\grechangedim{noteadditionalspacelinestext}{\the\dimexpr(\gre@dimen@interstafflinedistancebase+\gre@dimen@stafflinethicknessbase)/2 * \gre@factor\relax}{fixed}%
-     \gre@luasavedim{noteadditionalspacelinestext}}%
-  \fi
-  \gre@luasavedim{abovelinestextheight}%
-  \gre@luasavedim{abovelinestextraise}%
-  \gre@luasavedim{abovelinesnabcheight}%
-  \gre@luasavedim{abovelinesnabcraise}%
-  \gre@luasavedim{belowlinesnabcheight}%
-  \gre@luasavedim{spacelinestext}%
-  \gre@luasavedim{translationheight}%
-  \gre@luasavedim{spacebeneathtext}%
   \gre@generatelines %
   \gre@calculate@constantglyphraise %
   \gre@trace@end%
@@ -1549,20 +1532,6 @@
     \gre@error{Unrecognized distance "#1" in \protect\grescaledim}%
   \fi%
 }
-
-% Make a dim accessible in Lua code. Any scaling or inheriting is done
-% at the time of the expansion of \gre@luasavedim, not when the dim is
-% used in Lua.
-% #1: name of dim
-\def\gre@luasavedim#1{%
-  \edef\gre@prefix{\gre@getprefix{#1}}%
-  \directlua{%
-    gregoriotex.save_dim(%
-      "\luatexluaescapestring{#1}",%
-      "\luatexluaescapestring{\csname gre@space@\gre@prefix @#1\endcsname}"%
-    )%
-  }%
-}%
 
 % #1 : line number
 % #2-#4 : same as #1-#3 of \grechangedim

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -116,11 +116,11 @@
 
 \def\gre@endofglyphcommon{%
   \gre@trace{gre@endofglyphcommon}%
-  \global\unsetluatexattribute{\gre@attr@glyph@top}%
-  \global\unsetluatexattribute{\gre@attr@glyph@bottom}%
+  \global\unsetattribute{\gre@attr@glyph@top}%
+  \global\unsetattribute{\gre@attr@glyph@bottom}%
   \ifgre@endofscore %
-    \gre@localleftbox{}%
-    \gre@localrightbox{}%
+    \localleftbox{}%
+    \localrightbox{}%
   \fi %
   \gre@trace@end%
 }
@@ -129,8 +129,8 @@
 % #1: the high height
 % #2: the low height
 \def\GreGlyphHeights#1#2{%
-  \global\setluatexattribute\gre@attr@glyph@top{#1}%
-  \global\setluatexattribute\gre@attr@glyph@bottom{#2}%
+  \global\setattribute\gre@attr@glyph@top{#1}%
+  \global\setattribute\gre@attr@glyph@bottom{#2}%
 }%
 
 % Flag that tells us if the current glyph is the first glyph or not.
@@ -1087,7 +1087,7 @@
   \global\gre@dimen@notesaligncenter=0pt\relax% very important, see flat and natural
   \gre@unsetfixedtextformat %
   \ifgre@blockeolcustos\ifnum\gre@insidediscretionary=0\relax %
-     \gre@localrightbox{}%
+     \localrightbox{}%
   \fi\fi %
   \relax %
   \gre@trace@end%
@@ -1410,7 +1410,7 @@
       \fi%
     \else %
       \ifgre@endofscore %
-        \gre@localleftbox{}%
+        \localleftbox{}%
       \else %
         \ifnum\gre@newlinearg=-1\else %
           \gre@debugmsg{barspacing}{calling new line with argument: \gre@newlinearg}%
@@ -1551,7 +1551,7 @@
   \global\gre@dimen@notesaligncenter= 0 pt\relax % very important, see flat and natural
   \gre@unsetfixedtextformat %
   \ifgre@blockeolcustos\ifnum\gre@insidediscretionary=0\relax %
-     \gre@localrightbox{}%
+     \localrightbox{}%
   \fi\fi %
   \relax%
   \gre@trace@end%

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -124,7 +124,6 @@ local capture_header_macro = {}
 
 local per_line_dims = {}
 local per_line_counts = {}
-local saved_dims = {}
 
 local catcode_at_letter = luatexbase.catcodetables['gre@atletter']
 
@@ -709,19 +708,37 @@ local function compute_line_statistics(line, info)
   return info
 end
 
+local function get_space(name)
+  -- Get the value of a dim, measured in sp.
+  local value
+  value = token.get_macro('gre@space@dimen@'..name)
+  if value ~= nil then return tex.sp(value) end
+  value = token.get_macro('gre@space@skip@'..name)
+  if value ~= nil then return tex.sp(value) end
+  err("couldn't get value of space %s", name)
+end
+
+local iftrue_token = token.create('iftrue')
+local function get_if(name)
+  -- Get the value of a TeX conditional, as a boolean.
+  -- The 'mode' attribute of tokens is not well-documented, but appears to distinguish \iftrue from \iffalse.
+  if not token.is_defined('if'..name) then err("couldn't get value of %s") end
+  return token.create('if'..name).mode == iftrue_token.mode
+end
+
 local function adjust_additional_spaces(line, info, linenum)
   -- Adjust the vertical positioning of all the parts of line, as well
   -- as its total height and the interline skip above the line.
   
-  local function get_space(name)
+  local function get_per_line_space(name)
     if per_line_dims[linenum] ~= nil and per_line_dims[linenum][name] ~= nil then
       return per_line_dims[linenum][name]
     else
-      return saved_dims[name]
+      return get_space(name)
     end
   end
   
-  local function get_count(name)
+  local function get_per_line_count(name)
     if per_line_counts[linenum] ~= nil and per_line_counts[linenum][name] ~= nil then
       return per_line_counts[linenum][name]
     else
@@ -730,16 +747,21 @@ local function adjust_additional_spaces(line, info, linenum)
   end
 
   -- distance between stafflines
-  local staffline_distance = math.floor((tex.dimen['gre@dimen@interstafflinedistancebase'] + tex.dimen['gre@dimen@stafflinethicknessbase']+1)/2) * tex.count['gre@factor'] -- rounding to get same result as the TeX \dimexpr this is based on
-  local note_additional_space_lines_text = get_space('noteadditionalspacelinestext') -- this may be different from staffline_distance under the legacy option \gresetnoteadditionalspacelinestext{manual}
+  local staffline_distance = tex.round((tex.dimen['gre@dimen@interstafflinedistancebase'] + tex.dimen['gre@dimen@stafflinethicknessbase'])/2) * tex.count['gre@factor']
+  local note_additional_space_lines_text
+  if get_if('gre@noteadditionalspacelinestext') then
+    note_additional_space_lines_text = get_per_line_space('noteadditionalspacelinestext') -- this may be different from staffline_distance under the legacy option \gresetnoteadditionalspacelinestext{manual}
+  else
+    note_additional_space_lines_text = staffline_distance
+  end
 
   -- thresholds for additional top/bottom spaces
-  local top_threshold = get_count('additionaltopspacethreshold')
-  local alt_threshold = get_count('additionaltopspacealtthreshold')
-  local nabc_threshold = get_count('additionaltopspacenabcthreshold')
-  local bottom_threshold = get_count('noteadditionalspacelinestextthreshold')
+  local top_threshold = get_per_line_count('additionaltopspacethreshold')
+  local alt_threshold = get_per_line_count('additionaltopspacealtthreshold')
+  local nabc_threshold = get_per_line_count('additionaltopspacenabcthreshold')
+  local bottom_threshold = get_per_line_count('noteadditionalspacelinestextthreshold')
   
-  -- recompute top and bottom pitches, since we can't access \gre@pitch@adjust@top and \gre@pitch@adjust@bottom
+  -- compute top and bottom pitches
   local adjust_bottom = bottom_threshold + 3
   local adjust_top = 4 + 2*tex.count['gre@count@stafflines']
 
@@ -752,12 +774,12 @@ local function adjust_additional_spaces(line, info, linenum)
   -- translation height
   local translation_height = 0
   if info.has_translation then
-    translation_height = get_space('translationheight')
+    translation_height = get_per_line_space('translationheight')
   end
 
   -- per-line changes to other spaces
-  local extra_space_lines_text = get_space('spacelinestext') - saved_dims['spacelinestext']
-  local extra_space_beneath_text = get_space('spacebeneathtext') - saved_dims['spacebeneathtext']
+  local extra_space_lines_text = get_per_line_space('spacelinestext') - get_space('spacelinestext')
+  local extra_space_beneath_text = get_per_line_space('spacebeneathtext') - get_space('spacebeneathtext')
 
   -- how much to raise/lower each part
   local commentary_raise = additional_top_space_alt
@@ -767,29 +789,29 @@ local function adjust_additional_spaces(line, info, linenum)
 
   local nabc_raise
   if info.has_nabc then
-    cur = cur + get_space('abovelinesnabcraise')
+    cur = cur + get_per_line_space('abovelinesnabcraise')
     add = math.max(add, cur + additional_top_space_nabc)
     nabc_raise = add
-    cur = cur + get_space('abovelinesnabcheight')
-    add = add + get_space('abovelinesnabcheight')
+    cur = cur + get_per_line_space('abovelinesnabcheight')
+    add = add + get_per_line_space('abovelinesnabcheight')
   end
 
   local alt_raise
   if info.has_alt then
-    cur = cur + get_space('abovelinestextraise')
+    cur = cur + get_per_line_space('abovelinestextraise')
     add = math.max(add, cur + additional_top_space_alt)
     alt_raise = add
-    cur = cur + get_space('abovelinestextheight')
-    add = add + get_space('abovelinestextheight')
+    cur = cur + get_per_line_space('abovelinestextheight')
+    add = add + get_per_line_space('abovelinestextheight')
   end
 
-  cur = cur + get_space('spaceabovelines')
+  cur = cur + get_per_line_space('spaceabovelines')
   add = math.max(add, cur + additional_top_space)
-  local height_increase = add - saved_dims['spaceabovelines']
+  local height_increase = add - get_per_line_space('spaceabovelines')
 
   local blnabc_lower = 0
   if info.has_blnabc then
-    blnabc_lower = get_space('belowlinesnabcheight')
+    blnabc_lower = get_per_line_space('belowlinesnabcheight')
   end
   local lyrics_lower = blnabc_lower + extra_space_lines_text + additional_bottom_space
   local translation_lower = lyrics_lower + translation_height
@@ -1130,7 +1152,6 @@ local function at_score_end()
   luatexbase.remove_from_callback("hyphenate", "gregoriotex.disable_hyphenation")
   per_line_dims = {}
   per_line_counts = {}
-  saved_dims = {}
 end
 
 --- Toggle the state of GregorioTeX callbacks.
@@ -1651,11 +1672,6 @@ end
 
 local function font_size()
   tex.print(string.format('%.2f', (unsafe_get_font_by_id(font.current()).size / 65536.0)))
-end
-
-local function save_dim(name, value)
-  debugmessage('save_dim', 'dim %s value %spt', name, tex.sp(value)/2^16)
-  saved_dims[name] = tex.sp(value)
 end
 
 local function change_next_score_line_dim(line_expr, name, value)

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -53,6 +53,13 @@ local whatsit = node.id('whatsit')
 local rule = node.id('rule')
 local disc = node.id('disc')
 
+local subtype_lineskip, subtype_baselineksip
+for i, t in ipairs(node.subtypes('glue')) do
+  if t == 'lineskip' then subtype_lineskip = i
+  elseif t == 'baselineskip' then subtype_baselineskip = i
+  end
+end
+
 local hyphen = tex.defaulthyphenchar or 45
 
 local part_attr = luatexbase.attributes['gre@attr@part']
@@ -561,9 +568,9 @@ local function find_attr(cur, attr, val)
 end
 
 -- Recompute interline glue
-local function adjust_glue(glue)
+local function adjust_glue(g)
   -- Find previous line and its depth
-  local prevline = glue.prev
+  local prevline = g.prev
   while prevline ~= nil and prevline.id ~= hlist do
     prevline = prevline.prev
   end
@@ -574,25 +581,23 @@ local function adjust_glue(glue)
     prevdepth = prevline.depth
   end
     
-  debugmessage('adjust_glue', 'prev depth %.2f, cur height %.2f', prevdepth/2^16, glue.next.height/2^16)
+  debugmessage('adjust_glue', 'prev depth %.2f, cur height %.2f', prevdepth/2^16, g.next.height/2^16)
   debugmessage('adjust_glue', 'baselineskip width=%.2f', tex.baselineskip.width/2^16)
 
   local subtype = 'baselineskip'
-  debugmessage('adjust_glue', 'old glue is %s %spt plus %spt minus %spt', subtype, glue.width/2^16, glue.stretch/2^16, glue.shrink/2^16)
+  debugmessage('adjust_glue', 'old glue is %s %spt plus %spt minus %spt', subtype, g.width/2^16, g.stretch/2^16, g.shrink/2^16)
   
-  local new_width = tex.baselineskip.width - prevdepth - glue.next.height
+  local new_width = tex.baselineskip.width - prevdepth - g.next.height
   if new_width < tex.lineskiplimit then
-    glue.subtype = 1 -- lineskip
-    subtype = 'lineskip'
-    node.setglue(glue, node.getglue(tex.lineskip))
+    g.subtype = subtype_lineskip
+    node.setglue(g, node.getglue(tex.lineskip))
   else
-    new_subtype = 2 -- baselineskip
-    subtype = 'baselineskip'
-    node.setglue(glue, node.getglue(tex.baselineskip))
-    glue.width = new_width
+    g.subtype = subtype_baselineskip
+    node.setglue(g, node.getglue(tex.baselineskip))
+    g.width = new_width
   end
   
-  debugmessage('adjust_glue', 'new glue is %s %spt plus %spt minus %spt', subtype, glue.width/2^16, glue.stretch/2^16, glue.shrink/2^16)
+  debugmessage('adjust_glue', 'new glue is %s %spt plus %spt minus %spt', node.subtypes(glue)[g.id], g.width/2^16, g.stretch/2^16, g.shrink/2^16)
 end
 
 local function drop_initial(h)

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -1708,7 +1708,7 @@ local function prep_save_position(index, fn)
 end
 
 local function save_position(index, which)
-  tex.print(catcode_at_letter, string.format([[\luatexlatelua{gregoriotex.late_save_position('%s', %d, %d, \number\gre@lastxpos, \number\gre@lastypos)}]], cur_score_id, index, which))
+  tex.print(catcode_at_letter, string.format([[\luatexlatelua{gregoriotex.late_save_position('%s', %d, %d, \number\lastxpos, \number\lastypos)}]], cur_score_id, index, which))
 end
 
 local function late_save_position(score_id, index, which, xpos, ypos)
@@ -1761,7 +1761,7 @@ local function save_euouae(index, which)
   if which == 1 then
     prep_save_position(index, compute_saved_newline_before_euouae)
   end
-  tex.sprint(catcode_at_letter, [[\gre@savepos]])
+  tex.sprint(catcode_at_letter, [[\savepos]])
   save_position(index, which)
 end
 

--- a/tex/gregoriotex.sty
+++ b/tex/gregoriotex.sty
@@ -41,8 +41,8 @@
 \def\gre@bug#1{\PackageError{GregorioTeX}{#1 !! This is a bug in Gregorio.  Please report it at https://github.com/gregorio-project/gregorio/issues}{}}%
 \def\gre@typeout{\typeout}
 \long\def\gre@metapost#1{{%
-  \gre@localleftbox{}%
-  \gre@localrightbox{}%
+  \localleftbox{}%
+  \localrightbox{}%
   \begin{mplibcode}
   #1
   \end{mplibcode}%

--- a/tex/gregoriotex.tex
+++ b/tex/gregoriotex.tex
@@ -74,8 +74,8 @@
 \gre@allowdeprecatedtrue%
 
 \long\def\gre@metapost#1{{%
-  \gre@localleftbox{}%
-  \gre@localrightbox{}%
+  \localleftbox{}%
+  \localrightbox{}%
   \mplibcode
   #1
   \endmplibcode%


### PR DESCRIPTION
In #1641 there was a hack called `\gre@luasavedim` for sending a dimen/skip from TeX to Lua code. These are defined as macros, and I thought, based on old information, that it was not possible for Lua code to access TeX macros. But it is possible, and this patch takes advantage of that to simplify the vertical spacing code. No behavior should be changed, except that this now requires (I believe) LuaTeX 0.85 or later, which was released in late 2015. Is that a safe assumption to make?

If so, then there's some other modernization that can be done, so this is a draft PR for now.
