### PR TITLE
Fix regressions introduced after ctan merge (#1708)

### DIFF
--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1345,6 +1345,9 @@ Macro to print a nabc character above the lines.
   \#4 & integer & The low pitch of the notes covered by the nabc character(s).\\
 \end{argtable}
 
+\macroname{\textbackslash GreFlushNABC}{}{gregoriotex-nabc.tex}
+Flushes pending NABC neumes for syllables whose gabc element has no note glyphs (e.g.\ an empty gabc snippet).  Executes both the preparation phase (\textbackslash gre@nabc@pre@voice@i, \textbackslash gre@nabc@pre@voice@ii) and the placement phase (\textbackslash gre@nabc@emit@voice@i, \textbackslash gre@nabc@emit@voice@ii) so that NABC content is rendered even when no \textbackslash GreGlyph callback fires.
+
 \macroname{\textbackslash GreNABCChar}{[\#1]\{\#2\}}{gregoriotex-nabc.tex}
 Macro to print a nabc character.
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1345,10 +1345,6 @@ Macro to print a nabc character above the lines.
   \#4 & integer & The low pitch of the notes covered by the nabc character(s).\\
 \end{argtable}
 
-\macroname{\textbackslash GreFlushNABC}{}{gregoriotex-nabc.tex}
-Macro to immediately typeset pending nabc neumes stored by \textbackslash GreNABCNeumes.
-Useful when a syllable has nabc but no gabc glyph to trigger normal rendering.
-
 \macroname{\textbackslash GreNABCChar}{[\#1]\{\#2\}}{gregoriotex-nabc.tex}
 Macro to print a nabc character.
 

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1472,7 +1472,7 @@ Prints the nabc glyphs for the given nabc string.
 \end{argtable}
 
 \macroname{\textbackslash gre@nabc@prepare}{\#1\#2}{gregoriotex-main.tex}
-Phase 1 of NABC two-phase processing: pre-evaluates NABC content, emits note-level kern for left overflow (in \texttt{neume} alignment mode), and saves the rendered content in a box register.
+Phase 1 of NABC two-phase processing: pre-evaluates NABC content, tracks the maximum NABC width in \verb=\gre@dimen@nabc@maxwidth= for right-overflow detection by \verb=\gre@compute@nabc@extrakern=, emits note-level kern for left overflow (in \texttt{neume} alignment mode), and saves the rendered content in a box register.  No part attribute is set during this phase; the part attribute (7 for voice~1, 8 for voice~2) is applied only during Phase~2 (place) to avoid stray attributes when preparing voice~2.
 
 \begin{argtable}
   \#1 & content & The NABC content (from \textbackslash GreNABCChar)\\

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1472,7 +1472,7 @@ Prints the nabc glyphs for the given nabc string.
 \end{argtable}
 
 \macroname{\textbackslash gre@nabc@prepare}{\#1\#2}{gregoriotex-main.tex}
-Phase 1 of NABC two-phase processing: pre-evaluates NABC content, tracks the maximum NABC width in \verb=\gre@dimen@nabc@maxwidth= for right-overflow detection by \verb=\gre@compute@nabc@extrakern=, emits note-level kern for left overflow (in \texttt{neume} alignment mode), and saves the rendered content in a box register.  No part attribute is set during this phase; the part attribute (7 for voice~1, 8 for voice~2) is applied only during Phase~2 (place) to avoid stray attributes when preparing voice~2.
+Phase 1 of NABC two-phase processing: pre-evaluates NABC content, tracks the maximum NABC width in \verb=\gre@dimen@nabc@maxwidth= for right-overflow detection by \verb=\gre@compute@nabc@extrakern=, emits note-level kern for left overflow (in \texttt{neume} alignment mode), and saves the rendered content in a box register.
 
 \begin{argtable}
   \#1 & content & The NABC content (from \textbackslash GreNABCChar)\\

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -4201,6 +4201,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                 signed char high_pitch = UNDETERMINED_HEIGHT;
                 signed char low_pitch = UNDETERMINED_HEIGHT;
                 size_t i;
+                bool has_nabc = false;
                 compute_element_height_extrema(element, &high_pitch,
                         &low_pitch);
                 fixup_height_extrema(&high_pitch, &low_pitch);
@@ -4210,7 +4211,15 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                         tex_escape_text(f, element->nabc[i]);
                         fprintf(f, "}{%d}{%d}%%\n", pitch_value(high_pitch),
                                 pitch_value(low_pitch));
+                        has_nabc = true;
                     }
+                }
+                /* If the element has NABC but no glyphs (empty GABC
+                 * snippet), flush the NABC neumes now since there will
+                 * be no \GreGlyph to trigger rendering (#1700) */
+                if (has_nabc && element->type == GRE_ELEMENT
+                        && !element->u.first_glyph) {
+                    fprintf(f, "\\GreFlushNABC%%\n");
                 }
             }
             switch (element->type) {

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -4201,7 +4201,6 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                 signed char high_pitch = UNDETERMINED_HEIGHT;
                 signed char low_pitch = UNDETERMINED_HEIGHT;
                 size_t i;
-                bool has_nabc = false;
                 compute_element_height_extrema(element, &high_pitch,
                         &low_pitch);
                 fixup_height_extrema(&high_pitch, &low_pitch);
@@ -4211,15 +4210,7 @@ static void write_syllable(FILE *f, gregorio_syllable *syllable,
                         tex_escape_text(f, element->nabc[i]);
                         fprintf(f, "}{%d}{%d}%%\n", pitch_value(high_pitch),
                                 pitch_value(low_pitch));
-                        has_nabc = true;
                     }
-                }
-                /* If the element has NABC but no glyphs (empty GABC
-                 * snippet), flush the NABC neumes now since there will
-                 * be no \GreGlyph to trigger rendering (#1700) */
-                if (has_nabc && element->type == GRE_ELEMENT
-                        && !element->u.first_glyph) {
-                    fprintf(f, "\\GreFlushNABC%%\n");
                 }
             }
             switch (element->type) {

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -698,8 +698,10 @@
 % Phase 1: Pre-evaluate NABC content, emit kern, save content.
 % #1: content (from \GreNABCChar)
 % #2: box register to save to
+% Note: no part attribute is set here.  The part attribute (7 for voice 1,
+% 8 for voice 2) is applied only during Phase 2 (place), so that content
+% nodes do not carry a stray part=7 when preparing voice 2.
 \def\gre@nabc@prepare#1#2{%
-  \gre@attr@part=7\relax%
   \setbox\gre@box@nabctemp=\hbox{#1}%
   % Track maximum NABC width for right-overflow detection (extra kern at
   % syllable end).  Without this, \gre@compute@nabc@extrakern cannot detect
@@ -708,13 +710,10 @@
     \global\gre@dimen@nabc@maxwidth=\wd\gre@box@nabctemp\relax%
   \fi%
   \ifdim\gre@dimen@nabcleftoverflow>\gre@dimen@nabckernemitted\relax%
-    \unsetattribute{\gre@attr@part}%
     \kern\dimexpr(\gre@dimen@nabcleftoverflow-\gre@dimen@nabckernemitted)\relax%
-    \gre@attr@part=7\relax%
     \global\gre@dimen@nabckernemitted=\gre@dimen@nabcleftoverflow\relax%
   \fi%
   \global\setbox#2=\hbox{\unhbox\gre@box@nabctemp}%
-  \unsetattribute{\gre@attr@part}%
 }%
 
 % Phase 2: Place voice 1 (above staff)

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -701,6 +701,12 @@
 \def\gre@nabc@prepare#1#2{%
   \gre@attr@part=7\relax%
   \setbox\gre@box@nabctemp=\hbox{#1}%
+  % Track maximum NABC width for right-overflow detection (extra kern at
+  % syllable end).  Without this, \gre@compute@nabc@extrakern cannot detect
+  % when NABC content extends past the syllable notes width.
+  \ifdim\wd\gre@box@nabctemp>\gre@dimen@nabc@maxwidth\relax%
+    \global\gre@dimen@nabc@maxwidth=\wd\gre@box@nabctemp\relax%
+  \fi%
   \ifdim\gre@dimen@nabcleftoverflow>\gre@dimen@nabckernemitted\relax%
     \unsetattribute{\gre@attr@part}%
     \kern\dimexpr(\gre@dimen@nabcleftoverflow-\gre@dimen@nabckernemitted)\relax%

--- a/tex/gregoriotex-nabc.tex
+++ b/tex/gregoriotex-nabc.tex
@@ -141,8 +141,10 @@
 
 % Flush pending NABC neumes for elements without glyphs (empty GABC snippet)
 \def\GreFlushNABC{%
-  \gre@currentnabcvoice@i
-  \gre@currentnabcvoice@ii
+  \gre@nabc@pre@voice@i
+  \gre@nabc@pre@voice@ii
+  \gre@nabc@emit@voice@i
+  \gre@nabc@emit@voice@ii
 }
 
 \newif\ifgre@nabcfontloaded%

--- a/tex/gregoriotex-nabc.tex
+++ b/tex/gregoriotex-nabc.tex
@@ -139,6 +139,14 @@
   \fi %
 }
 
+% Flush pending NABC neumes for elements without glyphs (empty GABC snippet)
+\def\GreFlushNABC{%
+  \gre@nabc@pre@voice@i
+  \gre@nabc@pre@voice@ii
+  \gre@nabc@emit@voice@i
+  \gre@nabc@emit@voice@ii
+}
+
 \newif\ifgre@nabcfontloaded%
 \gre@nabcfontloadedfalse%
 

--- a/tex/gregoriotex-nabc.tex
+++ b/tex/gregoriotex-nabc.tex
@@ -139,14 +139,6 @@
   \fi %
 }
 
-% Flush pending NABC neumes for elements without glyphs (empty GABC snippet)
-\def\GreFlushNABC{%
-  \gre@nabc@pre@voice@i
-  \gre@nabc@pre@voice@ii
-  \gre@nabc@emit@voice@i
-  \gre@nabc@emit@voice@ii
-}
-
 \newif\ifgre@nabcfontloaded%
 \gre@nabcfontloadedfalse%
 


### PR DESCRIPTION
This PR fixes a regression introduced after resolving the conflicts found on merging the `ctan` branch into `develop` (see issue #1708), making the test `gabc-output/bugs/fix-1700` fail with a fatal LaTeX error.

# Root cause of the regressions

The `ctan` branch refactored the internal NABC rendering pipeline in `gregoriotex-main.tex`, replacing the single-phase pair `\gre@currentnabcvoice@{i,ii}` with a two-phase architecture:

| Phase | Voice i | Voice ii |
|-------|---------|----------|
| Pre-evaluate (phase 1) | `\gre@nabc@pre@voice@i` | `\gre@nabc@pre@voice@ii` |
| Place/emit (phase 2) | `\gre@nabc@emit@voice@i` | `\gre@nabc@emit@voice@ii` |

However, recent features implemented directly in `develop` branch still make use of some pieces defined in old `\gre@currentnabcvoice@{i,ii}` context.

When the merge was performed, some important parts of code didn't have their `\gre@currentnabcvoice@{i,ii}` dependency fixed (e.g. `\GreFlushNABC`), or weren't refactored as needed (e.g. `\gre@nabc@prepare`).

# Solution

- Fix `\GreFlushNABC` implementation, replacing the old `\gre@currentnabcvoice@{i,ii}` macros with new two-phase ones.
- Restore `\gre@dimen@nabc@maxwidth` within `\gre@nabc@prepare`, needed for NABC anti-overlapping mechanism. 
- Remove stray `part_attr=7` from `\gre@nabc@prepare` to fix invisible NABC voice 1 spacing 

Fixes #1708.

Supersedes #1710.