### PR TITLE
Deprecation path advancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). It follows [some conventions](http://keepachangelog.com/).
 
 ## [Unreleased][develop]
-
+### Removed
+- `\gresethyphenprotrusion`
+- `\GreInitialClefPosition`
+- What were arguments 2-5 of `\GreBeginScore`.  This macro now has only 4 arguments (instead of 8).
 
 ## [Unreleased][CTAN]
 *Note:* 6.2.0 was not released to CTAN and is not compatible with 6.1.0 which is on CTAN.  Please make all changes against develop until this is resolved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 ### Removed
 - `\gresethyphenprotrusion`
 - `\GreInitialClefPosition`
-- What were arguments 2-5 of `\GreBeginScore`.  This macro now has only 4 arguments (instead of 8).
+- What were arguments 2-5 and 8 of `\GreBeginScore`.  This macro now has only 3 arguments (instead of 8).
 
 ## [Unreleased][CTAN]
 *Note:* 6.2.0 was not released to CTAN and is not compatible with 6.1.0 which is on CTAN.  Please make all changes against develop until this is resolved.

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -38,22 +38,14 @@ respecting the annotation value in the \texttt{main.tex} file.
   \#2 & string & Second line text to place above the initial.\\
 \end{argtable}
 
-\macroname{\textbackslash GreBeginScore}{\#1\#2\#3\#4\#5\#6\#7\#8}{gregoriotex-main.tex}
+\macroname{\textbackslash GreBeginScore}{\#1\#2\#3\#4}{gregoriotex-main.tex}
 Macro to start a score.
 
 \begin{argtable}
   \#1 & string  & a unique identifier for the score (currently an SHA-1-based digest of the gabc file)\\
-  \#2 & integer & the height number of the top pitch of the entire score, including signs (DEPRECATED)\\
-  \#3 & integer & the height number of the bottom pitch of the entire score, including signs (DEPRECATED)\\
-  \#4 & integer & whether there is a translation line (DEPRECATED)\\
-      & 0 & there is no translation line in the score\\
-      & 1 & there is a translation line somewhere in the score\\
-  \#5 & integer & whether there is above lines text (DEPRECATED)\\
-      & 0 & there is no above lines text in the score\\
-      & 1 & there is above lines text somewhere in the score\\
-  \#6 & string  & the absolute filename of the gabc file if point-and-click is enabled\\
-  \#7 & integer & the number of staff lines\\
-  \#8 & \TeX\ code & macros to run before the score\\
+  \#2 & string  & the absolute filename of the gabc file if point-and-click is enabled\\
+  \#3 & integer & the number of staff lines\\
+  \#4 & \TeX\ code & macros to run before the score\\
 \end{argtable}
 
 \macroname{\textbackslash GreEndScore}{}{gregoriotex-main.tex}

--- a/doc/Command_Index_gregorio.tex
+++ b/doc/Command_Index_gregorio.tex
@@ -38,14 +38,13 @@ respecting the annotation value in the \texttt{main.tex} file.
   \#2 & string & Second line text to place above the initial.\\
 \end{argtable}
 
-\macroname{\textbackslash GreBeginScore}{\#1\#2\#3\#4}{gregoriotex-main.tex}
+\macroname{\textbackslash GreBeginScore}{\#1\#2\#3}{gregoriotex-main.tex}
 Macro to start a score.
 
 \begin{argtable}
   \#1 & string  & a unique identifier for the score (currently an SHA-1-based digest of the gabc file)\\
   \#2 & string  & the absolute filename of the gabc file if point-and-click is enabled\\
   \#3 & integer & the number of staff lines\\
-  \#4 & \TeX\ code & macros to run before the score\\
 \end{argtable}
 
 \macroname{\textbackslash GreEndScore}{}{gregoriotex-main.tex}

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -4693,7 +4693,7 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
     if (score->first_voice_info) {
         clef = score->first_voice_info->initial_clef;
     }
-    fprintf(f, "\\GreBeginScore{%s}{%s}{%u}{}%%\n",
+    fprintf(f, "\\GreBeginScore{%s}{%s}{%u}%%\n",
             digest_to_hex(score->digest),
             point_and_click_filename? point_and_click_filename : "",
             score->staff_lines);

--- a/src/gregoriotex/gregoriotex-write.c
+++ b/src/gregoriotex/gregoriotex-write.c
@@ -55,12 +55,6 @@ typedef struct gregoriotex_status {
     signed char top_height;
     signed char bottom_height;
 
-    /* indicates if there is a translation on the line */
-    bool translation; /* DEPRECATED */
-
-    /* indicates if there is "above lines text" on the line */
-    bool abovelinestext; /* DEPRECATED */
-
     bool suppressed_custos;
 } gregoriotex_status;
 
@@ -4431,7 +4425,6 @@ static void initialize_score(gregoriotex_status *const status,
 
     status->bottom_line = false;
     status->top_height = status->bottom_height = UNDETERMINED_HEIGHT;
-    status->abovelinestext = status->translation = false;
     status->suppressed_custos = false;
 
     /* first pass to compute positioning */
@@ -4450,14 +4443,6 @@ static void initialize_score(gregoriotex_status *const status,
             syllable = syllable->next_syllable) {
         int voice;
 
-        if (syllable->translation) {
-            status->translation = true;
-        }
-
-        if (syllable->abovelinestext) {
-            status->abovelinestext = true;
-        }
-
         /* simultaneously compute height extrema and determine the last "real"
          * element in each voice */
         for (voice = 0; voice < score->number_of_voices; ++voice) {
@@ -4468,10 +4453,6 @@ static void initialize_score(gregoriotex_status *const status,
                 gregorio_glyph *glyph;
 
                 switch (element->type) {
-                case GRE_ALT:
-                    status->abovelinestext = true;
-                    break;
-
                 case GRE_CUSTOS:
                     last_of_voice[voice] = element;
                     break;
@@ -4712,21 +4693,10 @@ void gregoriotex_write_score(FILE *const f, gregorio_score *const score,
     if (score->first_voice_info) {
         clef = score->first_voice_info->initial_clef;
     }
-    /* After removing deprecated arguments, this will become:
     fprintf(f, "\\GreBeginScore{%s}{%s}{%u}{}%%\n",
             digest_to_hex(score->digest),
             point_and_click_filename? point_and_click_filename : "",
-            score->staff_lines); */
-    fprintf(f, "\\GreBeginScore{%s}{%d}{%d}{%d}{%d}{%s}{%u}"
-            "{\\GreInitialClefPosition{%d}{%d}}%%\n", /* DEPRECATED */
-            digest_to_hex(score->digest),
-            status.top_height, /* DEPRECATED */
-            status.bottom_height, /* DEPRECATED */
-            bool_to_int(status.translation), /* DEPRECATED */
-            bool_to_int(status.abovelinestext), /* DEPRECATED */
-            point_and_click_filename? point_and_click_filename : "",
-            score->staff_lines,
-            clef.line, clef.secondary_line); /* DEPRECATED */
+            score->staff_lines);
     if (score->nabc_lines) {
         fprintf(f, "\\GreScoreNABCLines{%d}", (int)score->nabc_lines);
     }

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1214,14 +1214,10 @@
 
 %macro called at the beginning of a score
 % #1 is the gabc score id
-% #2 is the high height (DEPRECATED)
-% #3 is the low height (DEPRECATED)
-% #4 is 1 if there is a translation somewhere (DEPRECATED)
-% #5 is if 1 if we have space above the staff (DEPRECATED)
-% #6 is the point-and-click filename
-% #7 is the number of staff lines
-% #8 is to set the initial clef position
-\def\GreBeginScore#1#2#3#4#5#6#7#8{%
+% #2 is the point-and-click filename
+% #3 is the number of staff lines
+% #4 is to set the initial clef position
+\def\GreBeginScore#1#2#3#4{%
   % scores must be new paragraphs!
   \ifhmode\par\fi %
   \gre@beginningofscoretrue%
@@ -1230,8 +1226,8 @@
   \gre@resetledgerlineheuristics%
   \global\setattribute\gre@attr@syllable@id{0}%
   \global\setattribute\gre@attr@alteration@id{0}%
-  \xdef\gre@gabcname{#6}%
-  \gre@setstafflines{#7}%
+  \xdef\gre@gabcname{#2}%
+  \gre@setstafflines{#3}%
   \ifnum\gre@count@lastline=0\relax
     \xdef\gre@saved@parfillskip{\the\parfillskip}%
     \parfillskip=0pt plus 0pt minus 0pt\relax%
@@ -1245,7 +1241,7 @@
   \gre@generatelines %
   \noindent%
   \gre@calculate@additionalspaces
-  #8%
+  #4%
   \directlua{gregoriotex.at_score_beginning([[#1]])}%
   %TODO do something like LaTeX's AtBeginDocument
   \ifdefined\optgabcAtScoreBeginning %

--- a/tex/gregoriotex-main.tex
+++ b/tex/gregoriotex-main.tex
@@ -1216,8 +1216,7 @@
 % #1 is the gabc score id
 % #2 is the point-and-click filename
 % #3 is the number of staff lines
-% #4 is to set the initial clef position
-\def\GreBeginScore#1#2#3#4{%
+\def\GreBeginScore#1#2#3{%
   % scores must be new paragraphs!
   \ifhmode\par\fi %
   \gre@beginningofscoretrue%
@@ -1241,7 +1240,6 @@
   \gre@generatelines %
   \noindent%
   \gre@calculate@additionalspaces
-  #4%
   \directlua{gregoriotex.at_score_beginning([[#1]])}%
   %TODO do something like LaTeX's AtBeginDocument
   \ifdefined\optgabcAtScoreBeginning %

--- a/tex/gregoriotex-signs.tex
+++ b/tex/gregoriotex-signs.tex
@@ -294,8 +294,6 @@
   \gre@trace@end%
 }%
 
-\def\GreInitialClefPosition#1#2{}%% DEPRECATED
-
 % macro that typesets the clef
 % arguments are :
 %% #1: the type of the clef : c or f

--- a/tex/gregoriotex-spaces.tex
+++ b/tex/gregoriotex-spaces.tex
@@ -566,10 +566,6 @@
   \hbox to \gre@dimen@temp@four{#2\hss}%
 }%
 
-\def\gresethyphenprotrusion#1{% OBSOLETE
-  \gre@obsolete{\protect\gresethyphenprotrusion{percentage}}{\protect\gresetprotrusionfactor{eolhyphen}{factor}}% OBSOLETE
-}% OBSOLETE
-
 % dimen keeping the shift computed with next function
 \newdimen\gre@dimen@eolshift
 


### PR DESCRIPTION
Remove OBSOLETE code
Code which was DEPRECATED in the background (i.e. pending modification of executable) is modified.  This really should have been done for 6.2 (since we modified the executable in that release), but was overlooked.