### PR TITLE
Fix previousenddifference and bar@lastskip in discretionaries (clef changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ## [Unreleased][develop]
 
+- Fixed a few bugs related to horizontal spacing around bars and clef changes. See issues [#1191](https://github.com/gregorio-project/gregorio/issues/1191), case 3 of [#1724](https://github.com/gregorio-project/gregorio/issues/1724), [#1745](https://github.com/gregorio-project/gregorio/issues/1745), and [PR #1743](https://github.com/gregorio-project/gregorio/pull/1743).
 
 ## [Unreleased][CTAN]
 *Note:* 6.2.0 was not released to CTAN and is not compatible with 6.1.0 which is on CTAN.  Please make all changes against develop until this is resolved.

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -104,6 +104,7 @@
 \xdef\gre@insidediscretionary{\number 0}%
 
 \newdimen\gre@dimen@savedenddifference
+\newskip\gre@skip@savedlastskip
 
 % #1 is the type of discretionary, for penalty assignment. Recognized types:
 %   - 0: clef change
@@ -114,6 +115,8 @@
   \global\xdef\gre@insidediscretionary{\number 1}%
   \gre@debugmsg{barspacing}{save end diff: \the\gre@dimen@enddifference}%
   \gre@dimen@savedenddifference=\gre@dimen@enddifference
+  \gre@debugmsg{barspacing}{save last skip: \the\gre@skip@bar@lastskip}%
+  \gre@skip@savedlastskip=\gre@skip@bar@lastskip
   \discretionary{%
     \global\gre@lastoflinecount=1\relax % (a good magic trick)
     \gre@debugmsg{bolshift}{discretionary pre lastoflinecount: \the\gre@lastoflinecount}%
@@ -124,6 +127,8 @@
     }{%
     \gre@debugmsg{barspacing}{restore end diff: \the\gre@dimen@savedenddifference}%
     \gre@dimen@enddifference=\gre@dimen@savedenddifference
+    \gre@debugmsg{barspacing}{restore last skip: \the\gre@skip@savedlastskip}%
+    \gre@skip@bar@lastskip=\gre@skip@savedlastskip
     \gre@debugmsg{bolshift}{discretionary no lastoflinecount: \the\gre@lastoflinecount}%
     #3%
     }%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -103,9 +103,6 @@
 \let\gre@penalty\gre@truepenalty%
 \xdef\gre@insidediscretionary{\number 0}%
 
-\newdimen\gre@dimen@savedenddifference
-\newskip\gre@skip@savedlastskip
-
 % #1 is the type of discretionary, for penalty assignment. Recognized types:
 %   - 0: clef change
 \def\GreDiscretionary#1#2#3{%
@@ -114,9 +111,9 @@
   \global\let\gre@penalty\gre@falsepenalty %
   \global\xdef\gre@insidediscretionary{\number 1}%
   \gre@debugmsg{barspacing}{save end diff: \the\gre@dimen@enddifference}%
-  \gre@dimen@savedenddifference=\gre@dimen@enddifference
+  \edef\gre@saved@predisc@enddifference{\the\gre@dimen@enddifference}%
   \gre@debugmsg{barspacing}{save last skip: \the\gre@skip@bar@lastskip}%
-  \gre@skip@savedlastskip=\gre@skip@bar@lastskip
+  \edef\gre@saved@predisc@lastskip{\the\gre@skip@bar@lastskip}%
   \discretionary{%
     \global\gre@lastoflinecount=1\relax % (a good magic trick)
     \gre@debugmsg{bolshift}{discretionary pre lastoflinecount: \the\gre@lastoflinecount}%
@@ -125,10 +122,10 @@
     \global\gre@lastoflinecount=2\relax % (a good magic trick)
     \gre@debugmsg{bolshift}{discretionary post lastoflinecount: \the\gre@lastoflinecount}%
     }{%
-    \gre@debugmsg{barspacing}{restore end diff: \the\gre@dimen@savedenddifference}%
-    \gre@dimen@enddifference=\gre@dimen@savedenddifference
-    \gre@debugmsg{barspacing}{restore last skip: \the\gre@skip@savedlastskip}%
-    \gre@skip@bar@lastskip=\gre@skip@savedlastskip
+    \gre@debugmsg{barspacing}{restore end diff: \gre@saved@predisc@enddifference}%
+    \gre@dimen@enddifference=\gre@saved@predisc@enddifference
+    \gre@debugmsg{barspacing}{restore last skip: \gre@saved@predisc@lastskip}%
+    \gre@skip@bar@lastskip=\gre@saved@predisc@lastskip
     \gre@debugmsg{bolshift}{discretionary no lastoflinecount: \the\gre@lastoflinecount}%
     #3%
     }%

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -103,6 +103,8 @@
 \let\gre@penalty\gre@truepenalty%
 \xdef\gre@insidediscretionary{\number 0}%
 
+\newdimen\gre@dimen@savedenddifference
+
 % #1 is the type of discretionary, for penalty assignment. Recognized types:
 %   - 0: clef change
 \def\GreDiscretionary#1#2#3{%
@@ -110,6 +112,8 @@
   \global\let\gre@hskip\kern %
   \global\let\gre@penalty\gre@falsepenalty %
   \global\xdef\gre@insidediscretionary{\number 1}%
+  \gre@debugmsg{barspacing}{save end diff: \the\gre@dimen@enddifference}%
+  \gre@dimen@savedenddifference=\gre@dimen@enddifference
   \discretionary{%
     \global\gre@lastoflinecount=1\relax % (a good magic trick)
     \gre@debugmsg{bolshift}{discretionary pre lastoflinecount: \the\gre@lastoflinecount}%
@@ -118,6 +122,8 @@
     \global\gre@lastoflinecount=2\relax % (a good magic trick)
     \gre@debugmsg{bolshift}{discretionary post lastoflinecount: \the\gre@lastoflinecount}%
     }{%
+    \gre@debugmsg{barspacing}{restore end diff: \the\gre@dimen@savedenddifference}%
+    \gre@dimen@enddifference=\gre@dimen@savedenddifference
     \gre@debugmsg{bolshift}{discretionary no lastoflinecount: \the\gre@lastoflinecount}%
     #3%
     }%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -547,8 +547,8 @@
   \global\gre@dimen@nabc@maxwidth=0pt\relax %
   \global\gre@dimen@nabc@extrakern=0pt\relax %
   \let\ifgre@saved@prenotes@lastendswithmora\ifgre@lastendswithmora%
-  \xdef\gre@saved@prenotes@lastoflinecount{\number\gre@lastoflinecount\relax }%
-  \xdef\gre@saved@prenotes@bar@lastskip{\the\gre@skip@bar@lastskip}%
+  \edef\gre@saved@prenotes@lastoflinecount{\number\gre@lastoflinecount}%
+  \edef\gre@saved@prenotes@bar@lastskip{\the\gre@skip@bar@lastskip}%
   \ifgre@shownotes%
     \setbox\gre@box@syllablenotes=\hbox{#1}%
     \gre@compute@nabc@extrakern
@@ -580,9 +580,9 @@
     \gre@thisendswithmorafalse %
   \fi %
   \let\ifgre@lastendswithmora\ifgre@saved@prenotes@lastendswithmora%
-  \global\gre@lastoflinecount=\gre@saved@prenotes@lastoflinecount\relax %
+  \gre@lastoflinecount=\gre@saved@prenotes@lastoflinecount
+  \gre@skip@bar@lastskip=\gre@saved@prenotes@bar@lastskip
   \global\gre@count@lastglyphiscavum=0\relax %
-  \global\gre@skip@bar@lastskip=\gre@saved@prenotes@bar@lastskip
   \global\gre@endofscorefalse %
   \relax %
   \gre@trace@end%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -548,6 +548,7 @@
   \global\gre@dimen@nabc@extrakern=0pt\relax %
   \let\ifgre@saved@prenotes@lastendswithmora\ifgre@lastendswithmora%
   \xdef\gre@saved@prenotes@lastoflinecount{\number\gre@lastoflinecount\relax }%
+  \xdef\gre@saved@prenotes@bar@lastskip{\the\gre@skip@bar@lastskip}%
   \ifgre@shownotes%
     \setbox\gre@box@syllablenotes=\hbox{#1}%
     \gre@compute@nabc@extrakern
@@ -581,7 +582,7 @@
   \let\ifgre@lastendswithmora\ifgre@saved@prenotes@lastendswithmora%
   \global\gre@lastoflinecount=\gre@saved@prenotes@lastoflinecount\relax %
   \global\gre@count@lastglyphiscavum=0\relax %
-  \global\gre@skip@bar@lastskip=0pt\relax %
+  \global\gre@skip@bar@lastskip=\gre@saved@prenotes@bar@lastskip
   \global\gre@endofscorefalse %
   \relax %
   \gre@trace@end%

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -1642,6 +1642,7 @@
       \fi%
       % adjustment for alterations:
       \kern-\gre@skip@alterationshift %
+      \GreNoBreak
       %move to the beginning of the notes of the next syllable
       \gre@hskip\glueexpr(-\wd\gre@box@syllablenotes/2% back up to middle of notes
         -\gre@dimen@bar@shift% go back from actual middle to nominal middle of bar line


### PR DESCRIPTION
The bar spacing algorithm uses the previous syllable's enddifference, but in a discretionary (clef change), the "replace" syllable uses the "pre" syllable's enddifference, but it should be the syllable before the discretionary's enddifference. This commit saves and restores the enddifference correctly.

Fixes case 3 of https://github.com/gregorio-project/gregorio/issues/1724
Fixes https://github.com/gregorio-project/gregorio/issues/1191
