### PR TITLE
Use signed char instead of char for a pitch or ambitus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a bug that could cause a punctum mora that is supposed to be below the line (`.0`) to appear above the line. This bug was platform-dependent and was observed on a Windows system.  See [#1642](https://github.com/gregorio-project/gregorio/issues/1642).
 - Error messages from executable have been cleaned up to be more uniform.  See [#1644](https://github.com/gregorio-project/gregorio/issues/1644).
 - NABC neumes are now rendered for syllables with empty GABC/NABC snippets when NABC content is present (e.g. `(|vi|ta)`, `(|vi)`, `(||ta)`, `(g||ta)`).  See [#1700](https://github.com/gregorio-project/gregorio/issues/1700).
-<<<<<<< HEAD
 - Changed all uses of `char` as integers to `signed char`s for better portability. This previously affected some horizontal spacing in rare cases with some compilers. See [#1731](https://github.com/gregorio-project/gregorio/pull/1731).
 - Fixed a bug ([#1717](https://github.com/gregorio-project/gregorio/issues/1717)) that could cause incorrect vertical spacing.
 - Added a shim to implement lfs.mkdirp in versions of LuaTeX (<1.18) that do not have it. See [#1728](https://github.com/gregorio-project/gregorio/issues/1728).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a bug that could cause a punctum mora that is supposed to be below the line (`.0`) to appear above the line. This bug was platform-dependent and was observed on a Windows system.  See [#1642](https://github.com/gregorio-project/gregorio/issues/1642).
 - Error messages from executable have been cleaned up to be more uniform.  See [#1644](https://github.com/gregorio-project/gregorio/issues/1644).
 - NABC neumes are now rendered for syllables with empty GABC/NABC snippets when NABC content is present (e.g. `(|vi|ta)`, `(|vi)`, `(||ta)`, `(g||ta)`).  See [#1700](https://github.com/gregorio-project/gregorio/issues/1700).
+- Changed all uses of `char` as integers to `signed char`s for better portability (https://github.com/gregorio-project/gregorio/pull/1731). This previously affected some horizontal spacing in rare cases with some compilers.
 
 ## [Unreleased][CTAN]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a bug that could cause a punctum mora that is supposed to be below the line (`.0`) to appear above the line. This bug was platform-dependent and was observed on a Windows system.  See [#1642](https://github.com/gregorio-project/gregorio/issues/1642).
 - Error messages from executable have been cleaned up to be more uniform.  See [#1644](https://github.com/gregorio-project/gregorio/issues/1644).
 - NABC neumes are now rendered for syllables with empty GABC/NABC snippets when NABC content is present (e.g. `(|vi|ta)`, `(|vi)`, `(||ta)`, `(g||ta)`).  See [#1700](https://github.com/gregorio-project/gregorio/issues/1700).
-- Changed all uses of `char` as integers to `signed char`s for better portability (https://github.com/gregorio-project/gregorio/pull/1731). This previously affected some horizontal spacing in rare cases with some compilers.
-- Added a shim to implement lfs.mkdirp in versions of LuaTeX (<1.18) that do not have it (https://github.com/gregorio-project/gregorio/issues/1728).
+- Changed all uses of `char` as integers to `signed char`s for better portability. This previously affected some horizontal spacing in rare cases with some compilers. See [#1731](https://github.com/gregorio-project/gregorio/pull/1731).
+- Added a shim to implement lfs.mkdirp in versions of LuaTeX (<1.18) that do not have it. See [#1728](https://github.com/gregorio-project/gregorio/issues/1728).
 
 ## [Unreleased][CTAN]
 ### Fixed

--- a/src/gregoriotex/gregoriotex-position.c
+++ b/src/gregoriotex/gregoriotex-position.c
@@ -1008,7 +1008,7 @@ static __inline char compute_h_episema_height(
         const gregorio_glyph *const glyph, const gregorio_note *const note,
         const gregorio_vposition vpos)
 {
-    char height = note->u.note.pitch;
+    signed char height = note->u.note.pitch;
 
     if (note->signs & _V_EPISEMA) {
         if ((vpos == VPOS_ABOVE && note->v_episema_height >= height)
@@ -1057,7 +1057,7 @@ typedef struct height_computation {
     void (*const position)(gregorio_note *, signed char, bool);
 
     bool active;
-    char height;
+    signed char height;
     bool connected;
     const gregorio_element *start_element;
     const gregorio_glyph *start_glyph;

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -1959,11 +1959,11 @@ static __inline char *suppose_low_ledger_line(const gregorio_note *const note)
 static void write_auctum_duplex(FILE *f,
         const gregorio_note *const current_note)
 {
-    char pitch = current_note->u.note.pitch;
-    char previous_pitch = 0;
+    signed char pitch = current_note->u.note.pitch;
+    signed char previous_pitch = 0;
     /* second_pitch is the second argument of the \augmentumduplex macro,
      * that's what this function is all about. */
-    char second_pitch = 0;
+    signed char second_pitch = 0;
     /* this variable will be set to 1 if we are on the note before the last
      * note of a podatus or a porrectus or a torculus resupinus */
     unsigned char special_punctum = 0;
@@ -2019,7 +2019,7 @@ static void write_punctum_mora(FILE *f, const gregorio_glyph *glyph,
     /* 0 if space is normal, 1 if there should be no space after a punctum */
     unsigned char no_space = 0;
     /* the pitch where to set the punctum */
-    char pitch = current_note->u.note.pitch;
+    signed char pitch = current_note->u.note.pitch;
     /* a variable to know if we are on a punctum inclinatum or not */
     unsigned char punctum_inclinatum = 0;
     /* a temp variable */
@@ -2190,7 +2190,7 @@ static void write_punctum_mora(FILE *f, const gregorio_glyph *glyph,
 static __inline int get_punctum_inclinatum_space_case(
         const gregorio_note *const note)
 {
-    char temp;
+    signed char temp;
 
     switch (note->u.note.shape) {
     case S_PUNCTUM_INCLINATUM_ASCENDENS:
@@ -2355,7 +2355,7 @@ static __inline void write_single_hepisema(FILE *const f, int hepisema_case,
         const gregorio_hepisema_adjustment *adj =
                 gregorio_get_hepisema_adjustment(
                         note->he_adjustment_index[orientation]);
-        char ambitus = 0;
+        signed char ambitus = 0;
         char size_arg;
 
         switch (size) {
@@ -2466,7 +2466,7 @@ static void gregoriotex_write_hepisema(FILE *const f,
 static void write_additional_line(FILE *f, int i, gtex_type type, bool bottom,
         const gregorio_note *current_note, const gregorio_score *const score)
 {
-    char ambitus = 0;
+    signed char ambitus = 0;
     gregorio_assert(current_note, write_additional_line, "called with no note",
             return);
     /* patch to get a line under the full glyph in the case of dbc (for
@@ -2978,7 +2978,7 @@ static void compute_height_extrema(const gregorio_glyph *const glyph,
         const gregorio_note *note, signed char *const top_height,
         signed char *const bottom_height)
 {
-    char height;
+    signed char height;
     /* get the minima/maxima pitches */
     for (; note; note = note->next) {
         if (note->h_episema_above) {


### PR DESCRIPTION
When a char is used to store a pitch or ambitus, use a signed char. On some platforms, char is unsigned by default, causing some spaces between notes to be computed incorrectly. There was only one place causing a known problem, but this commit changes them all for good measure.