### PR TITLE
Fix nextbegindifference before soft alteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 - Fixed some typos that would cause a handful of spaces to be scaled incorrectly. See [PR #1746](https://github.com/gregorio-project/gregorio/pull/1746).
 - Fixed a few bugs related to horizontal spacing around bars and clef changes. See issues [#1191](https://github.com/gregorio-project/gregorio/issues/1191), case 3 of [#1724](https://github.com/gregorio-project/gregorio/issues/1724), [PR #1743](https://github.com/gregorio-project/gregorio/pull/1743), and [#1745](https://github.com/gregorio-project/gregorio/issues/1745).
 - Fixed a bug in horizontal spacing when the first syllable consists of only a bar. See [PR #1741](https://github.com/gregorio-project/gregorio/pull/1741).
+- Fixed a bug in horizontal spacing before a soft alteration. See [PR #1761](https://github.com/gregorio-project/gregorio/pull/1761).
 
 ## [Unreleased][CTAN]
 *Note:* 6.2.0 was not released to CTAN and is not compatible with 6.1.0 which is on CTAN.  Please make all changes against develop until this is resolved.

--- a/tex/gregoriotex-syllable.tex
+++ b/tex/gregoriotex-syllable.tex
@@ -362,6 +362,12 @@
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@naturalparen}%
   \or % 6 - parenthesized sharp
     \setbox\gre@box@temp@width=\hbox{\gre@fontchar@sharpparen}%
+  \or % 7 - soft flat
+    \setbox\gre@box@temp@width=\hbox{\gre@fontchar@flat}%
+  \or % 8 - soft natural
+    \setbox\gre@box@temp@width=\hbox{\gre@fontchar@natural}%
+  \or % 9 - soft sharp
+    \setbox\gre@box@temp@width=\hbox{\gre@fontchar@sharp}%
   \fi %
   \ifnum#2>0\relax %
     \advance\gre@dimen@temp@five by \dimexpr(\wd\gre@box@temp@width+\gre@space@dimen@alterationspace)\relax %


### PR DESCRIPTION
Addresses issue #1723, case 3. The bug was worse than noted there, though: the notesaligncenter was being set to 1.5 times the width of the first note.