### PR TITLE
Add overtie/undertie symbols, and lyric tying shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][develop]
+### Added
+- Added overtie/undertie special symbols (`<sp>ut</sp>` for `\greundertie`, `<sp>ot</sp>` for `\greovertie`, and `<sp>dt</sp>` for `\gredoubletie`), and a configurable lyric tying shorthand (`~` for `\GreLyricTie`).
+
 ### Fixed
 - Fixed a bug that could cause a punctum mora that is supposed to be below the line (`.0`) to appear above the line. This bug was platform-dependent and was observed on a Windows system.
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -785,6 +785,16 @@ text directly.
 \macroname{\textbackslash gretilde}{}{gregoriotex-main.tex}
 Macro to print $\sim$.  This macro is set using the above for \texttt{<sp>$\sim$</sp>}.
 
+\macroname{\textbackslash greundertie}{}{gregoriotex-main.tex}
+Macro to print an undertie.  This macro is set using the above for \texttt{<sp>ut</sp>}.
+
+\macroname{\textbackslash greovertie}{}{gregoriotex-main.tex}
+Macro to print an overtie.  This macro is set using the above for \texttt{<sp>ot</sp>}.
+
+\macroname{\textbackslash gredoubletie}{}{gregoriotex-main.tex}
+Macro to print a combined overtie and undertie.  This macro is set using the above for
+\texttt{<sp>dt</sp>}.
+
 
 
 \subsubsection{Styling}

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -998,6 +998,29 @@ Macro to determine whether a forced center (\ie, one specified by curly braces (
   & \texttt{prohibit} & Forced centers in gabc do not influence the syllable alignment.\\
 \end{argtable}
 
+\subsubsection{Lyric tying (for vernacular texts)}
+
+\macroname{\textbackslash gresetlyrictie}{\{\#1\}}{gregoriotex-main.tex}
+Macro to configure which tie symbol is used for the tilde character (\texttt{\textasciitilde}) in syllable text.
+This allows using a single short character in gabc files for lyric ties, which is especially useful to represent elisions in vernacular texts.
+
+\begin{argtable}
+  \#1 & \texttt{undertie} & Use \textbackslash greundertie (default)\\
+  & \texttt{overtie} & Use \textbackslash greovertie\\
+  & \texttt{doubletie} & Use \textbackslash gredoubletie\\
+\end{argtable}
+
+Example usage in \TeX\@:
+\begin{latexcode}
+  \gresetlyrictie{overtie}
+  \gregorioscore{myscore}
+\end{latexcode}
+
+Example usage in Portuguese text:
+\begin{latexcode}
+  (c4) On(f)de~o~a(f)mor(gh) e(h) a(g) ca(h)ri(ixi)da(hg)de(hg) (,)
+\end{latexcode}
+
 \macroname{\textbackslash gresettranslationcentering}{\{\#1\}}{gregoriotex-main.tex}
 Macro to specify how the translation text should be aligned with it respective syllable text.
 

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -785,13 +785,13 @@ text directly.
 \macroname{\textbackslash gretilde}{}{gregoriotex-main.tex}
 Macro to print $\sim$.  This macro is set using the above for \texttt{<sp>$\sim$</sp>}.
 
-\macroname{\textbackslash greundertie}{}{gregoriotex-main.tex}
+\macroname{\textbackslash GreUnderTie}{}{gregoriotex-main.tex}
 Macro to print an undertie.  This macro is set using the above for \texttt{<sp>ut</sp>}.
 
-\macroname{\textbackslash greovertie}{}{gregoriotex-main.tex}
+\macroname{\textbackslash GreOverTie}{}{gregoriotex-main.tex}
 Macro to print an overtie.  This macro is set using the above for \texttt{<sp>ot</sp>}.
 
-\macroname{\textbackslash gredoubletie}{}{gregoriotex-main.tex}
+\macroname{\textbackslash GreDoubleTie}{}{gregoriotex-main.tex}
 Macro to print a combined overtie and undertie.  This macro is set using the above for
 \texttt{<sp>dt</sp>}.
 
@@ -1005,9 +1005,9 @@ Macro to configure which tie symbol is used for the tilde character (\texttt{\te
 This allows using a single short character in gabc files for lyric ties, which is especially useful to represent elisions in vernacular texts.
 
 \begin{argtable}
-  \#1 & \texttt{undertie} & Use \textbackslash greundertie (default)\\
-  & \texttt{overtie} & Use \textbackslash greovertie\\
-  & \texttt{doubletie} & Use \textbackslash gredoubletie\\
+  \#1 & \texttt{undertie} & Use \textbackslash GreUnderTie (default)\\
+  & \texttt{overtie} & Use \textbackslash GreOverTie\\
+  & \texttt{doubletie} & Use \textbackslash GreDoubleTie\\
 \end{argtable}
 
 Example usage in \TeX\@:

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -785,13 +785,13 @@ text directly.
 \macroname{\textbackslash gretilde}{}{gregoriotex-main.tex}
 Macro to print $\sim$.  This macro is set using the above for \texttt{<sp>$\sim$</sp>}.
 
-\macroname{\textbackslash GreUnderTie}{}{gregoriotex-main.tex}
+\macroname{\textbackslash greundertie}{}{gregoriotex-main.tex}
 Macro to print an undertie.  This macro is set using the above for \texttt{<sp>ut</sp>}.
 
-\macroname{\textbackslash GreOverTie}{}{gregoriotex-main.tex}
+\macroname{\textbackslash greovertie}{}{gregoriotex-main.tex}
 Macro to print an overtie.  This macro is set using the above for \texttt{<sp>ot</sp>}.
 
-\macroname{\textbackslash GreDoubleTie}{}{gregoriotex-main.tex}
+\macroname{\textbackslash gredoubletie}{}{gregoriotex-main.tex}
 Macro to print a combined overtie and undertie.  This macro is set using the above for
 \texttt{<sp>dt</sp>}.
 
@@ -1005,9 +1005,9 @@ Macro to configure which tie symbol is used for the tilde character (\texttt{\te
 This allows using a single short character in gabc files for lyric ties, which is especially useful to represent elisions in vernacular texts.
 
 \begin{argtable}
-  \#1 & \texttt{undertie} & Use \textbackslash GreUnderTie (default)\\
-  & \texttt{overtie} & Use \textbackslash GreOverTie\\
-  & \texttt{doubletie} & Use \textbackslash GreDoubleTie\\
+  \#1 & \texttt{undertie} & Use \textbackslash greundertie (default)\\
+  & \texttt{overtie} & Use \textbackslash greovertie\\
+  & \texttt{doubletie} & Use \textbackslash gredoubletie\\
 \end{argtable}
 
 Example usage in \TeX\@:

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -762,6 +762,14 @@ Macro for typesetting low choral signs.
   & \texttt{1} & Choral sign occurs before last note of podatus, porrectus, or torculus resupinus.\\
 \end{argtable}
 
+\macroname{\textbackslash GreLyricTie}{}{gregoriotex-main.tex}
+Macro that holds the current lyric tie style. This is an alias to the currently
+selected tie macro (\textbackslash greundertie, \textbackslash greovertie,
+or \textbackslash gredoubletie) as set by \textbackslash gresetlyrictie.
+This macro is used internally when rendering the tilde character (\textasciitilde) in lyrics.
+Users should typically use \textbackslash gresetlyrictie to change the tie style
+rather than redefining this macro directly.
+
 \macroname{\textbackslash GreMode}{\#1\#2\#3}{gregoriotex-main.tex}
 If the gabc file contains a mode in the header, then this function
 places said mode as the first (top) annotation.  If the user has

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -311,8 +311,10 @@ These tags allow for a variety of special effects.
 Additionally, besides parentheses, there are a few other special characters in
 the syllable text.  Curly braces (\texttt{\{} and \texttt{\}}) are for
 \nameref{lyriccentering}.  Square brackets (\texttt{[} and \texttt{]}) are for
-\nameref{translationtext} that appears below the lyric text.  See immediately
-below for more information.
+\nameref{translationtext} that appears below the lyric text.  The tilde
+(\texttt{\textasciitilde}) produces a lyric tie, which is configurable via
+\verb=\gresetlyrictie= (default: \greundertie).  See the sections below for more
+information.
 
 \subsubsection{Lyric Centering}\label{lyriccentering}
 

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -313,7 +313,7 @@ the syllable text.  Curly braces (\texttt{\{} and \texttt{\}}) are for
 \nameref{lyriccentering}.  Square brackets (\texttt{[} and \texttt{]}) are for
 \nameref{translationtext} that appears below the lyric text.  The tilde
 (\texttt{\textasciitilde}) produces a lyric tie, which is configurable via
-\verb=\gresetlyrictie= (default: \GreUnderTie).  See the sections below for more
+\verb=\gresetlyrictie= (default: \greundertie).  See the sections below for more
 information.
 
 \subsubsection{Lyric Centering}\label{lyriccentering}
@@ -371,9 +371,9 @@ special characters are defined by default:
   \texttt{\&} & An ampersand, avoiding \TeX{} interpretation.\\
   \texttt{\#} & A hash mark, avoiding \TeX{} interpretation.\\
   \texttt{\_} & An underscore, avoiding \TeX{} interpretation.\\
-  \texttt{ot} & An overtie (\GreOverTie).\\
-  \texttt{ut} & An undertie (\GreUnderTie).\\
-  \texttt{dt} & A combined overtie + undertie (\GreDoubleTie).\\
+  \texttt{ot} & An overtie (\greovertie).\\
+  \texttt{ut} & An undertie (\greundertie).\\
+  \texttt{dt} & A combined overtie + undertie (\gredoubletie).\\
   \texttt{\textasciitilde} & A centered tilde (a ``math'' tilde, \gretilde).\\
 \end{tabularx}
 

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -369,6 +369,9 @@ special characters are defined by default:
   \texttt{\&} & An ampersand, avoiding \TeX{} interpretation.\\
   \texttt{\#} & A hash mark, avoiding \TeX{} interpretation.\\
   \texttt{\_} & An underscore, avoiding \TeX{} interpretation.\\
+  \texttt{ot} & An overtie (\greovertie).\\
+  \texttt{ut} & An undertie (\greundertie).\\
+  \texttt{dt} & A combined overtie + undertie (\gredoubletie).\\
   \texttt{\textasciitilde} & A centered tilde (a ``math'' tilde, \gretilde).\\
 \end{tabularx}
 

--- a/doc/Gabc.tex
+++ b/doc/Gabc.tex
@@ -313,7 +313,7 @@ the syllable text.  Curly braces (\texttt{\{} and \texttt{\}}) are for
 \nameref{lyriccentering}.  Square brackets (\texttt{[} and \texttt{]}) are for
 \nameref{translationtext} that appears below the lyric text.  The tilde
 (\texttt{\textasciitilde}) produces a lyric tie, which is configurable via
-\verb=\gresetlyrictie= (default: \greundertie).  See the sections below for more
+\verb=\gresetlyrictie= (default: \GreUnderTie).  See the sections below for more
 information.
 
 \subsubsection{Lyric Centering}\label{lyriccentering}
@@ -371,9 +371,9 @@ special characters are defined by default:
   \texttt{\&} & An ampersand, avoiding \TeX{} interpretation.\\
   \texttt{\#} & A hash mark, avoiding \TeX{} interpretation.\\
   \texttt{\_} & An underscore, avoiding \TeX{} interpretation.\\
-  \texttt{ot} & An overtie (\greovertie).\\
-  \texttt{ut} & An undertie (\greundertie).\\
-  \texttt{dt} & A combined overtie + undertie (\gredoubletie).\\
+  \texttt{ot} & An overtie (\GreOverTie).\\
+  \texttt{ut} & An undertie (\GreUnderTie).\\
+  \texttt{dt} & A combined overtie + undertie (\GreDoubleTie).\\
   \texttt{\textasciitilde} & A centered tilde (a ``math'' tilde, \gretilde).\\
 \end{tabularx}
 

--- a/src/gabc/gabc-score-determination.l
+++ b/src/gabc/gabc-score-determination.l
@@ -234,7 +234,10 @@ semicolon. */
 <score>[\n\r][\n\r \t]* {
         RETURN_SPACE;
     }
-<score>(\$.|[^-,;:.\{\}\(\[\]<%\n\r])+ {
+<score>~ {
+        return LYRIC_TIE;
+    }
+<score>(\$.|[^-,;:.\{\}\(\[\]<%~\n\r])+ {
         RETURN_CHARACTERS;
     }
 <score>- {

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -718,6 +718,7 @@ static char *concatenate(char *first, char *const second) {
 %token VERB_BEGIN VERB_END
 %token CENTER_BEGIN CENTER_END
 %token ELISION_BEGIN ELISION_END
+%token LYRIC_TIE
 %token TRANSLATION_BEGIN TRANSLATION_END TRANSLATION_CENTER_END
 %token ALT_BEGIN ALT_END
 %token NLBA_B NLBA_E
@@ -1015,6 +1016,11 @@ character:
     above_line_text
     | CHARACTERS {
         add_text($1.text);
+    }
+    | LYRIC_TIE {
+        gregorio_begin_style(&current_character, ST_SPECIAL_CHAR);
+        add_text(gregorio_strdup("~"));
+        gregorio_end_style(&current_character, ST_SPECIAL_CHAR);
     }
     | style_beginning
     | style_end

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -1018,9 +1018,7 @@ character:
         add_text($1.text);
     }
     | LYRIC_TIE {
-        gregorio_begin_style(&current_character, ST_SPECIAL_CHAR);
         add_text(gregorio_strdup("~"));
-        gregorio_end_style(&current_character, ST_SPECIAL_CHAR);
     }
     | style_beginning
     | style_end

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1470,6 +1470,9 @@ static void gtex_print_char(FILE *f, const grewchar to_print)
     case L'-':
         fprintf(f, "\\GreHyph{}");
         break;
+    case L'~':
+        fprintf(f, "\\GreLyricTie{}");
+        break;
     default:
         gregorio_print_unichar(f, to_print);
         break;

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1633,21 +1633,21 @@
   \relax %
 }%
 
-\def\GreUnderTie{%
+\def\greundertie{%
   \kern-0.25em%
   \raisebox{-1ex}{\resizebox{0.7em}{!}{$\smile$}}%
   \kern-0.25em%
   \relax %
 }%
 
-\def\GreOverTie{%
+\def\greovertie{%
   \kern-0.25em%
   \raisebox{1ex}{\resizebox{0.7em}{!}{$\frown$}}%
   \kern-0.25em%
   \relax %
 }%
 
-\def\GreDoubleTie{%
+\def\gredoubletie{%
   \kern-0.25em%
   \raisebox{-1ex}{\resizebox{0.7em}{!}{$\smile$}}%
   \kern-0.7em%
@@ -1657,15 +1657,15 @@
 }%
 
 % Command to set the lyric tie character (~) to one of the tie macros
-% Default: \GreUnderTie
-\let\gre@lyrictie\GreUnderTie%
+% Default: \greundertie
+\let\gre@lyrictie\greundertie%
 \let\GreLyricTie\gre@lyrictie%
 
 \def\gresetlyrictie#1{%
   \IfStrEqCase{#1}{%
-    {undertie}{\let\gre@lyrictie\GreUnderTie\let\GreLyricTie\gre@lyrictie}%
-    {overtie}{\let\gre@lyrictie\GreOverTie\let\GreLyricTie\gre@lyrictie}%
-    {doubletie}{\let\gre@lyrictie\GreDoubleTie\let\GreLyricTie\gre@lyrictie}%
+    {undertie}{\let\gre@lyrictie\greundertie\let\GreLyricTie\gre@lyrictie}%
+    {overtie}{\let\gre@lyrictie\greovertie\let\GreLyricTie\gre@lyrictie}%
+    {doubletie}{\let\gre@lyrictie\gredoubletie\let\GreLyricTie\gre@lyrictie}%
   }[% all other cases
     \gre@error{Unrecognized option "#1" for \protect\gresetlyrictie\MessageBreak Possible options are: 'undertie', 'overtie', 'doubletie'}%
   ]%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1658,14 +1658,13 @@
 
 % Command to set the lyric tie character (~) to one of the tie macros
 % Default: \greundertie
-\let\gre@lyrictie\greundertie%
-\let\GreLyricTie\gre@lyrictie%
+\let\GreLyricTie\greundertie%
 
 \def\gresetlyrictie#1{%
   \IfStrEqCase{#1}{%
-    {undertie}{\let\gre@lyrictie\greundertie\let\GreLyricTie\gre@lyrictie}%
-    {overtie}{\let\gre@lyrictie\greovertie\let\GreLyricTie\gre@lyrictie}%
-    {doubletie}{\let\gre@lyrictie\gredoubletie\let\GreLyricTie\gre@lyrictie}%
+    {undertie}{\let\GreLyricTie\greundertie}%
+    {overtie}{\let\GreLyricTie\greovertie}%
+    {doubletie}{\let\GreLyricTie\gredoubletie}%
   }[% all other cases
     \gre@error{Unrecognized option "#1" for \protect\gresetlyrictie\MessageBreak Possible options are: 'undertie', 'overtie', 'doubletie'}%
   ]%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1656,6 +1656,20 @@
   \relax %
 }%
 
+% Command to set the lyric tie character (~) to one of the tie macros
+% Default: \greundertie
+\let\gre@lyrictie\greundertie%
+
+\def\gresetlyrictie#1{%
+  \IfStrEqCase{#1}{%
+    {undertie}{\let\gre@lyrictie\greundertie}%
+    {overtie}{\let\gre@lyrictie\greovertie}%
+    {doubletie}{\let\gre@lyrictie\gredoubletie}%
+  }[% all other cases
+    \gre@error{Unrecognized option "#1" for \protect\gresetlyrictie\MessageBreak Possible options are: 'undertie', 'overtie', 'doubletie'}%
+  ]%
+}%
+
 
 \def\gresetgregoriofont{\@ifnextchar[{\gre@setgregoriofont}{\gre@setgregoriofont[]}}%
 \def\gresetgregoriofontscaled{\@ifnextchar[{\gre@setgregoriofontscaled}{\gre@setgregoriofontscaled[]}}%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1633,21 +1633,21 @@
   \relax %
 }%
 
-\def\greundertie{%
+\def\GreUnderTie{%
   \kern-0.25em%
   \raisebox{-1ex}{\resizebox{0.7em}{!}{$\smile$}}%
   \kern-0.25em%
   \relax %
 }%
 
-\def\greovertie{%
+\def\GreOverTie{%
   \kern-0.25em%
   \raisebox{1ex}{\resizebox{0.7em}{!}{$\frown$}}%
   \kern-0.25em%
   \relax %
 }%
 
-\def\gredoubletie{%
+\def\GreDoubleTie{%
   \kern-0.25em%
   \raisebox{-1ex}{\resizebox{0.7em}{!}{$\smile$}}%
   \kern-0.7em%
@@ -1657,14 +1657,15 @@
 }%
 
 % Command to set the lyric tie character (~) to one of the tie macros
-% Default: \greundertie
-\let\gre@lyrictie\greundertie%
+% Default: \GreUnderTie
+\let\gre@lyrictie\GreUnderTie%
+\let\GreLyricTie\gre@lyrictie%
 
 \def\gresetlyrictie#1{%
   \IfStrEqCase{#1}{%
-    {undertie}{\let\gre@lyrictie\greundertie}%
-    {overtie}{\let\gre@lyrictie\greovertie}%
-    {doubletie}{\let\gre@lyrictie\gredoubletie}%
+    {undertie}{\let\gre@lyrictie\GreUnderTie\let\GreLyricTie\gre@lyrictie}%
+    {overtie}{\let\gre@lyrictie\GreOverTie\let\GreLyricTie\gre@lyrictie}%
+    {doubletie}{\let\gre@lyrictie\GreDoubleTie\let\GreLyricTie\gre@lyrictie}%
   }[% all other cases
     \gre@error{Unrecognized option "#1" for \protect\gresetlyrictie\MessageBreak Possible options are: 'undertie', 'overtie', 'doubletie'}%
   ]%

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1633,6 +1633,29 @@
   \relax %
 }%
 
+\def\greundertie{%
+  \kern-0.25em%
+  \raisebox{-1ex}{\resizebox{0.7em}{!}{$\smile$}}%
+  \kern-0.25em%
+  \relax %
+}%
+
+\def\greovertie{%
+  \kern-0.25em%
+  \raisebox{1ex}{\resizebox{0.7em}{!}{$\frown$}}%
+  \kern-0.25em%
+  \relax %
+}%
+
+\def\gredoubletie{%
+  \kern-0.25em%
+  \raisebox{-1ex}{\resizebox{0.7em}{!}{$\smile$}}%
+  \kern-0.7em%
+  \raisebox{1ex}{\resizebox{0.7em}{!}{$\frown$}}%
+  \kern-0.25em%
+  \relax %
+}%
+
 
 \def\gresetgregoriofont{\@ifnextchar[{\gre@setgregoriofont}{\gre@setgregoriofont[]}}%
 \def\gresetgregoriofontscaled{\@ifnextchar[{\gre@setgregoriofontscaled}{\gre@setgregoriofontscaled[]}}%

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -229,7 +229,7 @@
 \gresetspecial{\string\092}{\textbackslash{}}%
 \gresetspecial{\string\038}{\&{}}%
 \gresetspecial{\string\035}{\#{}}%
-\gresetspecial{\string\095}{\_{} }%
+\gresetspecial{\string\095}{\_{}}%
 \gresetspecial{ut}{\greundertie{}}%
 \gresetspecial{dt}{\gredoubletie{}}%
 \gresetspecial{ot}{\greovertie{}}%

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -229,7 +229,10 @@
 \gresetspecial{\string\092}{\textbackslash{}}%
 \gresetspecial{\string\038}{\&{}}%
 \gresetspecial{\string\035}{\#{}}%
-\gresetspecial{\string\095}{\_{}}%
+\gresetspecial{\string\095}{\_{} }%
+\gresetspecial{ut}{\greundertie{}}%
+\gresetspecial{dt}{\gredoubletie{}}%
+\gresetspecial{ot}{\greovertie{}}%
 \gresetspecial{\string\126}{\gretilde{}}%
 \gre@iflatex{%
   \@ifpackageloaded{luainputenc}{}{%

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -230,9 +230,9 @@
 \gresetspecial{\string\038}{\&{}}%
 \gresetspecial{\string\035}{\#{}}%
 \gresetspecial{\string\095}{\_{}}%
-\gresetspecial{ut}{\GreUnderTie{}}%
-\gresetspecial{dt}{\GreDoubleTie{}}%
-\gresetspecial{ot}{\GreOverTie{}}%
+\gresetspecial{ut}{\greundertie{}}%
+\gresetspecial{dt}{\gredoubletie{}}%
+\gresetspecial{ot}{\greovertie{}}%
 \gresetspecial{\string\126}{\gretilde{}}%
 \gre@iflatex{%
   \@ifpackageloaded{luainputenc}{}{%

--- a/tex/gregoriotex-symbols.tex
+++ b/tex/gregoriotex-symbols.tex
@@ -230,9 +230,9 @@
 \gresetspecial{\string\038}{\&{}}%
 \gresetspecial{\string\035}{\#{}}%
 \gresetspecial{\string\095}{\_{}}%
-\gresetspecial{ut}{\greundertie{}}%
-\gresetspecial{dt}{\gredoubletie{}}%
-\gresetspecial{ot}{\greovertie{}}%
+\gresetspecial{ut}{\GreUnderTie{}}%
+\gresetspecial{dt}{\GreDoubleTie{}}%
+\gresetspecial{ot}{\GreOverTie{}}%
 \gresetspecial{\string\126}{\gretilde{}}%
 \gre@iflatex{%
   \@ifpackageloaded{luainputenc}{}{%


### PR DESCRIPTION
## Summary

This PR introduces three new lyric text symbols (overtie, undertie, and doubletie) and implements lyric tie functionality for vernacular texts with elisions.

## New Features

### 1. Tie Symbols for Lyric Text

Three new special character macros are now available for use in lyric text:

- **`\GreUnderTie`**: Produces an undertie symbol: ‿
- **`\GreOverTie`**: Produces an overtie symbol: ⁀
- **`\GreDoubleTie`**: Produces a combined overtie and undertie symbol

These can be inserted in GABC files using:
- `<sp>ut</sp>` for undertie
- `<sp>ot</sp>` for overtie
- `<sp>dt</sp>` for doubletie

### 2. Lyric Tie with Tilde (~)

A more convenient syntax for lyric ties has been implemented using the tilde character (`~`) directly in syllable text, which is translated to macro `\GreLyricTie`. This feature is especially useful for representing **elisions in vernacular texts**.

When a tilde appears in the syllable text (not inside note parentheses), it is automatically converted to a tie symbol. The specific tie symbol used can be configured with the `\gresetlyrictie` command.

**Configuration:**
```latex
\gresetlyrictie{undertie}  % default
\gresetlyrictie{overtie}
\gresetlyrictie{doubletie}
```

**Example - Portuguese with elisions:**
```gabc
name: Ubi Caritas (Portuguese);
%%
(c4) On(f)d{e~o~a}(f)mor(gh) e(h) a(g) ca(h)ri(ixi)da(hg)de(hg) (,)
```

This will render "Onde o amor" with tying symbols connecting the elided syllables.

### 3. Tilde Symbol Clarification

- `<sp>~</sp>` → tilde symbol (~)
- `~` in syllable text → lyric tie (configurable)
- `~` in note groups → liquescent modifier

## Resolves

- Solves #1647