### PR TITLE
Make bool.h compatible with C23 (used by default by GCC 15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][develop]
 ### Added
 - Added overtie/undertie special symbols (`<sp>ut</sp>` for `\greundertie`, `<sp>ot</sp>` for `\greovertie`, and `<sp>dt</sp>` for `\gredoubletie`), and a configurable lyric tying shorthand (`~` for `\GreLyricTie`).
+- Added support for the C23 standard (the default in GCC 15). The included build scripts continue to default to GNU89 C.
 
 ### Fixed
 - Fixed a bug that could cause a punctum mora that is supposed to be below the line (`.0`) to appear above the line. This bug was platform-dependent and was observed on a Windows system.  See [#1642](https://github.com/gregorio-project/gregorio/issues/1642).

--- a/src/bool.h
+++ b/src/bool.h
@@ -23,8 +23,12 @@
 #ifndef BOOL_H
 #define BOOL_H
 
+#if __STDC_VERSION__ >= 199901L
+#include <stdbool.h>
+#else
 typedef unsigned int bool;
 #define true 1
 #define false 0
+#endif
 
 #endif


### PR DESCRIPTION
Passes all tests with -std=gnu89, -std=c99, and -std=c23. (With the latter two, the option -Wno-gnu-statement-expression also has to be removed.)

I did not check whether the change in sizeof(bool) would be a problem.

Credit: @jakubjelinek
Closes #1650