### PR TITLE
Handle option errors internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ## [Unreleased][develop]
 ### Changed
 - Changed the way errors in the options (in particular invalid options) were handled.  Instead of letting getopt print the message, we catch and print the message ourselves.  This gives us more control over how the message looks and removes duplication (because getopt was seeing the error twice).
+- Consolidated `gregorio_fail()` and `gregorio_fail2()` into one macro which allows for arbitrary number of substitution arguments in the message.  Previously `gregorio_fail()` did not allow any substitutions and `gregorio_fail2()` allowed one substitution.
 
 
 ## [Unreleased][CTAN]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][develop]
+### Changed
+- Changed the way errors in the options (in particular invalid options) were handled.  Instead of letting getopt print the message, we catch and print the message ourselves.  This gives us more control over how the message looks and removes duplication (because getopt was seeing the error twice).
 
 
 ## [Unreleased][CTAN]

--- a/src/characters.c
+++ b/src/characters.c
@@ -1017,7 +1017,7 @@ void gregorio_rebuild_characters(gregorio_character **const param_character,
                 case ST_CENTER:
                     /* not reachable unless there's a programming error */
                     /* LCOV_EXCL_START */
-                    gregorio_fail2(gregorio_rebuild_characters,
+                    gregorio_fail(gregorio_rebuild_characters,
                             "encountered unexpected end %s",
                             grestyle_style_to_string(
                                 current_character->cos.s.style));

--- a/src/gabc/gabc-glyphs-determination.c
+++ b/src/gabc/gabc-glyphs-determination.c
@@ -439,7 +439,7 @@ static char add_note_to_a_glyph(gregorio_glyph_type current_glyph_type,
     default:
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
-        gregorio_fail2(add_note_to_a_glyph, "unexpected shape: %s",
+        gregorio_fail(add_note_to_a_glyph, "unexpected shape: %s",
                 gregorio_shape_to_string(shape));
         break;
         /* LCOV_EXCL_STOP */

--- a/src/gabc/gabc-notes-determination.l
+++ b/src/gabc/gabc-notes-determination.l
@@ -79,7 +79,7 @@ static __inline gregorio_sign_orientation letter_to_sign_orientation(
     }
     /* not reachable unless there's a programming error */
     /* LCOV_EXCL_START */
-    gregorio_fail2(letter_to_sign_orientation,
+    gregorio_fail(letter_to_sign_orientation,
             "invalid sign orientation letter: %c", letter);
     return SO_OVER;
     /* LCOV_EXCL_STOP */
@@ -94,7 +94,7 @@ static __inline int letter_to_pitch_adjustment(const char letter) {
     }
     /* not reachable unless there's a programming error */
     /* LCOV_EXCL_START */
-    gregorio_fail2(letter_to_pitch_adjustment,
+    gregorio_fail(letter_to_pitch_adjustment,
             "invalid sign orientation letter: %c", letter);
     return 0;
     /* LCOV_EXCL_STOP */
@@ -207,7 +207,7 @@ static void add_h_episema(void)
         default:
             /* not reachable unless there's a programming error */
             /* LCOV_EXCL_START */
-            gregorio_fail2(gabc_notes_determination,
+            gregorio_fail(gabc_notes_determination,
                     "unrecognized horizontal episema modifier: %c", current);
             break;
             /* LCOV_EXCL_STOP */
@@ -271,7 +271,7 @@ static __inline const char *over_or_under(
     }
     /* not reachable unless there's a programming error */
     /* LCOV_EXCL_START */
-    gregorio_fail2(over_or_under, "invalid ledger type %d", type);
+    gregorio_fail(over_or_under, "invalid ledger type %d", type);
     return "";
     /* LCOV_EXCL_STOP */
 }
@@ -376,7 +376,7 @@ static __inline gregorio_bar parse_dominican_bar(char bar)
     }
     /* not reachable unless there's a programming error */
     /* LCOV_EXCL_START */
-    gregorio_fail2(check_dominican_line, "invalid dominican bar: %d", (int)bar);
+    gregorio_fail(check_dominican_line, "invalid dominican bar: %d", (int)bar);
     return B_NO_BAR;
     /* LCOV_EXCL_STOP */
 }
@@ -391,7 +391,7 @@ static __inline gregorio_clef letter_to_clef(char letter)
     }
     /* not reachable unless there's a programming error */
     /* LCOV_EXCL_START */
-    gregorio_fail2(letter_to_clef, "invalid clef: %c", letter);
+    gregorio_fail(letter_to_clef, "invalid clef: %c", letter);
     return CLEF_C;
     /* LCOV_EXCL_STOP */
 }

--- a/src/gabc/gabc-score-determination.y
+++ b/src/gabc/gabc-score-determination.y
@@ -487,7 +487,7 @@ static void add_auto_protrusion(char *protrusion)
         default:
             /* not reachable unless there's a programming error */
             /* LCOV_EXCL_START */
-            gregorio_fail2(add_auto_protrusion,
+            gregorio_fail(add_auto_protrusion,
                     "unsupported protruding punctuation: %c", *protrusion);
             break;
             /* LCOV_EXCL_STOP */

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -549,7 +549,7 @@ int main(int argc, char **argv)
             break;
         case '?':
             if (optopt) {
-                fprintf(stderr, "%s: invalid option -- '%c'\n", argv[0], optopt);
+                fprintf(stderr, "%s: invalid option '%c'\n", argv[0], optopt);
             } else {
                 fprintf(stderr, "%s: invalid option\n", argv[0]);
             }
@@ -558,7 +558,7 @@ int main(int argc, char **argv)
             break;
 
         case ':':
-            fprintf(stderr, "%s: option requires an argument -- '%c'\n",
+            fprintf(stderr, "%s: option '%c' requires an argument \n",
                     argv[0], optopt);
             print_short_usage(argv[0]);
             gregorio_exit(1);

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
     bool debug = false;
     bool must_print_short_usage = false;
     int option_index = 0;
-    static const char *const options = "o:SF:l:f:shOLVvWDpd";
+    static const char *const options = ":o:SF:l:f:shOLVvWDpd";
     static const struct option long_options[] = {
         {"output-file", 1, 0, 'o'},
         {"stdout", 0, 0, 'S'},
@@ -352,6 +352,13 @@ int main(int argc, char **argv)
 
     gregorio_support_init("gregorio", argv[0]);
     setlocale(LC_CTYPE, "C");
+    
+    /* Turn off getopt's error handling:
+     * Its formatting isn't consistent with what we do elsewhere
+     * and we're going to call getopt_long() twice, so some of its
+     * error messages would be duplicated.
+     * Instead we're going to handle errors in the options ourselves. */
+    opterr = 0;
 
     /* need to look for the -l option up front */
     for (;;) {
@@ -541,12 +548,23 @@ int main(int argc, char **argv)
             debug = true;
             break;
         case '?':
+            if (optopt) {
+                fprintf(stderr, "%s: invalid option -- '%c'\n", argv[0], optopt);
+            } else {
+                fprintf(stderr, "%s: invalid option\n", argv[0]);
+            }
+            must_print_short_usage = true;
+            break;
+
+        case ':':
+            fprintf(stderr, "%s: option requires an argument -- '%c'\n",
+                    argv[0], optopt);
             must_print_short_usage = true;
             break;
         default:
             /* not reachable unless there's a programming error */
             /* LCOV_EXCL_START */
-            gregorio_fail2(main, "unknown option: %c", c);
+            gregorio_fail2(main, "%s: internal error: unexpected option code '%c'\n", argv[0], c);
             print_short_usage(argv[0]);
             gregorio_exit(1);
             break;

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -553,13 +553,15 @@ int main(int argc, char **argv)
             } else {
                 fprintf(stderr, "%s: invalid option\n", argv[0]);
             }
-            must_print_short_usage = true;
+            print_short_usage(argv[0]);
+            gregorio_exit(1);
             break;
 
         case ':':
             fprintf(stderr, "%s: option requires an argument -- '%c'\n",
                     argv[0], optopt);
-            must_print_short_usage = true;
+            print_short_usage(argv[0]);
+            gregorio_exit(1);
             break;
         default:
             /* not reachable unless there's a programming error */

--- a/src/gregorio-utils.c
+++ b/src/gregorio-utils.c
@@ -566,7 +566,7 @@ int main(int argc, char **argv)
         default:
             /* not reachable unless there's a programming error */
             /* LCOV_EXCL_START */
-            gregorio_fail2(main, "%s: internal error: unexpected option code '%c'\n", argv[0], c);
+            gregorio_fail(main, "%s: internal error: unexpected option code '%c'\n", argv[0], c);
             print_short_usage(argv[0]);
             gregorio_exit(1);
             break;

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -700,7 +700,7 @@ static const char *determine_note_glyph_name(const gregorio_note *const note,
                     true);
         }*/ /* all cases return, so this line is not hit; LCOV_EXCL_LINE */
         /* LCOV_EXCL_START */
-        gregorio_fail2(determine_note_glyph_name, "unknown queuetype: %d",
+        gregorio_fail(determine_note_glyph_name, "unknown queuetype: %d",
                 queuetype_of(note));
         return "";
         /* LCOV_EXCL_STOP */
@@ -738,7 +738,7 @@ static const char *determine_note_glyph_name(const gregorio_note *const note,
                 return SHAPE_VirgaReversaLongqueueDescendens;
             } /* all cases return, so this line is not hit; LCOV_EXCL_LINE */
             /* LCOV_EXCL_START */
-            gregorio_fail2(determine_note_glyph_name, "unknown queuetype: %d",
+            gregorio_fail(determine_note_glyph_name, "unknown queuetype: %d",
                     queuetype_of(note));
             return "";
             /* LCOV_EXCL_STOP */
@@ -784,7 +784,7 @@ static const char *determine_note_glyph_name(const gregorio_note *const note,
             return SHAPE_StrophaAuctaLongtail;
         } /* all cases return, so this line is not hit; LCOV_EXCL_LINE */
         /* LCOV_EXCL_START */
-        gregorio_fail2(determine_note_glyph_name, "unknown queuetype: %d",
+        gregorio_fail(determine_note_glyph_name, "unknown queuetype: %d",
                 queuetype_of(note));
         return "";
         /* LCOV_EXCL_STOP */
@@ -809,7 +809,7 @@ static const char *determine_note_glyph_name(const gregorio_note *const note,
     default:
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
-        gregorio_fail2(determine_note_glyph_name,
+        gregorio_fail(determine_note_glyph_name,
                 "called with unknown shape: %s",
                 gregorio_shape_to_string(note->u.note.shape));
         return "";
@@ -1217,7 +1217,7 @@ const char *gregoriotex_determine_glyph_name(const gregorio_glyph *const glyph,
     default:
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
-        gregorio_fail2(gregoriotex_determine_glyph_name,
+        gregorio_fail(gregoriotex_determine_glyph_name,
                 "called with unknown glyph: %s",
                 gregorio_glyph_type_to_string(glyph->u.notes.glyph_type));
         break;
@@ -1501,7 +1501,7 @@ static unsigned char gregoriotex_internal_style_to_gregoriotex(
     default:
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
-        gregorio_fail2(gregoriotex_internal_style_to_gregoriotex,
+        gregorio_fail(gregoriotex_internal_style_to_gregoriotex,
                 "unrecognized style: %s", grestyle_style_to_string(style));
         return 0;
         /* LCOV_EXCL_STOP */
@@ -1663,7 +1663,7 @@ static char clef_flat_height(gregorio_clef clef, signed char line, bool flatted)
         default:
             /* not reachable unless there's a programming error */
             /* LCOV_EXCL_START */
-            gregorio_fail2(clef_flat_height, "unknown line number: %d", line);
+            gregorio_fail(clef_flat_height, "unknown line number: %d", line);
             break;
             /* LCOV_EXCL_STOP */
         }
@@ -1688,7 +1688,7 @@ static char clef_flat_height(gregorio_clef clef, signed char line, bool flatted)
         default:
             /* not reachable unless there's a programming error */
             /* LCOV_EXCL_START */
-            gregorio_fail2(clef_flat_height, "unknown line number: %d", line);
+            gregorio_fail(clef_flat_height, "unknown line number: %d", line);
             break;
             /* LCOV_EXCL_STOP */
         }
@@ -1696,7 +1696,7 @@ static char clef_flat_height(gregorio_clef clef, signed char line, bool flatted)
     default:
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
-        gregorio_fail2(clef_flat_height, "unknown clef type: %d", clef);
+        gregorio_fail(clef_flat_height, "unknown clef type: %d", clef);
         break;
         /* LCOV_EXCL_STOP */
     }
@@ -1811,7 +1811,7 @@ static void write_bar(FILE *f, const gregorio_score *const score,
     default:
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
-        gregorio_fail2(write_bar, "unknown bar type: %d", type);
+        gregorio_fail(write_bar, "unknown bar type: %d", type);
         break;
         /* LCOV_EXCL_STOP */
     }

--- a/src/messages.h
+++ b/src/messages.h
@@ -80,10 +80,7 @@ int gregorio_get_return_value(void);
 #define gregorio_not_null_ptr(VARIABLE,FUNCTION,ON_FALSE) \
     gregorio_assert(VARIABLE && *VARIABLE, FUNCTION, #VARIABLE " may not be null", ON_FALSE)
 
-#define gregorio_fail(FUNCTION,MESSAGE) \
-    gregorio_message(_(MESSAGE), #FUNCTION, VERBOSITY_ASSERTION, __LINE__)
-
-#define gregorio_fail2(FUNCTION,FORMAT,ARG) \
-    gregorio_messagef(#FUNCTION, VERBOSITY_ASSERTION, __LINE__, FORMAT, ARG)
+#define gregorio_fail(FUNCTION, FORMAT, args...) \
+    gregorio_messagef(#FUNCTION, VERBOSITY_ASSERTION, __LINE__, _(FORMAT), ##args)
 
 #endif

--- a/src/struct.c
+++ b/src/struct.c
@@ -697,7 +697,7 @@ void gregorio_add_sign(gregorio_note *note, gregorio_sign sign,
     default:
         /* not reachable unless there's a programming error */
         /* LCOV_EXCL_START */
-        gregorio_fail2(gregorio_add_sign, "unexpected sign to add: %s",
+        gregorio_fail(gregorio_add_sign, "unexpected sign to add: %s",
                 gregorio_sign_to_string(sign));
         break;
         /* LCOV_EXCL_STOP */
@@ -1317,7 +1317,7 @@ static __inline signed char next_pitch_from_glyph(const gregorio_glyph *glyph,
                     default:
                         /* not reachable unless there's a programming error */
                         /* LCOV_EXCL_START */
-                        gregorio_fail2(next_pitch_from_glyph,
+                        gregorio_fail(next_pitch_from_glyph,
                                 "unrecognized alteration shape: %s",
                                 gregorio_shape_to_string(note->u.note.shape));
                         break;


### PR DESCRIPTION
While working on #1732, I noticed that the `invalid option` error had some quirks to it that made it inconsistent with our other errors.  After some investigation, I discovered this was because `getopt_long()` was producing part of the error message and it has its own sense of how to format the message (in a way that wasn't consistent with ours).  I thus disabled `getopt_long()`'s error handling and modified our option handling to account for an invalid option (formatting the message the way we want it to be).

There will be some test implications from this (scripted/cli/invalid_option.sh and related), but I don't have time to make the corresponding PR on the test repository tonight, hence I'm marking this as DRAFT for now.  Once I have the chance to futz with the tests, I'll mark this ready for review.