### PR TITLE
Change additionaltopspacenabcthreshold default from 4 to 0

### DIFF
--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -362,7 +362,7 @@
 % same, for notes taken into account for alt text vertical position
 \grechangecount{additionaltopspacealtthreshold}{0}%
 % same, for notes taken into account for nabc vertical position
-\grechangecount{additionaltopspacenabcthreshold}{4}%
+\grechangecount{additionaltopspacenabcthreshold}{0}%
 %the space between the lines and the bottom of the text
 \gre@createdim{dimen}{spacelinestext}{3.48471ex}{fixed}%
 %the per-note additional space between lines and the bottom of the text


### PR DESCRIPTION
Follow-up of #1767: redefines the default value of `additionaltopspacenabcthreshold`.