### PR TITLE
Change spacebeforesigns from a skip to a dimen (#1656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Previously, if a score ended with `Z` (ragged line break) or `z` (justified line break), the appearance of the last line would sometimes depend on `Z` versus `z` and sometimes depend on `\gresetlastline{ragged}` versus `\gresetlastline{justified}`. Now, the appearance of the last line always depends on `\gresetlastline`.
 - The meanings of the distances `spaceabovelines` and `abovelinestextheight` were changed to be (hopefully) easier to use and closer to their descriptions in the documentation.
 - All lengths related to vertical spacing are documented in greater detail in a dedicated section in GregorioRef.pdf.
+- `spacebeforesigns` was changed from a skip to a dimen; that is, it can no longer have a stretch or shrink (`plus` or `minus`).
 
 ### Deprecated
 - The count `grefinalpenalty` no longer has any effect and will be removed in a future release.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,10 @@ Forced line breaks (`Z` or `z`) at the very end of a score are discouraged. Plea
 
 The meanings of these distances were changed to be (hopefully) easier to use and closer to their descriptions in the documentation. Please see the section "Vertical spacing" in GregorioRef.pdf for more information. Scores that use the default settings and have above-lines text (`<alt>`) will now have slightly more whitespace above the above-lines text. Scores that set either of these two distances explicitly may experience larger changes in whitespace between staves, and should be checked.
 
+### `spacebeforesigns`
+
+This space (the space before a punctum mora) was changed from a skip to a dimen; that is, it can no longer have stretch or shrink (`plus` or `minus`). For example, a command `\grechangedim{spacebeforesigns}{0.050 cm plus 0.004 cm minus 0.004 cm}{scalable}` should be changed to `\grechangedim{spacebeforesigns}{0.050 cm}{scalable}`.
+
 ## 6.1
 
 ### Multiline initials

--- a/doc/gsp-sample.tex
+++ b/doc/gsp-sample.tex
@@ -175,7 +175,7 @@
 % space before end-of-line custos
 \grechangedim{spacebeforeeolcustos}{0.23 cm plus 0 cm minus 0 cm}{scalable}%
 % space before punctum mora and augmentum duplex
-\grechangedim{spacebeforesigns}{0.050 cm plus 0.004 cm minus 0.004 cm}{scalable}%
+\grechangedim{spacebeforesigns}{0.050}{scalable}%
 % when a syllable is shifted left because of a preceding punctum mora, moraadjustmentbar is
 % also added. Use it to make the syllable a bit further from the punctum mora if you want.
 % This version is the general case.

--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -132,7 +132,7 @@
 % space before end-of-line custos
 \gre@createdim{skip}{spacebeforeeolcustos}{0.23 cm plus 0 cm minus 0 cm}{scalable}%
 % space before punctum mora and augmentum duplex
-\gre@createdim{skip}{spacebeforesigns}{0.050 cm plus 0.004 cm minus 0.004 cm}{scalable}%
+\gre@createdim{dimen}{spacebeforesigns}{0.050 cm}{scalable}%
 % when a syllable is shifted left because of a preceding punctum mora, moraadjustmentbar is
 % also added. Use it to make the syllable a bit further from the punctum mora if you want.
 % This version is the general case.

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -1154,27 +1154,20 @@
   \gre@trace{gre@punctum@mora{#1}{#2}{#3}{#4}}%
   \GreNoBreak %
   \ifcase#2\relax %
-    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
-    \gre@hskip\gre@skip@temp@four%
   \or %
-    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
-    \kern\gre@skip@temp@four %
   \or %
-    % to get the widht of a punctum minus a line, we calculate the width of a flexus (with ambitus of two) minus the width of a punctum
+    % to get the width of a punctum minus a line, we calculate the width of a flexus (with ambitus of two) minus the width of a punctum
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPPesQuadratumLongqueueThreeNothing}%
     \gre@dimen@temp@five=\wd\gre@box@temp@width %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPPunctum}%
     \advance\gre@dimen@temp@five by -\wd\gre@box@temp@width %
     \kern-\gre@dimen@temp@five %
-    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
-    \kern\gre@skip@temp@four %
   \or %
     \setbox\gre@box@temp@width=\hbox{\gre@font@music\GreCPPunctum}%
     \gre@dimen@temp@five=\wd\gre@box@temp@width %
     \kern-\gre@dimen@temp@five %
-    \gre@skip@temp@four = \gre@space@skip@spacebeforesigns\relax%
-    \kern\gre@skip@temp@four %
   \fi %
+  \kern\gre@space@dimen@spacebeforesigns
   \ifnum#2=0\relax %
     \global\gre@lastendswithmoratrue%
   \fi %
@@ -1204,21 +1197,18 @@
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@punctummora}%
     \gre@skip@temp@four = -\wd\gre@box@temp@width %
     \kern\gre@skip@temp@four%
-    \gre@skip@temp@four = -\gre@space@skip@spacebeforesigns\relax%
-    \kern\gre@skip@temp@four %
+    \kern-\gre@space@dimen@spacebeforesigns
   \or %
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@punctummora}%
     \gre@skip@temp@four = -\wd\gre@box@temp@width %
     \kern\gre@skip@temp@four%
-    \gre@skip@temp@four = -\gre@space@skip@spacebeforesigns\relax%
-    \kern\gre@skip@temp@four %
+    \kern-\gre@space@dimen@spacebeforesigns
     \kern\gre@dimen@temp@five %
   \or %
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@punctummora}%
     \gre@skip@temp@four = -\wd\gre@box@temp@width %
     \kern\gre@skip@temp@four%
-    \gre@skip@temp@four = -\gre@space@skip@spacebeforesigns\relax%
-    \kern\gre@skip@temp@four %
+    \kern-\gre@space@dimen@spacebeforesigns
     \kern\gre@dimen@temp@five %
   \fi %
   \GreNoBreak %
@@ -2099,9 +2089,9 @@
     \global\gre@dimen@morawidth=\wd\gre@box@temp@width %
   \fi %
   \ifnum #1=1%
-    \global\gre@skip@punctummorashift=\glueexpr - \gre@dimen@morawidth - \gre@space@skip@spacebeforesigns + \gre@space@skip@moraadjustment\relax %
+    \global\gre@skip@punctummorashift=\glueexpr - \gre@dimen@morawidth - \gre@space@dimen@spacebeforesigns + \gre@space@skip@moraadjustment\relax
   \else %
-    \global\gre@skip@punctummorashift=\glueexpr - \gre@dimen@morawidth - \gre@space@skip@spacebeforesigns + \gre@space@skip@moraadjustmentbar\relax %
+    \global\gre@skip@punctummorashift=\glueexpr - \gre@dimen@morawidth - \gre@space@dimen@spacebeforesigns + \gre@space@skip@moraadjustmentbar\relax
   \fi %
   \relax %
   \gre@trace@end%

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -1516,6 +1516,11 @@
     \IfSubStr{#3}{plus}{\gre@checklengthtrue}{\relax}%
     \IfSubStr{#3}{minus}{\gre@checklengthtrue}{\relax}%
     %if #2 is one of the distances which cannot be rubber.
+    \ifgre@checklength
+      \IfStrEq{\gre@prefix}{dimen}%
+        {\gre@error{'#2' is a dimen and cannot have stretch (plus) or shrink (minus)}}%
+        {}%
+    \fi
     % special check for bar@rubber
     \IfStrEq*{#2}{bar@rubber}%
       {%


### PR DESCRIPTION
This does change a number of tests. Most of the changes are miniscule; the biggest one was `tex-output/multi-line-initials/multi-line-initials.tex`.

Closes #1656.