### PR TITLE
fix(lua): replace os.spawn with io.popen to prevent fd-inheritance corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed a few bugs related to horizontal spacing around bars and clef changes. See issues [#1191](https://github.com/gregorio-project/gregorio/issues/1191), case 3 of [#1724](https://github.com/gregorio-project/gregorio/issues/1724), [PR #1743](https://github.com/gregorio-project/gregorio/pull/1743), and [#1745](https://github.com/gregorio-project/gregorio/issues/1745).
 - Fixed a bug in horizontal spacing when the first syllable consists of only a bar. See [PR #1741](https://github.com/gregorio-project/gregorio/pull/1741).
 - Fixed a bug in horizontal spacing before a soft alteration. See [PR #1761](https://github.com/gregorio-project/gregorio/pull/1761).
+- Worked around a LuaTeX bug (file descriptor inheritance in `os.spawn()`) that could corrupt LuaTeX's input state when `\gregorioscore` or `\gabcsnippet` was used inside an `\input`-ted file on a clean build. See [#1757](https://github.com/gregorio-project/gregorio/issues/1757).
 
 ### Added
 - Code for several features related to horizontal spacing (spacing between non-bar syllables, syllable rewriting, clearing, and hyphenation) was moved into Lua. This results in some changes in horizontal spacing, which, if perceptible, should be improvements. See [#1720](https://github.com/gregorio-project/gregorio/issues/1720).

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -142,8 +142,44 @@ local catcode_at_letter = luatexbase.catcodetables['gre@atletter']
 
 local first_line_prevdepth = 0
 
+-- Single-quotes s for safe use as one word in a shell command line.
+local function gre_shellquote(s)
+  return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+-- Unlike os.spawn(), which execs cmd's arguments directly, io.popen() only
+-- takes a single command line run through /bin/sh -c. Quote each argument so
+-- that paths with spaces stay intact and shell metacharacters in filenames
+-- (e.g. from the .tex source) aren't interpreted as shell syntax.
+local function gre_build_cmdstr(cmd)
+  local quoted = {}
+  for i, a in ipairs(cmd) do
+    quoted[i] = gre_shellquote(a)
+  end
+  return table.concat(quoted, ' ')
+end
+
+-- Returns exit code (0 = success, positive = failure, nil = could not
+-- launch — caller interprets nil as shell-escape disabled).
+local function gre_exec(cmd)
+  -- Workaround for a LuaTeX bug: os.spawn() leaks open fds to the child on
+  -- Unix, corrupting \input state (see #1757). Use io.popen() there instead;
+  -- Windows is unaffected and keeps os.spawn().
+  if os.type ~= 'windows' then
+    local handle = io.popen(gre_build_cmdstr(cmd), 'r')
+    if handle then
+      handle:read('*all')
+      local ok, _, code = handle:close()
+      return ok and 0 or (code or 1)
+    end
+    return nil
+  else
+    return os.spawn(cmd)
+  end
+end
+
 local function get_prog_output(cmd, tmpname, fmt)
-  local rc = os.spawn(cmd)
+  local rc = gre_exec(cmd) or 1
   local content = nil
   if rc == 0 then
     local f = io.open(tmpname, 'r');
@@ -1350,7 +1386,7 @@ local function compile_gabc(gabc_file, gtex_file, glog_file, allow_deprecated)
   kpse.record_input_file(gabc_file)
   kpse.record_output_file(glog_file)
   kpse.record_output_file(gtex_file)
-  local res = os.spawn(cmd)
+  local res = gre_exec(cmd)
 
   if res == nil then
     err("\nSomething went wrong when executing\n    '%s'.\n"


### PR DESCRIPTION
## Summary

- Replaces `os.spawn()` with `io.popen()` at both call sites in `tex/gregoriotex.lua` where a `gregorio` child process is launched.
- Adds three helpers (`gre_shellquote`, `gre_build_cmdstr`, `gre_use_popen`) defined once, before `get_prog_output`.
- Windows is unaffected: `gre_use_popen` is `false` when `os.type == 'windows'`, preserving the original `os.spawn()` path.

## Problem

`os.spawn()` on Unix is implemented as `fork()+execve()` without setting `FD_CLOEXEC` on any file descriptor.  The `gregorio` child process therefore inherits every fd open in the LuaTeX parent — including the fd of any `.tex` file currently being `\input`-ted.  Parent and child share the same kernel-level `struct file` (which holds the seek position `f_pos`); any fd activity in the child can silently advance the read offset LuaTeX still relies on, corrupting TeX's input state.

Both call sites are affected:

| Call site | Reached via |
|---|---|
| `get_prog_output()` | `\gabcsnippet` → `direct_gabc()` |
| `compile_gabc()` | `\gregorioscore` → `include_score()` |

The bug manifests only when `\gregorioscore` or `\gabcsnippet` is used inside an `\input`-ted file **and** no cached `.gtex` exists (clean-state build).  Observed on NixOS sandboxes and GitHub Actions.

Typical symptoms:

- `! Misplaced \noalign.` / `! Undefined control sequence. \gre` (hard error)
- Silent content duplication in the PDF (scores or paragraphs appear twice, no error)

## Fix

`io.popen()` invokes `/bin/sh -c`, which manages its own fd space before the final `exec`, eliminating the inheritance.  Arguments are individually POSIX-single-quoted by `gre_shellquote()` so paths with spaces or shell metacharacters remain safe.

Closes #1757