### PR TITLE
Revert "Fix conflict between develop and ctan branches after merging PRs #1701 and #1703"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Added
 - Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 - Nabc can now appear below the staff in addition (or instead of) above.  See [#1645](https://github.com/gregorio-project/gregorio/issues/1645).
-- Added `\gresetnabcalignment` command to control NABC horizontal alignment mode (`full` or `neume`). In `neume` mode, significative letters are excluded from alignment calculation, keeping the neume body centered above the corresponding note. Supports per-voice configuration with optional voice parameter.  See [#1702](https://github.com/gregorio-project/gregorio/issues/1702).
 
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.  Mentioned in [#1488](https://github.com/gregorio-project/gregorio/issues/1488).

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1294,15 +1294,6 @@ Sets the visibility of an NABC voice.
 
 \textbf{Important:} NABC glyphs visibility is controlled independently from notes visibility (\verb=\gresetnotes=). This allows you to hide the main notes (i.e. using \verb=\gresetnotes{invisible}= or some \verb=\gresetnotes{?phantom}= variant) while keeping NABC glyphs visible, which is useful for producing NABC-only output with lyrics.
 
-\macroname{\textbackslash gresetnabcalignment}{[\#1]\{\#2\}}{gregoriotex-nabc.tex}
-Sets the horizontal alignment reference for nabc neumes relative to the gabc notes below.  By default, nabc neumes are aligned to the left edge of the entire complex glyph descriptor (including significative letters), which can produce aesthetically suboptimal results when there are significative letters to the left of the neume.  The optional voice parameter allows setting the alignment independently for each nabc voice.
-
-\begin{argtable}
-  \#1 & integer & (Optional) The nabc voice number: 1 = above staff, 2 = below staff.  If omitted, sets the default for all voices and clears any per-voice overrides.\\
-  \#2 & \texttt{neume} & Align to the neume (basic glyph descriptor + prepunctis), ignoring significative letters.\\
-  & \texttt{full} & Align to the entire complex glyph descriptor (default).\\
-\end{argtable}
-
 \macroname{\textbackslash greprintsigns}{\{\#1\}\{\#2\}}{gregoriotex-signs.tex}
 Macro to prevent rythmic signs from printing (all signs are printed by default):
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1053,14 +1053,16 @@ The arguments are the same as \verb=\GreSetInitialClef= without the \#7th one, w
 to be \texttt{1}.
 
 \macroname{\textbackslash GreSetNabcAboveLines}{\#1}{gregoriotex-main.tex}
-Macro to place argument containing Nabc neumes above the lines.
+Macro to place argument containing Nabc neumes above the lines and empty
+\verb=\gre@currentnabcvoice@i= when done.
 
 \begin{argtable}
   \#1 & string & Nabc neumes to be placed above the lines.\\
 \end{argtable}
 
 \macroname{\textbackslash GreSetNabcBelowLines}{\#1}{gregoriotex-main.tex}
-Macro to place argument containing Nabc neumes below the lines.
+Macro to place argument containing Nabc neumes below the lines and empty
+\verb=\gre@currentnabcvoice@ii= when done.
 
 \begin{argtable}
   \#1 & string & Nabc neumes to be placed below the lines.\\

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -556,6 +556,12 @@ Macro to hold the height of the current flat for the secondary clef (\texttt{3} 
 \macroname{\textbackslash gre@currenttextabovelines}{}{gregoriotex-main.tex}
 Macro for storing the text which needs to be placed above the lines.
 
+\macroname{\textbackslash gre@currentnabcvoice@i}{}{gregoriotex-main.tex}
+Macro for storing the nabc neumes which need to be placed above the lines.
+
+\macroname{\textbackslash gre@currentnabcvoice@ii}{}{gregoriotex-main.tex}
+Macro for storing the nabc neumes which need to be placed below the lines.
+
 \macroname{\textbackslash gre@typesettextabovelines}{\#1\#2}{gregoriotex-main.tex}
 Macro for typesetting the text or nabc neumes above the lines.
 
@@ -1471,49 +1477,6 @@ Prints the nabc glyphs for the given nabc string.
   \#2 & string & The \texttt{nabc} syntax which indicates what neumes are to be printed.\\
 \end{argtable}
 
-\macroname{\textbackslash gre@nabc@prepare}{\#1\#2}{gregoriotex-main.tex}
-Phase 1 of NABC two-phase processing: pre-evaluates NABC content, emits note-level kern for left overflow (in \texttt{neume} alignment mode), and saves the rendered content in a box register.
-
-\begin{argtable}
-  \#1 & content & The NABC content (from \textbackslash GreNABCChar)\\
-  \#2 & box register & Box register to save the rendered content to\\
-\end{argtable}
-
-\macroname{\textbackslash gre@nabc@place@voice@i}{}{gregoriotex-main.tex}
-Phase 2 of NABC two-phase processing for voice 1 (above staff): places the pre-rendered NABC voice 1 content from \textbackslash gre@box@nabc@voice@i at the correct vertical position above the staff.
-
-\macroname{\textbackslash gre@nabc@place@voice@ii}{}{gregoriotex-main.tex}
-Phase 2 of NABC two-phase processing for voice 2 (below staff): places the pre-rendered NABC voice 2 content from \textbackslash gre@box@nabc@voice@ii at the correct vertical position below the staff.
-
-\macroname{\textbackslash gre@nabc@pre@voice@i}{}{gregoriotex-main.tex}
-Deferred macro for phase 1 processing of NABC voice 1 (above staff). Set by \textbackslash GreSetNabcAboveLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
-
-\macroname{\textbackslash gre@nabc@pre@voice@ii}{}{gregoriotex-main.tex}
-Deferred macro for phase 1 processing of NABC voice 2 (below staff). Set by \textbackslash GreSetNabcBelowLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
-
-\macroname{\textbackslash gre@nabc@emit@voice@i}{}{gregoriotex-main.tex}
-Deferred macro for phase 2 processing of NABC voice 1 (above staff). Set by \textbackslash GreSetNabcAboveLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
-
-\macroname{\textbackslash gre@nabc@emit@voice@ii}{}{gregoriotex-main.tex}
-Deferred macro for phase 2 processing of NABC voice 2 (below staff). Set by \textbackslash GreSetNabcBelowLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
-
-\macroname{\textbackslash gre@setnabcalignment@global}{\#1}{gregoriotex-nabc.tex}
-Sets the default NABC horizontal alignment mode for all voices and clears any per-voice overrides.
-
-\begin{argtable}
-  \#1 & \texttt{neume} & Align to the neume (basic glyph + prepunctis), ignoring significative letters\\
-  & \texttt{full} & Align to the entire complex glyph descriptor (default)\\
-\end{argtable}
-
-\macroname{\textbackslash gre@setnabcalignment@voice}{[\#1]\{\#2\}}{gregoriotex-nabc.tex}
-Sets the NABC horizontal alignment mode for a specific voice.
-
-\begin{argtable}
-  \#1 & integer & The nabc voice number: 1 = above staff, 2 = below staff\\
-  \#2 & \texttt{neume} & Align to the neume (basic glyph + prepunctis), ignoring significative letters\\
-  & \texttt{full} & Align to the entire complex glyph descriptor (default)\\
-\end{argtable}
-
 
 \subsection{Auxiliary File}
 Gregorio\TeX\ creates its own auxiliary file (extension \texttt{gaux}) which it uses to store information between successive typesetting runs.  This allows for such features as the dynamic interline spacing.  The following functions are used to interact with that auxiliary file.
@@ -1754,14 +1717,13 @@ number of lines for the staff.
 Alias that will hold the character for the dotted divisio maior backing for the
 current number of lines for the staff.
 
-\macroname{\textbackslash gre@nabccharno}{\#1\#2\#3\#4}{gregoriotex-nabc.tex}
+\macroname{\textbackslash gre@nabccharno}{\#1\#2\#3}{gregoriotex-nabc.tex}
 Prints the nabc glyphs for the given nabc string.
 
 \begin{argtable}
   \#1 & string & nabc code representing the character\\
   \#2 & string & name of nabc font to use\\
   \#3 & integer & scaling factor\\
-  \#4 & integer & voice number (1 = above staff, 2 = below staff)\\
 \end{argtable}
 
 
@@ -2188,15 +2150,6 @@ Box holding the text associated with a syllable.
 \macroname{\textbackslash gre@box@hep}{}{gregoriotex-chars.tex}
 Box holding the horizontal episema.
 
-\macroname{\textbackslash gre@box@nabctemp}{}{gregoriotex-nabc.tex}
-Temporary box used during NABC two-phase processing to pre-evaluate NABC content and trigger Lua-side calculations (such as left overflow in \texttt{neume} alignment mode).
-
-\macroname{\textbackslash gre@box@nabc@voice@i}{}{gregoriotex-nabc.tex}
-Box for saving NABC voice 1 (above staff) content between phase 1 (prepare) and phase 2 (place) of the two-phase processing. The two-phase approach ensures all note-level kerns are emitted before any voice hbox is placed, guaranteeing correct horizontal alignment.
-
-\macroname{\textbackslash gre@box@nabc@voice@ii}{}{gregoriotex-nabc.tex}
-Box for saving NABC voice 2 (below staff) content between phase 1 (prepare) and phase 2 (place) of the two-phase processing. The two-phase approach ensures all note-level kerns are emitted before any voice hbox is placed, guaranteeing correct horizontal alignment.
-
 
 \subsection{Protrusion factors}
 
@@ -2359,12 +2312,6 @@ Working alias for \verb=\gre@skip@temp@one= or \verb=\gre@dimen@temp@one=, as ap
 
 \macroname{\textbackslash gre@skip@syllablefinalskip}{}{gregoriotex-spaces.tex}
 The final distance to skip at the end of a syllable.
-
-\macroname{\textbackslash gre@dimen@nabcleftoverflow}{}{gregoriotex-nabc.tex}
-Dimension for communicating NABC left overflow from Lua to \TeX. When NABC alignment mode is \texttt{neume}, significative letters on the left side of a neume extend to the left of the neume body. This dimension holds the overflow width (set by Lua code during NABC rendering) so that the \TeX\ layer can reserve space at the note level to prevent overlap with previous elements. Reset to 0pt after each syllable.
-
-\macroname{\textbackslash gre@dimen@nabckernemitted}{}{gregoriotex-nabc.tex}
-Tracks the total kern emitted at the note level across all NABC voices for the current syllable. Used to coordinate left overflow handling between voice 1 (above staff) and voice 2 (below staff), ensuring that only the maximum overflow is applied. Reset to 0pt after each syllable.
 
 \macroname{\textbackslash greslurheight}{}{gregoriotex-signs.tex}
 Stores the computed height of a variable-length slur.  The control sequence name

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -659,102 +659,53 @@
     + \gre@space@dimen@spacebeneathtext %
     + \gre@space@dimen@spacelinestext)\relax%
   \gre@debugmsg{spacing}{Raise alt text: \the\gre@dimen@temp@five}%
-  \ifnum#2=1\relax%
-    % For NABC: pre-evaluate content in a box to trigger Lua execution,
-    % which may set \gre@dimen@nabcleftoverflow for 'neume' alignment mode.
-    \setbox\gre@box@nabctemp=\hbox{#1}%
-    % Reserve space at the note level for left-extending significative letters.
-    % Only emit additional kern beyond what was already emitted (by a previous
-    % voice).  The kern must NOT carry the nabc part attribute, otherwise the
-    % Lua post_linebreak filter will try to shift it (kerns have no shift field).
-    \ifdim\gre@dimen@nabcleftoverflow>\gre@dimen@nabckernemitted\relax%
-      \unsetattribute{\gre@attr@part}%
-      \kern\dimexpr(\gre@dimen@nabcleftoverflow-\gre@dimen@nabckernemitted)\relax%
-      \gre@attr@part=7\relax%
-      \global\gre@dimen@nabckernemitted=\gre@dimen@nabcleftoverflow\relax%
-    \fi%
-    \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\unhbox\gre@box@nabctemp\hss}%
-  \else%
+  \ifnum#2=1\relax
+    % NABC: measure natural width for overflow detection
+    \setbox0=\hbox{#1}%
+    \ifdim\wd0 > \gre@dimen@nabc@maxwidth\relax
+      \global\gre@dimen@nabc@maxwidth=\wd0\relax
+    \fi
+    \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\box0\hss}%
+  \else
     \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{%
       \gre@style@abovelinestext
         \gre@applyphantomwrapper{\gre@abovelinestext@phantomwrapper}{#1}%
       \endgre@style@abovelinestext
     \hss}%
-  \fi%
+  \fi
   \unsetattribute{\gre@attr@part}%
   \gre@trace@end%
 }%
 
-% NABC two-phase processing macros.
-% Phase 1 (prepare): pre-evaluate Lua content, emit note-level kern for
-% overflow, and save the rendered content in a box register.
-% Phase 2 (place): emit the saved box at the correct position.
-% By splitting into two phases across all voices, we ensure that all
-% note-level kerns are emitted before any voice hbox is placed.  This
-% guarantees that each voice's hbox starts at position P + total_kern
-% (the max across all voices), so each voice's neume correctly aligns
-% with the GABC note regardless of the other voice's overflow.
+% similarly, but for typesetting Nabc neumes above lines
 
-% Phase 1: Pre-evaluate NABC content, emit kern, save content.
-% #1: content (from \GreNABCChar)
-% #2: box register to save to
-\def\gre@nabc@prepare#1#2{%
-  \gre@attr@part=7\relax%
-  \setbox\gre@box@nabctemp=\hbox{#1}%
-  \ifdim\gre@dimen@nabcleftoverflow>\gre@dimen@nabckernemitted\relax%
-    \unsetattribute{\gre@attr@part}%
-    \kern\dimexpr(\gre@dimen@nabcleftoverflow-\gre@dimen@nabckernemitted)\relax%
-    \gre@attr@part=7\relax%
-    \global\gre@dimen@nabckernemitted=\gre@dimen@nabcleftoverflow\relax%
-  \fi%
-  \global\setbox#2=\hbox{\unhbox\gre@box@nabctemp}%
-  \unsetattribute{\gre@attr@part}%
-}%
-
-% Phase 2: Place voice 1 (above staff)
-\def\gre@nabc@place@voice@i{%
-  \gre@attr@part=7\relax%
-  \gre@dimen@temp@five=\dimexpr(\gre@dimen@staffheight %
-    + \gre@space@dimen@spacebeneathtext %
-    + \gre@space@dimen@spacelinestext)\relax%
-  \leavevmode\raise\gre@dimen@temp@five\hbox to 0pt{\unhbox\gre@box@nabc@voice@i\hss}%
-  \unsetattribute{\gre@attr@part}%
-}%
-
-% Phase 2: Place voice 2 (below staff)
-\def\gre@nabc@place@voice@ii{%
-  \gre@dimen@temp@five=\dimexpr(\gre@space@dimen@spacebeneathtext
-    + \gre@space@dimen@spacelinestext)\relax
-  \leavevmode\raise\gre@dimen@temp@five\hbox attr \gre@attrid@part=8 to 0pt{\unhbox\gre@box@nabc@voice@ii\hss}%
-}%
-
-% Deferred macros for two-phase processing.
-% pre = Phase 1, emit = Phase 2.  Set by \GreSetNabcAboveLines / BelowLines,
-% called from \gre@newglyphcommon.
-\xdef\gre@nabc@pre@voice@i{}%
-\xdef\gre@nabc@pre@voice@ii{}%
-\xdef\gre@nabc@emit@voice@i{}%
-\xdef\gre@nabc@emit@voice@ii{}%
+\xdef\gre@currentnabcvoice@i{}%
+\xdef\gre@currentnabcvoice@ii{}%
 
 \def\GreSetNabcAboveLines#1{%
-  \gdef\gre@nabc@pre@voice@i{%
-    \gre@nabc@prepare{#1}\gre@box@nabc@voice@i%
-    \gdef\gre@nabc@pre@voice@i{}%
+  \gdef\gre@currentnabcvoice@i{%
+    \gre@typesettextabovelines{#1}{1}%
+    \gdef\gre@currentnabcvoice@i{}%
   }%
-  \gdef\gre@nabc@emit@voice@i{%
-    \gre@nabc@place@voice@i%
-    \gdef\gre@nabc@emit@voice@i{}%
-  }%
+}%
+
+\def\gre@typesettextbelowlines#1{%
+  \gre@trace{gre@typesettextbelowlines{#1}}%
+  \gre@dimen@temp@five=\dimexpr(\gre@space@dimen@spacebeneathtext
+    + \gre@space@dimen@spacelinestext)\relax
+  % Measure natural width for overflow detection
+  \setbox0=\hbox{#1}%
+  \ifdim\wd0 > \gre@dimen@nabc@maxwidth\relax
+    \global\gre@dimen@nabc@maxwidth=\wd0\relax
+  \fi
+  \leavevmode\raise\gre@dimen@temp@five\hbox attr \gre@attrid@part=8 to 0pt{\box0\hss}%
+  \gre@trace@end%
 }%
 
 \def\GreSetNabcBelowLines#1{%
-  \gdef\gre@nabc@pre@voice@ii{%
-    \gre@nabc@prepare{#1}\gre@box@nabc@voice@ii%
-    \gdef\gre@nabc@pre@voice@ii{}%
-  }%
-  \gdef\gre@nabc@emit@voice@ii{%
-    \gre@nabc@place@voice@ii%
-    \gdef\gre@nabc@emit@voice@ii{}%
+  \gdef\gre@currentnabcvoice@ii{%
+    \gre@typesettextbelowlines{#1}%
+    \gdef\gre@currentnabcvoice@ii{}%
   }%
 }%
 

--- a/tex/gregoriotex-nabc.lua
+++ b/tex/gregoriotex-nabc.lua
@@ -106,17 +106,6 @@ end
 local gregalltab = {}
 local gregallmetrics = {}
 
--- NABC alignment mode (per-voice, with global default):
--- 'full' = align to left of entire complex glyph descriptor (default)
--- 'neume' = align to left of neume (basic glyph + prepunctis), ignoring
---           significative letters
--- Index 0 = global default, 1..n = per-voice override
-local nabc_alignment = { [0] = 'full' }
-
-local function get_nabc_alignment(voice)
-  return nabc_alignment[voice or 0] or nabc_alignment[0] or 'full'
-end
-
 local gregallneumekinds = { vi = 1, pu = 1, ta = 1, gr = 1, cl = 1, un = 1, pv = 1, pe = 1, po = 1, to = 1, ci = 1, sc = 1, pf = 1, sf = 1, tr = 1,
   st = 1, ds = 1, ts = 1, tg = 1, bv = 1, tv = 1, pr = 1, pi = 1, vs = 1, ["or"] = 1, sa = 1, pq = 1, qi = 1, ql = 1, pt = 1,
   un = 1, oc = 1, ni = 1 }
@@ -302,7 +291,7 @@ local add_spacing = function(str, len, idx, ret)
   return idx, ret
 end
 
-local gregallparse_neumes = function(str, kind, scale, voice)
+local gregallparse_neumes = function(str, kind, scale)
   local len = str:len()
   local idx = 1
   local ret = ''
@@ -456,17 +445,6 @@ local gregallparse_neumes = function(str, kind, scale, voice)
           end
         end
         base = pre..base..post
-        -- Apply alignment offset: in 'neume' mode, shift left by the
-        -- width of left-side significative letters (positions 1, 4, 7)
-        -- so that the neume (base glyph + prepunctis) is the reference.
-        -- Also set \gre@dimen@nabcleftoverflow so the TeX layer can
-        -- reserve space at the note level and prevent overlap with the
-        -- previous element.
-        if get_nabc_alignment(voice) == 'neume' and lwidths[10] > 0 then
-          local overflow_sp = string.format("%.3f", lwidths[10] * scale)
-          base = '\\global\\gre@dimen@nabcleftoverflow=' .. overflow_sp .. 'sp'
-              .. '\\kern -' .. overflow_sp .. 'sp' .. base
-        end
       end
     end
     ret = ret .. base
@@ -485,26 +463,7 @@ local function print_nabc(nabc)
   tex.sprint(catcode_at_letter, nabc)
 end
 
-local function set_nabc_alignment(mode, voice)
-  if mode == 'neume' or mode == 'full' then
-    if voice then
-      nabc_alignment[voice] = mode
-    else
-      -- Setting without voice resets all per-voice overrides
-      nabc_alignment = { [0] = mode }
-    end
-  else
-    texio.write_nl('Warning: unknown nabc alignment mode "'..mode..'", using "full".')
-    if voice then
-      nabc_alignment[voice] = 'full'
-    else
-      nabc_alignment = { [0] = 'full' }
-    end
-  end
-end
-
 gregoriotex.parse_nabc = gregallparse_neumes
 gregoriotex.print_nabc = print_nabc
 gregoriotex.init_nabc_font = init_font
 gregoriotex.nabc_font_tables = gregalltab
-gregoriotex.set_nabc_alignment = set_nabc_alignment

--- a/tex/gregoriotex-nabc.tex
+++ b/tex/gregoriotex-nabc.tex
@@ -21,24 +21,6 @@
 
 \gre@declarefileversion{gregoriotex-nabc.tex}{6.1.0}% GREGORIO_VERSION
 
-% Dimension for communicating NABC left overflow from Lua to TeX.
-% When nabc alignment is 'neume', left-side significative letters extend
-% to the left of the neume.  This dimension holds the overflow width so
-% that \gre@typesettextabovelines can reserve space at the note level.
-\newdimen\gre@dimen@nabcleftoverflow
-\gre@dimen@nabcleftoverflow=0pt\relax
-% Tracks how much kern has been emitted at note level across all NABC voices.
-% Used to coordinate overflow between voice 1 (above) and voice 2 (below).
-\newdimen\gre@dimen@nabckernemitted
-\gre@dimen@nabckernemitted=0pt\relax
-\newbox\gre@box@nabctemp
-% Boxes for saving NABC voice content between prepare and place phases.
-% The two-phase processing ensures that all voices are pre-evaluated and
-% all note-level kerns emitted before any voice hbox is placed, so that
-% each voice is at the correct horizontal position (P + total_kern).
-\newbox\gre@box@nabc@voice@i
-\newbox\gre@box@nabc@voice@ii
-
 % \gresetnabcfont[#1]#2#3
 % #1: voice
 % #2: font name
@@ -55,13 +37,9 @@
   }%
 }
 
-% #1: NABC string
-% #2: font name
-% #3: scale
-% #4: voice number
-\def\gre@nabccharno#1#2#3#4{%
-  \gre@trace{gre@nabccharno{#1}{#2}{#3}{#4}}%
-  {\directlua{gregoriotex.print_nabc(gregoriotex.parse_nabc("#1", "\luaescapestring{#2}", #3, #4))}}%
+\def\gre@nabccharno#1#2#3{%
+  \gre@trace{gre@nabccharno{#1}{#2}{#3}}%
+  {\directlua{gregoriotex.print_nabc(gregoriotex.parse_nabc("#1", "\luaescapestring{#2}", #3))}}%
   \gre@trace@end%
 }
 
@@ -75,7 +53,7 @@
   \csname gre@font@nabcvoice@\romannumeral#1\endcsname
   \gre@style@nabc
   \ifcase#1\relax\or\gre@style@abovelinesnabc\or\gre@style@belowlinesnabc\fi
-  \gre@nabccharno{#2}{\csname gre@nabcvoice@\romannumeral#1@fontname\endcsname}{1}{#1}%
+  \gre@nabccharno{#2}{\csname gre@nabcvoice@\romannumeral#1@fontname\endcsname}{1}%
   \ifcase#1\relax\or\endgre@style@abovelinesnabc\or\endgre@style@belowlinesnabc\fi
   \endgre@style@nabc
 }}
@@ -96,36 +74,6 @@
     {\csname gre@nabcvoice@\romannumeral#1@visiblefalse\endcsname}%
     {\csname gre@nabcvoice@\romannumeral#1@phantomwrapper\endcsname}%
     {\protect\gresetnabc}%
-}
-
-% \gresetnabcalignment[#1]#2 - set the horizontal alignment reference for NABC
-% neumes relative to the gabc notes below.
-% #1: voice number (optional; if omitted, sets the default for all voices
-%     and clears any per-voice overrides)
-% #2: alignment mode
-%   neume - align to the neume (basic glyph + prepunctis), ignoring
-%           significative letters
-%   full  - align to the entire complex glyph descriptor (default)
-\def\gresetnabcalignment{\@ifnextchar[{\gre@setnabcalignment@voice}{\gre@setnabcalignment@global}}%
-\def\gre@setnabcalignment@global#1{%
-  \IfStrEqCase{#1}{%
-    {neume}%
-      {\directlua{gregoriotex.set_nabc_alignment("neume")}}%
-    {full}%
-      {\directlua{gregoriotex.set_nabc_alignment("full")}}%
-    }[% all other cases
-      \gre@error{Unrecognized option "#1" for \protect\gresetnabcalignment\MessageBreak Possible options are: 'neume' and 'full'}%
-    ]%
-}%
-\def\gre@setnabcalignment@voice[#1]#2{%
-  \IfStrEqCase{#2}{%
-    {neume}%
-      {\directlua{gregoriotex.set_nabc_alignment("neume", #1)}}%
-    {full}%
-      {\directlua{gregoriotex.set_nabc_alignment("full", #1)}}%
-    }[% all other cases
-      \gre@error{Unrecognized option "#2" for \protect\gresetnabcalignment\MessageBreak Possible options are: 'neume' and 'full'}%
-    ]%
 }
 
 \def\GreNABCNeumes#1#2#3#4{%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -96,24 +96,8 @@
   \fi %
   \global\gre@skip@bar@lastskip=0pt\relax %
   \gre@currenttextabovelines %
-  % NABC two-phase processing: first pre-evaluate all voices and emit
-  % note-level kerns, then place all voice hboxes.  This ensures each
-  % voice's hbox is at position P + total_kern so that neumes align
-  % correctly with the GABC note regardless of the other voice's overflow.
-  \gre@nabc@pre@voice@i
-  \gre@nabc@pre@voice@ii
-  % Ensure nabcleftoverflow holds the max for text alignment adjustment.
-  \ifdim\gre@dimen@nabckernemitted>\gre@dimen@nabcleftoverflow\relax%
-    \global\gre@dimen@nabcleftoverflow=\gre@dimen@nabckernemitted\relax%
-  \fi%
-  \gre@nabc@emit@voice@i
-  \gre@nabc@emit@voice@ii
-  % Reset NABC overflow accumulators after all voices have been processed.
-  % During boxing, keep values so the adjustment code can read them.
-  \ifgre@boxing\else%
-    \global\gre@dimen@nabcleftoverflow=0pt\relax%
-    \global\gre@dimen@nabckernemitted=0pt\relax%
-  \fi%
+  \gre@currentnabcvoice@i
+  \gre@currentnabcvoice@ii
   \ifcase\gre@count@lastglyphiscavum\or %
     \global\gre@count@lastglyphiscavum=2\relax %
   \or %
@@ -1042,13 +1026,6 @@
   % have the same alteration ids, if any.
   \edef\gre@saved@attr@alteration@id{\number\gre@attr@alteration@id\relax}%
   \gre@syllablenotes{#9}% we put the notes in a box, so that we have the width of it
-  % Adjust notesaligncenter for NABC left overflow in 'neume' alignment mode.
-  % The kern emitted before the glyph pushes it right; the text must follow.
-  \ifdim\gre@dimen@nabcleftoverflow>0pt\relax%
-    \global\advance\gre@dimen@notesaligncenter by \gre@dimen@nabcleftoverflow\relax%
-    \global\gre@dimen@nabcleftoverflow=0pt\relax%
-    \global\gre@dimen@nabckernemitted=0pt\relax%
-  \fi%
   % now we calculate the begin difference, that is to say \gre@dimen@notesaligncenter - \gre@dimen@textaligncenter
   \gre@dimen@begindifference=\dimexpr(\gre@dimen@notesaligncenter - \gre@dimen@textaligncenter)\relax %
   % Now, let's go for something I took years to figure out: we want to align


### PR DESCRIPTION
Reverts gregorio-project/gregorio#1709

This merge broke things.  Several of the tests which were changed for spacing reasons have reverted and fix-1700 no longer compiles.