### PR TITLE
Add missing \GreNoBreak

### DIFF
--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -1641,6 +1641,7 @@
       \fi%
       % adjustment for alterations:
       \kern-\gre@skip@alterationshift %
+      \GreNoBreak
       %move to the beginning of the notes of the next syllable
       \gre@hskip\glueexpr(-\wd\gre@box@syllablenotes/2% back up to middle of notes
         -\gre@dimen@bar@shift% go back from actual middle to nominal middle of bar line


### PR DESCRIPTION
This adds a `\GreNoBreak` at a place where a line break could unintentionally occur (at a kern followed by a glue; putting the penalty in between makes it impossible to break at the kern).
