### PR TITLE
Unset \gre@ifbeginningofscore in \GreBarSyllables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][develop]
-
+- Fixed a bug in horizontal spacing when the first syllable consists of only a bar. See [PR #1741](https://github.com/gregorio-project/gregorio/pull/1741).
 
 ## [Unreleased][CTAN]
 *Note:* 6.2.0 was not released to CTAN and is not compatible with 6.1.0 which is on CTAN.  Please make all changes against develop until this is resolved.

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -1470,6 +1470,7 @@
   \gre@debugmsg{general}{New bar syllable}%
   \gre@debugmsg{general}{}%
   \global\advance\gre@attr@syllable@id by 1\relax %
+  \gre@beginningofscorefalse
   \gre@possibleluahyphenafterthissyllablefalse %
   \gre@showhyphenafterthissyllablefalse %
   % the algorithm of this function is *extremely* complex, and has been much painful to write... good luck to understand.


### PR DESCRIPTION
Previously, beginningofscore would remain set if the first syllables were \GreBarSyllables. This would cause the first \GreSyllable to be set as if it were the first syllable of the line (with bolshift). Now, the first \GreSyllable should be set correctly.