### PR TITLE
Unset glyph height attributes right after glyph is emitted. Fixes #1717.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a bug that could cause a punctum mora that is supposed to be below the line (`.0`) to appear above the line. This bug was platform-dependent and was observed on a Windows system.  See [#1642](https://github.com/gregorio-project/gregorio/issues/1642).
 - Error messages from executable have been cleaned up to be more uniform.  See [#1644](https://github.com/gregorio-project/gregorio/issues/1644).
 - NABC neumes are now rendered for syllables with empty GABC/NABC snippets when NABC content is present (e.g. `(|vi|ta)`, `(|vi)`, `(||ta)`, `(g||ta)`).  See [#1700](https://github.com/gregorio-project/gregorio/issues/1700).
+- Fixed a bug [#1717](https://github.com/gregorio-project/gregorio/issues/1717) that could cause incorrect vertical spacing.
 
 ## [Unreleased][CTAN]
 ### Fixed

--- a/doc/Command_Index_internal.tex
+++ b/doc/Command_Index_internal.tex
@@ -2220,6 +2220,9 @@ Internal to \verb|\gre@syllable@act|.
 An attribute to mark various parts of the score. \verb|gre@attr@part| is the attribute, while \verb|gre@attrid@part| is the attribute number (to be used with \verb|\hbox attr|).
 1 = commentary, 2 = stafflines, 3 = initial.
 
+\macroname{\textbackslash gre@unset@glyph@heights}{}{gregoriotex-syllable.tex}
+Undo the attributes set by \verb|\GreGlyphHeights|.
+
 \subsection{Boxes}
 
 Boxes are used to store elements of the score before they are printed for the purposes of reusing them and/or measuring them in order to determine their appropriate placement.

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1288,8 +1288,7 @@
   \setbox\gre@box@annotation=\box\voidb@x%
   \setbox\gre@box@commentary=\box\voidb@x%
   \directlua{gregoriotex.at_score_end()}%
-  \unsetattribute{\gre@attr@glyph@top}%
-  \unsetattribute{\gre@attr@glyph@bottom}%
+  \gre@unset@glyph@heights
   \unsetattribute{\gre@attr@dash}%
   \xdef\gre@bolshiftcleftypelocal{\gre@bolshiftcleftypeglobal}%
   \ifnum\gre@count@lastline=0\relax

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -316,6 +316,7 @@
     \gre@update@clefwidth@current{\wd\gre@box@temp@width}%
   \fi %
   \copy\gre@box@temp@width %
+  \gre@unset@glyph@heights
   \ifcase#4 %
     \gre@skip@temp@two=\gre@space@skip@afterclefnospace\relax%
   \or %
@@ -670,6 +671,7 @@
     \IfStrEq{#2}{}{}{%
       \GreGlyphHeights{#1}{#1}%
       \csname Gre#2\endcsname{#1}{0}{}{}{}}%
+      \gre@unset@glyph@heights
   \fi %
   \gre@trace@end%
 }%
@@ -747,6 +749,7 @@
   \or\gre@fontchar@custosbottomlong %
   \or\gre@fontchar@custosbottommiddle %
   \fi%
+  \gre@unset@glyph@heights
   \gre@trace@end%
 }%
 
@@ -2392,6 +2395,7 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\gre@char@bar@virgulahigh}%
     \GreAdditionalLine{\GreOCaseBarVirgula}{0}{2}%
     #4\relax %
+    \gre@unset@glyph@heights
     \ifnum\gre@count@temp@one=1\relax %
       \GreNoBreak %
       \gre@skip@temp@four = \csname gre@space@skip@bar@virgula\gre@bar@space@suffix{#2}{#3}{#5}\endcsname\relax%
@@ -2408,6 +2412,7 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\gre@char@bar@divisiominimahigh}%
     \GreAdditionalLine{\GreOCaseBarStandard}{0}{2}%
     #4\relax %
+    \gre@unset@glyph@heights
     \ifnum\gre@count@temp@one=1\relax %
       \GreNoBreak %
       \gre@skip@temp@four = \csname gre@space@skip@bar@minima\gre@bar@space@suffix{#2}{#3}{#5}\endcsname\relax%
@@ -2461,6 +2466,7 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\gre@char@bar@divisiominimishigh}%
     \GreAdditionalLine{\GreOCaseBarStandard}{0}{2}%
     #4\relax %
+    \gre@unset@glyph@heights
     \ifnum\gre@count@temp@one=1\relax %
       \GreNoBreak %
       \gre@skip@temp@four = \csname gre@space@skip@bar@minimis\gre@bar@space@suffix{#2}{#3}{#5}\endcsname\relax%
@@ -2505,6 +2511,7 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\gre@char@bar@virgulaparenhigh}%
     \GreAdditionalLine{\GreOCaseBarVirgulaParen}{0}{2}%
     #4\relax %
+    \gre@unset@glyph@heights
     \ifnum\gre@count@temp@one=1\relax %
       \GreNoBreak %
       \gre@skip@temp@four = \csname gre@space@skip@bar@virgulaparen\gre@bar@space@suffix{#2}{#3}{#5}\endcsname\relax%
@@ -2521,6 +2528,7 @@
     \raise\gre@dimen@glyphraisevalue\hbox{\gre@font@music\gre@char@bar@divisiominimaparenhigh}%
     \GreAdditionalLine{\GreOCaseBarParen}{0}{2}%
     #4\relax %
+    \gre@unset@glyph@heights
     \ifnum\gre@count@temp@one=1\relax %
       \GreNoBreak %
       \gre@skip@temp@four = \csname gre@space@skip@bar@minimaparen\gre@bar@space@suffix{#2}{#3}{#5}\endcsname\relax%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -132,14 +132,13 @@
 
 \def\gre@endofglyphcommon{%
   \gre@trace{gre@endofglyphcommon}%
-  \global\unsetattribute{\gre@attr@glyph@top}%
-  \global\unsetattribute{\gre@attr@glyph@bottom}%
+  \gre@unset@glyph@heights
   \ifgre@endofscore %
     \localleftbox{}%
     \localrightbox{}%
   \fi %
   \gre@trace@end%
-}
+}%
 
 % passes the glyph height limits:
 % #1: the high height
@@ -147,6 +146,11 @@
 \def\GreGlyphHeights#1#2{%
   \global\setattribute\gre@attr@glyph@top{#1}%
   \global\setattribute\gre@attr@glyph@bottom{#2}%
+}%
+
+\def\gre@unset@glyph@heights{%
+  \global\unsetattribute{\gre@attr@glyph@top}%
+  \global\unsetattribute{\gre@attr@glyph@bottom}%
 }%
 
 % Flag that tells us if the current glyph is the first glyph or not.
@@ -195,6 +199,7 @@
   \else
     \hbox{\unhcopy\gre@box@temp@width}%
   \fi
+  \gre@unset@glyph@heights
   \ifgre@endofscore\else\ifgre@boxing\else %
     #3%
   \fi\fi %


### PR DESCRIPTION
Fixes #1717.
