### PR TITLE
Feature/nabc skip accidentals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Added new option `\gresetlastline{trimmed}`, which sets the last line ragged and also trims the staff lines. See [#1418](https://github.com/gregorio-project/gregorio/issues/1418).
 - Nabc can now appear below the staff in addition (or instead of) above.  See [#1645](https://github.com/gregorio-project/gregorio/issues/1645).
 - Added `\gresetnabcalignment` command to control NABC horizontal alignment mode (`full` or `neume`). In `neume` mode, significative letters are excluded from alignment calculation, keeping the neume body centered above the corresponding note. Supports per-voice configuration with optional voice parameter.  See [#1702](https://github.com/gregorio-project/gregorio/issues/1702).
+- Added `\gresetnabcskipaccidentals` command to control whether NABC neumes are anchored to the first real square note, skipping any leading accidental sign. See [#1712](https://github.com/gregorio-project/gregorio/issues/1712).
 
 ### Changed
 - Variable line heights are now computed in one pass instead of two. Per-line adjustments using `\grechangenextscorelinedim` and `\grechangenextscorelinecount` are also done in one pass, but only work on dimensions/counts related to line heights.  Mentioned in [#1488](https://github.com/gregorio-project/gregorio/issues/1488).

--- a/doc/Command_Index_User.tex
+++ b/doc/Command_Index_User.tex
@@ -1259,6 +1259,17 @@ Sets the horizontal alignment reference for nabc neumes relative to the gabc not
   & \texttt{full} & Align to the entire complex glyph descriptor (default).\\
 \end{argtable}
 
+\macroname{\textbackslash gresetnabcskipaccidentals}{[\#1]\{\#2\}}{gregoriotex-nabc.tex}
+Controls whether NABC neumes skip leading accidental signs (flat, natural, sharp)
+when computing the horizontal anchor position, aligning instead to the first real
+square note.  By default this feature is disabled.
+
+\begin{argtable}
+  \#1 & integer & (Optional) The nabc voice number: 1 = above staff, 2 = below staff.  If omitted, applies to all voices.\\
+  \#2 & \texttt{true} & Skip leading accidentals; anchor neume to first square note.\\
+  & \texttt{false} & Use the leftmost symbol as anchor (default).\\
+\end{argtable}
+
 \macroname{\textbackslash greprintsigns}{\{\#1\}\{\#2\}}{gregoriotex-signs.tex}
 Macro to prevent rythmic signs from printing (all signs are printed by default):
 

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -1058,6 +1058,29 @@ Macro to place argument containing Nabc neumes below the lines.
   \#1 & string & Nabc neumes to be placed below the lines.\\
 \end{argtable}
 
+\macroname{\textbackslash GreSetNabcAboveLinesDeferred}{\#1}{gregoriotex-main.tex}
+Deferred variant of \verb=\GreSetNabcAboveLines= used when skip-accidentals is
+enabled for voice~1 (\verb=\gresetnabcskipaccidentals[1]{true}=).  The
+pre-phase is guarded by \verb=\ifgre@nabc@in@alteration= so it silently
+postpones execution during free-standing accidental signs and fires only at
+the next real \verb=\GreGlyph= call, anchoring the neume to the first square
+note.  The emit-phase is likewise guarded by \verb=\ifgre@nabc@voice@i@ready=
+to prevent placing an empty box before the pre-phase has run.
+
+\begin{argtable}
+  \#1 & string & Nabc neumes to be placed above the lines.\\
+\end{argtable}
+
+\macroname{\textbackslash GreSetNabcBelowLinesDeferred}{\#1}{gregoriotex-main.tex}
+Deferred variant of \verb=\GreSetNabcBelowLines= used when skip-accidentals is
+enabled for voice~2 (\verb=\gresetnabcskipaccidentals[2]{true}=).  Mirrors
+\verb=\GreSetNabcAboveLinesDeferred= but targets voice~2 (below staff), using
+\verb=\ifgre@nabc@voice@ii@ready= and the \verb=\gre@nabc@*@voice@ii= macros.
+
+\begin{argtable}
+  \#1 & string & Nabc neumes to be placed below the lines.\\
+\end{argtable}
+
 \macroname{\textbackslash GreSetNextSyllable}{\#1\#2\#3}{gregoriotex-syllable.tex}
 Macro to set the text of the next syllable for spacing purposes.
 
@@ -1328,11 +1351,14 @@ Macro used to prevent a line break from occurring at a given position.
 A Lua\TeX\ attribute which designates a unique identifier for each score.
 
 \macroname{\textbackslash GreNABCNeumes}{\#1\#2\#3\#4}{gregoriotex-nabc.tex}
-Macro to print a nabc character above the lines.
+Macro called by the generated \texttt{.gtex} file to typeset the neumes of one
+NABC voice for a GABC element.  Dispatches to \verb=\GreSetNabcAboveLines= or
+\verb=\GreSetNabcBelowLines= (possibly the Deferred variant when
+\verb=\gresetnabcskipaccidentals= is enabled for that voice).
 
 \begin{argtable}
-  \#1 & integer & the line on which the character should appear (currently unused)\\
-  \#2 & string & The \texttt{nabc} syntax which indicates what neumes are to be printed\\
+  \#1 & integer & NABC voice number: 1 = above staff, 2 = below staff.\\
+  \#2 & string & The \texttt{nabc} syntax which indicates what neumes are to be printed.\\
   \#3 & integer & The high pitch of the notes covered by the nabc character(s).\\
   \#4 & integer & The low pitch of the notes covered by the nabc character(s).\\
 \end{argtable}

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -1386,16 +1386,29 @@ Phase 2 of NABC two-phase processing for voice 1 (above staff): places the pre-r
 Phase 2 of NABC two-phase processing for voice 2 (below staff): places the pre-rendered NABC voice 2 content from \textbackslash gre@box@nabc@voice@ii at the correct vertical position below the staff.
 
 \macroname{\textbackslash gre@nabc@pre@voice@i}{}{gregoriotex-main.tex}
-Deferred macro for phase 1 processing of NABC voice 1 (above staff). Set by \textbackslash GreSetNabcAboveLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
+Deferred macro for phase~1 processing of NABC voice~1 (above staff).  Set by
+\verb=\GreSetNabcAboveLines= (or \verb=\GreSetNabcAboveLinesDeferred= when
+skip-accidentals is enabled), called from \verb=\gre@newglyphcommon=.  When set
+by the deferred variant, guarded by \verb=\ifgre@nabc@in@alteration=: execution
+is postponed during free-standing accidentals and fires at the next real glyph.
+After execution, resets itself to empty.
 
 \macroname{\textbackslash gre@nabc@pre@voice@ii}{}{gregoriotex-main.tex}
-Deferred macro for phase 1 processing of NABC voice 2 (below staff). Set by \textbackslash GreSetNabcBelowLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
+Deferred macro for phase~1 processing of NABC voice~2 (below staff).  Set by
+\verb=\GreSetNabcBelowLines= (or \verb=\GreSetNabcBelowLinesDeferred= when
+skip-accidentals is enabled), called from \verb=\gre@newglyphcommon=.  Mirrors
+\verb=\gre@nabc@pre@voice@i= for voice~2.  After execution, resets itself to empty.
 
 \macroname{\textbackslash gre@nabc@emit@voice@i}{}{gregoriotex-main.tex}
-Deferred macro for phase 2 processing of NABC voice 1 (above staff). Set by \textbackslash GreSetNabcAboveLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
+Deferred macro for phase~2 processing of NABC voice~1 (above staff).  Set by
+\verb=\GreSetNabcAboveLines= (or \verb=\GreSetNabcAboveLinesDeferred=).  When
+set by the deferred variant, guarded by \verb=\ifgre@nabc@voice@i@ready= so it
+does not fire before phase~1 has completed.  After execution, resets itself to empty.
 
 \macroname{\textbackslash gre@nabc@emit@voice@ii}{}{gregoriotex-main.tex}
-Deferred macro for phase 2 processing of NABC voice 2 (below staff). Set by \textbackslash GreSetNabcBelowLines, called from \textbackslash gre@newglyphcommon. After execution, resets itself to empty.
+Deferred macro for phase~2 processing of NABC voice~2 (below staff).  Set by
+\verb=\GreSetNabcBelowLines= (or \verb=\GreSetNabcBelowLinesDeferred=).  Mirrors
+\verb=\gre@nabc@emit@voice@i= for voice~2, guarded by \verb=\ifgre@nabc@voice@ii@ready=.
 
 \macroname{\textbackslash gre@setnabcalignment@global}{\#1}{gregoriotex-nabc.tex}
 Sets the default NABC horizontal alignment mode for all voices and clears any per-voice overrides.
@@ -1412,6 +1425,27 @@ Sets the NABC horizontal alignment mode for a specific voice.
   \#1 & integer & The nabc voice number: 1 = above staff, 2 = below staff\\
   \#2 & \texttt{neume} & Align to the neume (basic glyph + prepunctis), ignoring significative letters\\
   & \texttt{full} & Align to the entire complex glyph descriptor (default)\\
+\end{argtable}
+
+\macroname{\textbackslash gre@setnabcskipaccidentals@global}{\#1}{gregoriotex-nabc.tex}
+Sets the skip-accidentals flag for all NABC voices simultaneously.  Internal
+implementation of \verb=\gresetnabcskipaccidentals= when called without the
+optional voice argument.
+
+\begin{argtable}
+  \#1 & \texttt{true} & Enable skip-accidentals for all voices\\
+  & \texttt{false} & Disable skip-accidentals for all voices (default)\\
+\end{argtable}
+
+\macroname{\textbackslash gre@setnabcskipaccidentals@voice}{[\#1]\{\#2\}}{gregoriotex-nabc.tex}
+Sets the skip-accidentals flag for a specific NABC voice.  Internal
+implementation of \verb=\gresetnabcskipaccidentals= when called with the
+optional voice argument.
+
+\begin{argtable}
+  \#1 & integer & The nabc voice number: 1 = above staff, 2 = below staff\\
+  \#2 & \texttt{true} & Enable skip-accidentals for the given voice\\
+  & \texttt{false} & Disable skip-accidentals for the given voice\\
 \end{argtable}
 
 
@@ -1931,6 +1965,42 @@ Boolean indicating whether the first nabc voice should be shown.
 
 \macroname{\textbackslash ifgre@nabcvoice@ii@visible}{}{gregoriotex-nabc.tex}
 Boolean indicating whether the second nabc voice should be shown.
+
+\macroname{\textbackslash ifgre@nabc@voice@i@skipaccidentals}{}{gregoriotex-nabc.tex}
+When true, NABC neumes for voice~1 are anchored to the first real square note,
+skipping any leading free-standing accidental signs.  Controlled by
+\verb=\gresetnabcskipaccidentals=.
+
+\macroname{\textbackslash ifgre@nabc@voice@ii@skipaccidentals}{}{gregoriotex-nabc.tex}
+When true, NABC neumes for voice~2 are anchored to the first real square note,
+skipping any leading free-standing accidental signs.  Mirrors
+\verb=\ifgre@nabc@voice@i@skipaccidentals= for voice~2.
+
+\macroname{\textbackslash ifgre@nabc@in@alteration}{}{gregoriotex-nabc.tex}
+Set to true by \verb=\gre@alteration@visible= around its internal call to
+\verb=\gre@newglyphcommon=, so that the deferred NABC pre/emit macros can detect
+they are being triggered by a free-standing accidental sign rather than by a real
+glyph and defer execution accordingly.
+
+\macroname{\textbackslash ifgre@nabc@voice@i@ready}{}{gregoriotex-main.tex}
+Set to true by \verb=\GreSetNabcAboveLinesDeferred= pre-phase when the NABC box
+for voice~1 has been filled, and cleared after the emit-phase places it.  The
+emit-phase checks this flag to avoid placing an empty box when called before
+phase~1 has executed.
+
+\macroname{\textbackslash ifgre@nabc@voice@ii@ready}{}{gregoriotex-main.tex}
+Set to true by \verb=\GreSetNabcBelowLinesDeferred= pre-phase when the NABC box
+for voice~2 has been filled, and cleared after the emit-phase places it.  Mirrors
+\verb=\ifgre@nabc@voice@i@ready= for voice~2.
+
+\macroname{\textbackslash ifgre@staffdimensions@zeroed}{}{gregoriotex-main.tex}
+Boolean indicating whether the staff dimensions (line height, inter-line space, and total staff height) have been zeroed.  Set to true by \verb=\gre@staffdimensions@dozero= when lines are made invisible or hphantom, and cleared by \verb=\gre@staffdimensions@unzero= when lines are restored.
+
+\macroname{\textbackslash ifgre@nabc@needsspacing}{}{gregoriotex-syllable.tex}
+Boolean indicating whether any NABC voice is visible and therefore requires horizontal spacing to be preserved even when notes are invisible.  Set by \verb=\gre@check@nabc@needsspacing=.
+
+\macroname{\textbackslash ifgre@notes@invisrender}{}{gregoriotex-syllable.tex}
+Boolean indicating that notes are being typeset in invisible-rendering mode.  Set to true inside \verb=\gre@applynotesphantom= so that glyph rendering code can suppress note output while still allowing NABC neumes to be rendered.
 
 \macroname{\textbackslash ifgre@showlyrics}{}{gregoriotex-syllable.tex}
 Boolean indicating whether the lyrics should be shown.

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -724,6 +724,7 @@
 \xdef\gre@nabc@emit@voice@i{}%
 \xdef\gre@nabc@emit@voice@ii{}%
 
+% Arms the two-phase NABC machinery for voice 1 (above staff).
 \def\GreSetNabcAboveLines#1{%
   \gdef\gre@nabc@pre@voice@i{%
     \gre@nabc@prepare{#1}\gre@box@nabc@voice@i%
@@ -735,6 +736,7 @@
   }%
 }%
 
+% Arms the two-phase NABC machinery for voice 2 (below staff).
 \def\GreSetNabcBelowLines#1{%
   \gdef\gre@nabc@pre@voice@ii{%
     \gre@nabc@prepare{#1}\gre@box@nabc@voice@ii%
@@ -743,6 +745,48 @@
   \gdef\gre@nabc@emit@voice@ii{%
     \gre@nabc@place@voice@ii%
     \gdef\gre@nabc@emit@voice@ii{}%
+  }%
+}%
+
+% Deferred variant of \GreSetNabcAboveLines for voice 1: skips accidentals
+% and anchors the neume to the first real square note.
+\def\GreSetNabcAboveLinesDeferred#1{%
+  \global\gre@nabc@voice@i@readyfalse%
+  \gdef\gre@nabc@pre@voice@i{%
+    \ifgre@nabc@in@alteration\else%
+      \gre@nabc@prepare{#1}\gre@box@nabc@voice@i%
+      \global\gre@nabc@voice@i@readytrue%
+      \gdef\gre@nabc@pre@voice@i{}%
+    \fi%
+  }%
+  \gdef\gre@nabc@emit@voice@i{%
+    \ifgre@nabc@voice@i@ready%
+      \gre@nabc@place@voice@i%
+      \global\gre@nabc@voice@i@readyfalse%
+      \gdef\gre@nabc@emit@voice@i{}%
+    \fi%
+    % if not ready: do nothing and do not self-destruct
+  }%
+}%
+
+% Deferred variant of \GreSetNabcBelowLines for voice 2: skips accidentals
+% and anchors the neume to the first real square note.
+\def\GreSetNabcBelowLinesDeferred#1{%
+  \global\gre@nabc@voice@ii@readyfalse%
+  \gdef\gre@nabc@pre@voice@ii{%
+    \ifgre@nabc@in@alteration\else%
+      \gre@nabc@prepare{#1}\gre@box@nabc@voice@ii%
+      \global\gre@nabc@voice@ii@readytrue%
+      \gdef\gre@nabc@pre@voice@ii{}%
+    \fi%
+  }%
+  \gdef\gre@nabc@emit@voice@ii{%
+    \ifgre@nabc@voice@ii@ready%
+      \gre@nabc@place@voice@ii%
+      \global\gre@nabc@voice@ii@readyfalse%
+      \gdef\gre@nabc@emit@voice@ii{}%
+    \fi%
+    % if not ready: do nothing and do not self-destruct
   }%
 }%
 

--- a/tex/gregoriotex-nabc.tex
+++ b/tex/gregoriotex-nabc.tex
@@ -86,6 +86,24 @@
 \gre@nabcvoice@ii@visibletrue
 % define more of these when more voices are supported
 
+% Per-voice 'skip-accidentals' flags: when true, NABC neumes are anchored to
+% the first real square note, skipping any leading accidental signs.
+\newif\ifgre@nabc@voice@i@skipaccidentals
+\gre@nabc@voice@i@skipaccidentalsfalse
+\newif\ifgre@nabc@voice@ii@skipaccidentals
+\gre@nabc@voice@ii@skipaccidentalsfalse
+% In-alteration signal: set to true by \gre@alteration@visible around the
+% \gre@newglyphcommon call so that deferred pre/emit macros can detect they
+% are being called from an alteration and defer execution.
+\newif\ifgre@nabc@in@alteration
+\gre@nabc@in@alterationfalse
+% Per-voice 'ready' flags: set when the deferred pre-phase fills the nabc
+% box, cleared after the emit-phase places it.
+\newif\ifgre@nabc@voice@i@ready
+\gre@nabc@voice@i@readyfalse
+\newif\ifgre@nabc@voice@ii@ready
+\gre@nabc@voice@ii@readyfalse
+
 \def\gresetnabc#1#2{%
   \IfStrEqCase{#2}{%
     {visible}%
@@ -97,14 +115,7 @@
     ]%
 }
 
-% \gresetnabcalignment[#1]#2 - set the horizontal alignment reference for NABC
-% neumes relative to the gabc notes below.
-% #1: voice number (optional; if omitted, sets the default for all voices
-%     and clears any per-voice overrides)
-% #2: alignment mode
-%   neume - align to the neume (basic glyph + prepunctis), ignoring
-%           significative letters
-%   full  - align to the entire complex glyph descriptor (default)
+% See Command_Index_User.tex for documentation.
 \def\gresetnabcalignment{\@ifnextchar[{\gre@setnabcalignment@voice}{\gre@setnabcalignment@global}}%
 \def\gre@setnabcalignment@global#1{%
   \IfStrEqCase{#1}{%
@@ -127,13 +138,46 @@
     ]%
 }
 
+% See Command_Index_User.tex for documentation.
+\def\gresetnabcskipaccidentals{%
+  \@ifnextchar[{\gre@setnabcskipaccidentals@voice}{\gre@setnabcskipaccidentals@global}%
+}%
+\def\gre@setnabcskipaccidentals@global#1{%
+  \IfStrEqCase{#1}{%
+    {true}%
+      {\global\gre@nabc@voice@i@skipaccidentalstrue
+       \global\gre@nabc@voice@ii@skipaccidentalstrue}%
+    {false}%
+      {\global\gre@nabc@voice@i@skipaccidentalsfalse
+       \global\gre@nabc@voice@ii@skipaccidentalsfalse}%
+    }[%
+      \gre@error{Unrecognized option "#1" for \protect\gresetnabcskipaccidentals\MessageBreak Possible options are: 'true' and 'false'}%
+    ]%
+}%
+\def\gre@setnabcskipaccidentals@voice[#1]#2{%
+  \IfStrEqCase{#2}{%
+    {true}%
+      {\ifnum#1=1\relax\global\gre@nabc@voice@i@skipaccidentalstrue\fi%
+       \ifnum#1=2\relax\global\gre@nabc@voice@ii@skipaccidentalstrue\fi}%
+    {false}%
+      {\ifnum#1=1\relax\global\gre@nabc@voice@i@skipaccidentalsfalse\fi%
+       \ifnum#1=2\relax\global\gre@nabc@voice@ii@skipaccidentalsfalse\fi}%
+    }[%
+      \gre@error{Unrecognized option "#2" for \protect\gresetnabcskipaccidentals\MessageBreak Possible options are: 'true' and 'false'}%
+    ]%
+}
+
 \def\GreNABCNeumes#1#2#3#4{%
   \csname ifgre@nabcvoice@\romannumeral#1@visible\endcsname %
     \ifcase#1\relax
       \or % 1
-        \GreSetNabcAboveLines{\GreNABCChar[1]{#2}}%
+        \csname GreSetNabcAboveLines%
+          \ifgre@nabc@voice@i@skipaccidentals Deferred\fi\endcsname
+        {\GreNABCChar[1]{#2}}%
       \or % 2
-        \GreSetNabcBelowLines{\GreNABCChar[2]{#2}}%
+        \csname GreSetNabcBelowLines%
+          \ifgre@nabc@voice@ii@skipaccidentals Deferred\fi\endcsname
+        {\GreNABCChar[2]{#2}}%
       \fi
   \fi %
 }

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -2764,7 +2764,9 @@
     attr \gre@attrid@alteration@type=#2\relax
     {\gre@pointandclick{\gre@alteration@char}{#6}}%
   \ifnum#3=0\relax %
+    \gre@nabc@in@alterationtrue%
     \gre@newglyphcommon %
+    \gre@nabc@in@alterationfalse%
   \fi %
   \ifgre@in@custos\else\relax %
     \global\gre@dimen@lastglyphwidth=\wd\gre@box@temp@width %


### PR DESCRIPTION
Fixes #1712.

**NOTE**: there should be a small conflict when merging `ctan` branch into `develop` after this PR, due to lack of lack of `\gre@nabcvoice@{i,ii}@phantomwrapper` in `ctan`. They were introduced in PR #1683 directly in `develop`. Resolving this conflict is just a matter of replacing `\GreSetNabc{Above,Below}Lines` with `\csname GreSetNabc{Above,Below}Lines\ifgre@nabc@voice@i@skipaccidentals Deferred\fi\endcsname`