### PR TITLE
Fix segfault on empty GRE_ELEMENT when nabc_state wraps mid-syllable (#1726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a bug that could cause a punctum mora that is supposed to be below the line (`.0`) to appear above the line. This bug was platform-dependent and was observed on a Windows system.  See [#1642](https://github.com/gregorio-project/gregorio/issues/1642).
 - Error messages from executable have been cleaned up to be more uniform.  See [#1644](https://github.com/gregorio-project/gregorio/issues/1644).
 - NABC neumes are now rendered for syllables with empty GABC/NABC snippets when NABC content is present (e.g. `(|vi|ta)`, `(|vi)`, `(||ta)`, `(g||ta)`).  See [#1700](https://github.com/gregorio-project/gregorio/issues/1700).
+- Fixed a segfault related to NABC state wrapping.  See [#1726](https://github.com/gregorio-project/gregorio/issues/1726).
 
 ## [Unreleased][CTAN]
 ### Fixed

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -886,7 +886,11 @@ note:
                              "det_score", VERBOSITY_FATAL, 0);
         }
         if (nabc_state == 0) {
-            /* empty GABC snippet: create an empty element */
+            gregorio_message(
+                _("Empty GABC element created by extra \"|\" separator. "
+                  "With nabc-lines>1, use a single \"|\" to start a new "
+                  "element after the last NABC voice."),
+                "det_score", VERBOSITY_ERROR, 0);
             gregorio_add_element(&elements[voice], NULL);
             current_element = elements[voice];
             while (current_element->next) {

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -886,15 +886,21 @@ note:
                              "det_score", VERBOSITY_FATAL, 0);
         }
         if (nabc_state == 0) {
-            gregorio_message(
-                _("Empty GABC element created by extra \"|\" separator. "
-                  "With nabc-lines>1, use a single \"|\" to start a new "
-                  "element after the last NABC voice."),
-                "det_score", VERBOSITY_ERROR, 0);
-            gregorio_add_element(&elements[voice], NULL);
-            current_element = elements[voice];
-            while (current_element->next) {
-                current_element = current_element->next;
+            gregorio_messagef("det_score", VERBOSITY_WARNING, 0,
+                _("Starting a new element with empty GABC notation at "
+                  "\"|\" separator (all %zu NABC voice(s) were already "
+                  "assigned to the previous element)."),
+                nabc_lines);
+            if (!elements[voice]) {
+                gregorio_add_element(&elements[voice], NULL);
+                current_element = elements[voice];
+            } else {
+                gregorio_element *last_element = current_element;
+                while (last_element->next) {
+                    last_element = last_element->next;
+                }
+                gregorio_add_element(&last_element, NULL);
+                current_element = last_element;
             }
         }
         nabc_state = (nabc_state + 1) % (nabc_lines+1);

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -3956,7 +3956,8 @@ static void write_default_end_of_element(FILE *f,
         if (next_element->type == GRE_ALT) {
             next_element = next_element->next;
         }
-        if (next_element && next_element->type == GRE_ELEMENT) {
+        if (next_element && next_element->type == GRE_ELEMENT
+                && element->u.first_glyph) {
             for (last_glyph = element->u.first_glyph; last_glyph->next;
                     last_glyph = last_glyph->next) {
                 /* iterate to find the last glyph */


### PR DESCRIPTION
Fixes #1726.

When `nabc_state` wraps back to 0 mid-syllable (e.g. with `nabc-lines: 2` and more `||`-groups than one cycle), the parser creates an empty `GRE_ELEMENT` with `first_glyph == NULL`. `write_default_end_of_element()` then dereferences `first_glyph->next` unconditionally, causing a segfault.

This adds a NULL check for `element->u.first_glyph` before iterating glyphs to find the last pitch for unison detection.

### Reproducer

```gabc
name:t;
nabc-lines:2;
%%
(f3) ma(f!hhf||ta//tghh||gf||cl) (::)
```