### PR TITLE
Add commands to documentation for macros with long arg tables

### DIFF
--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1082,11 +1082,11 @@ Macro for defining the various types of horizontal episema porrectus.
   \#2 & string & Camel case name of horizontal episema porrectus to be defined\\
 \end{argtable}
 
-\macroname{\textbackslash gre@get@spaceskip}{\#1}{gregoriotex-signs.tex}
+\longmacroname{\textbackslash gre@get@spaceskip}{\#1}{gregoriotex-signs.tex}
 Loads \verb=\gre@skip@temp@four= with the appropriate rubber length given the
 desired case.
 
-\begin{argtable}
+\begin{longargtable}
   \#1 & \texttt{0} & Default space.\\
   & \texttt{1} & Zero-width space.\\
   & \texttt{2} & Space between flat or natural and a note.\\
@@ -1114,7 +1114,7 @@ desired case.
   & \texttt{24} & Space before a right-leaning puncta inclinatum when the pitch is ascending (up to 4 pitches away). \\
   & \texttt{25} & Space before a left-leaning puncta inclinatum when the pitch is descending (up to 4 pitches away). \\
   & \texttt{26} & Space after after a non-punctum inclinatum and before the upright punctum inclinatum. \\
-\end{argtable}
+\end{longargtable}
 
 \macroname{\textbackslash gre@endsyllablepart}{}{gregoriotex-syllable.tex}
 Macro which stores the end part of the current syllable (that which comes after the alignment part).

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1093,7 +1093,7 @@ desired case.
   & \texttt{3} & Space between two puncta inclinata, descending.\\
   & \texttt{4} & Space between bivirga or trivirga.\\
   & \texttt{5} & space between bistropha or tristropha.\\
-  & \texttt{6} & Space after a punctum mora XXX: not used yet, not so sure it is a good idea\ldots\\
+  & \texttt{6} & Space after a punctum mora\\
   & \texttt{7} & Space between a punctum inclinatum and a punctum inclinatum debilis, descending.\\
   & \texttt{8} & Space between two puncta inclinata debilis.\\
   & \texttt{9} & Space before a punctum (or something else) and a punctum inclinatum.\\

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -102,6 +102,11 @@
 \let\oldsubsubsection\subsubsection
 \def\subsubsection{\filbreak\breakablefalse\oldsubsubsection}
 
+% macro used to title a macro description, arguments are
+% #1: the name of the macro
+% #2: the argument pattern the macro takes
+% #3: the file in which the macro is defined
+% contains page breaking controls so that a macro’s description all stays on the same page
 \newcommand{\macroname}[3]{%
   \vspace{3.25ex plus 1ex minus .2ex}%
   \ifbreakable%
@@ -115,6 +120,10 @@
   \index{#1}}
   %\addcontentsline{toc}{subsubsection}{#1}}
 
+% macro used to title a macro description when said description takes more than a single page 
+% (usually because of the use of longargtable instead of argtable)
+% arguments are the same as for \macroname
+% this macro will always force a pagebreak before beginning the macro description
 \newcommand{\longmacroname}[3]{%
   \clearpage
   \vspace{3.25ex plus 1ex minus .2ex}%
@@ -141,6 +150,7 @@
 \font\greextra = {name:greextra} at 12 pt\relax
 \newcommand{\excluded}[1]{{\tiny\itshape #1}}
 
+% normal table used when describing the arguments of a macro
 \newenvironment{argtable}{%
   \bigskip\rowcolors{1}{lightgray}{lightgray}
   \tabularx{\textwidth}{clX}
@@ -148,6 +158,7 @@
     \hline}%
   {\endtabularx\bigskip}
 
+% long table (capable of spanning multiple pages) used when describing the arguments of a macro
 \newenvironment{longargtable}{%
   \bigskip\rowcolors{1}{lightgray}{lightgray}
   \xltabular{\textwidth}{clX}

--- a/doc/GregorioRef.tex
+++ b/doc/GregorioRef.tex
@@ -82,6 +82,7 @@
 \hypersetup{colorlinks, citecolor=black, filecolor=black, linkcolor=green, urlcolor=green}
 
 \usepackage{longtable}
+\usepackage{xltabular}
 \usepackage{multirow}
 \usepackage{pdflscape}
 \usepackage{hhline}
@@ -114,6 +115,15 @@
   \index{#1}}
   %\addcontentsline{toc}{subsubsection}{#1}}
 
+\newcommand{\longmacroname}[3]{%
+  \clearpage
+  \vspace{3.25ex plus 1ex minus .2ex}%
+  \makebox[\linewidth]{\ttfamily\bfseries #1#2%
+  \hspace{\fill}\normalfont\itshape #3}%
+  \vspace{1.5ex plus .2ex}%
+  \index{#1}}
+  %\addcontentsline{toc}{subsubsection}{#1}}
+
 \newcommand{\optional}[1]{{\itshape #1}}
 
 \lstset{backgroundcolor=\color{lightgray},
@@ -137,6 +147,16 @@
     Arg & Value & Description \\
     \hline}%
   {\endtabularx\bigskip}
+
+\newenvironment{longargtable}{%
+  \bigskip\rowcolors{1}{lightgray}{lightgray}
+  \xltabular{\textwidth}{clX}
+    Arg & Value & Description \\
+    \hline\endhead
+    \multicolumn{3}{r}{\itshape Continued next page}\\\endfoot
+    \endlastfoot}%
+  {\endxltabular\bigskip}
+
 
 \makeatletter%
 \NewDocumentEnvironment{gdimension}{m}{\macroname{#1}{}{gregoriotex-gsp-default.tex}}{%

--- a/doc/doc_README.md
+++ b/doc/doc_README.md
@@ -25,14 +25,14 @@ The manual is divided into two files.  The first, GregorioRef.tex, contains seve
    table is generated automatically, so updates to this file should not be necessary.
  
 The second file, GregorioNabcRef.tex, documents the nabc syntax which provides the ability
-to describe some adiastematic neumes.
+to describe some adiastematic neumes (see below).
 
 Whenever modifications are made to the codebase, the manual source files should be updated
 to reflect the changes.  To aid with identifying needed changes, please use the
 `doc_check.sh` script in the parent to this directory.  Running this script will generate
 a text file with 2 lists in it: macros which are currently undocumented and macros which
 are documented but no longer appear in the code base.  This script doesn't look at the
-gabc syntax.
+gabc or nabc syntax.
 
 ## Building
 

--- a/doc/doc_README.md
+++ b/doc/doc_README.md
@@ -1,13 +1,38 @@
 Documentation for gregorio and gregoriotex
 ==========================================
 
-This folder contains the source files of a manual is primarily intended for
-developers. Users should not expect to find an indepth guide on using gregorio.
+This folder contains the source files of two manuals that are primarily intended for
+developers. Users should not expect to find an in-depth guide on using gregorio.
 
 You can find a compiled PDF version in the files of each [Gregorio release](https://github.com/gregorio-project/gregorio/releases).
 
 Developers can use this manual as a reference for information on the
 internal workings of gregorio.
+
+The manual is divided into two files.  The first, GregorioRef.tex, contains several parts:
+
+ * Command_Index_User.tex: This file documents the user interface.  That includes package
+   options, user macros (mostly prefixed by `\gre`), counts, distances, penalties, and
+   colors.
+ * Command_Index_gregorio.tex: This file documents the macros written to gtex files by the
+   executable.  These should all be prefixed by `\Gre`.
+ * Command_Index_internal.tex: This file documents the internal macros used by GregorioTeX
+   to carryout various tasks as it typesets a score.  These should all be prefixed by
+   `\gre@`.
+ * Gabc.tex: This file documents the gabc syntax.
+ * Appendix_Font_Tables.tex: This is the source for the appendix which lists all the
+   available glyphs in the greciliae font and any variant glyphs contained within.  This
+   table is generated automatically, so updates to this file should not be necessary.
+ 
+The second file, GregorioNabcRef.tex, documents the nabc syntax which provides the ability
+to describe some adiastematic neumes.
+
+Whenever modifications are made to the codebase, the manual source files should be updated
+to reflect the changes.  To aid with identifying needed changes, please use the
+`doc_check.sh` script in the parent to this directory.  Running this script will generate
+a text file with 2 lists in it: macros which are currently undocumented and macros which
+are documented but no longer appear in the code base.  This script doesn't look at the
+gabc syntax.
 
 ## Building
 


### PR DESCRIPTION
`tabularx` does not allow it's table contents to be broken over multiple pages.  Previously having a table bigger than could normally fit on one page just led to an overfull page, but recent changes have caused such a table create a cascade that leads to TeX capacity exceeding errors. Using the `xltabular` package, we define a new version of `argtable`, `longargtable`, which can be split over multiple pages. To prevent issues with the page breaking controls that are built into `\macroname` interfering with the headers and footers of this `longargtable`, we also define `\longmacroname` which forces a pagebreak directly before that macro in the docs.  Paired with `longargtable` this forces the macro with the long argument description to start a new page and use the pagebreaks allowed by the new environment.

Fixes https://github.com/gregorio-project/gregorio/issues/1706