### PR TITLE
fix: crash in post_linebreak when lastglyph is nil (issue #1762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ As of v3.0.0 this project adheres to [Semantic Versioning](http://semver.org/). 
 
 ## [Unreleased][develop]
 ### Fixed
+- Fixed a crash in `post_linebreak` when a syllable's text is produced by a nested hbox (e.g. `\stackon{…}{…}` inside `<v>…</v>` in GABC), which left `lastglyph` as `nil` and caused a nil-dereference on natural line breaks. See [#1762](https://github.com/gregorio-project/gregorio/issues/1762).
 - Fixed a bug that could cause problems with headers/footers by generalizing the fix for fancyhdr (see [#1610](https://github.com/gregorio-project/gregorio/pull/1610) to work with any headers/footers. In particular, it fixes a similar problem with the `memoir` class. See [#1753](https://github.com/gregorio-project/gregorio/pull/1753).
 - Fixed some typos that would cause a handful of spaces to be scaled incorrectly. See [PR #1746](https://github.com/gregorio-project/gregorio/pull/1746).
 - Fixed a few bugs related to horizontal spacing around bars and clef changes. See issues [#1191](https://github.com/gregorio-project/gregorio/issues/1191), case 3 of [#1724](https://github.com/gregorio-project/gregorio/issues/1724), [PR #1743](https://github.com/gregorio-project/gregorio/pull/1743), and [#1745](https://github.com/gregorio-project/gregorio/issues/1745).

--- a/tex/gregoriotex.lua
+++ b/tex/gregoriotex.lua
@@ -951,6 +951,22 @@ local function adjust_additional_spaces(line, info, linenum)
   end
 end
 
+-- node.traverse_id does not recurse into sub-lists; this helper walks the
+-- full node tree so that the last glyph is found even inside nested hboxes
+-- produced by <v>…\hbox{…}…</v> or <v>…\stackon{…}{…}…</v> in GABC.
+local function find_last_glyph(head)
+  local result = nil
+  for n in node.traverse(head) do
+    if n.id == glyph then
+      result = n
+    elseif n.head then
+      local inner = find_last_glyph(n.head)
+      if inner then result = inner end
+    end
+  end
+  return result
+end
+
 local function post_linebreak(h, groupcode, glyphes)
   --dump_nodes(h)
   -- TODO: to be changed according to the font
@@ -1059,13 +1075,10 @@ local function post_linebreak(h, groupcode, glyphes)
 
     -- If the last syllable needed a dash, add it
     if adddash then
-      local lastglyph
-      -- we traverse the list, to detect the font to use,
-      -- and also not to add an hyphen if there is already one
-      for g in node.traverse_id(glyph, lastseennode.head) do
-        lastglyph = g
-      end
-      if not (lastglyph.char == hyphen or lastglyph.char == 45) then
+      -- use find_last_glyph so nested hboxes (e.g. from \stackon) are searched
+      local lastglyph = find_last_glyph(lastseennode.head)
+      -- guard nil: if no glyph is found at any level, skip hyphen insertion
+      if lastglyph and not (lastglyph.char == hyphen or lastglyph.char == 45) then
         local dashnode, hyphnode = getdashnnode()
         hyphnode.font = lastglyph.font
         insert_after(lastseennode.head, lastglyph, dashnode)


### PR DESCRIPTION
## Summary

- `node.traverse_id` does not recurse into sub-lists, so when the text of a syllable is inside a nested box (e.g. `\stackon{…}{…}` within `<v>…</v>` in GABC), the loop that searches for the last glyph ends with `lastglyph = nil`, and the following line causes a crash by dereferencing `nil`.
- Introduces `find_last_glyph`, a recursive helper that walks the entire node tree (descending into `hlist`, `vlist`, etc.) to find the last glyph, even when it is inside nested hboxes.
- Replaces the flat loop `for g in node.traverse_id(glyph, lastseennode.head)` with a call to `find_last_glyph`.
- Adds a `nil` guard in the hyphen insertion condition, for the (rare) case in which no glyph is found at any level of the tree.

Closes #1762.

## Test plan

- [ ] Compile a GABC document containing `<v>…\stackon{…}{…}…</v>` in a mid-word syllable, with a natural line break (without `(z)`/`(Z)`), and verify that the crash no longer occurs.
- [ ] Verify that documents without nested boxes continue to produce hyphens correctly at line breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)